### PR TITLE
Add camera_on editing to class attendance

### DIFF
--- a/supabase/migrations/20260515163922_class-attendance-camera-on.sql
+++ b/supabase/migrations/20260515163922_class-attendance-camera-on.sql
@@ -1,0 +1,2 @@
+alter table public.class_attendance
+add column if not exists camera_on boolean;

--- a/supabase/schemas/03_semesters_cohorts_classes.sql
+++ b/supabase/schemas/03_semesters_cohorts_classes.sql
@@ -66,6 +66,7 @@ create table public.class_attendance (
   class_id uuid not null references public.class (id) on update cascade on delete cascade,
   profile_id uuid not null references public.profile (id) on update cascade on delete cascade,
   status public.class_attendance_status,
+  camera_on boolean,
   recorded_by uuid references auth.users (id) on update cascade on delete set null,
   notes text,
   created_at timestamptz not null default now(),

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -71,6 +71,7 @@ export type Database = {
       }
       class_attendance: {
         Row: {
+          camera_on: boolean | null
           class_id: string
           created_at: string
           id: string
@@ -81,6 +82,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          camera_on?: boolean | null
           class_id: string
           created_at?: string
           id?: string
@@ -91,6 +93,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          camera_on?: boolean | null
           class_id?: string
           created_at?: string
           id?: string

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -24,21 +24,40 @@ export async function action({ request }: Route.ActionArgs) {
 
   const formData = await request.formData()
   const intent = formData.get('intent') as string | null
-  if (intent !== 'update-status') {
+  if (intent !== 'update-status' && intent !== 'update-camera-on') {
     return new Response('Unsupported action', { status: 400, headers: auth.headers })
   }
 
   const classId = formData.get('class_id') as string
   const profileId = formData.get('profile_id') as string
-  const status = (formData.get('status') as string | null) ?? null
   if (!classId || !profileId) {
     return new Response('Missing identifiers', { status: 400, headers: auth.headers })
+  }
+
+  const updates: { status?: string | null; camera_on?: boolean | null; recorded_by: string } = {
+    recorded_by: auth.user.id,
+  }
+
+  if (intent === 'update-status') {
+    const status = (formData.get('status') as string | null) ?? null
+    updates.status = status || null
+  }
+
+  if (intent === 'update-camera-on') {
+    const rawCameraOn = (formData.get('camera_on') as string | null) ?? ''
+    if (rawCameraOn === 'true') {
+      updates.camera_on = true
+    } else if (rawCameraOn === 'false') {
+      updates.camera_on = false
+    } else {
+      updates.camera_on = null
+    }
   }
 
   const { supabase } = createClient(request)
   const { error } = await supabase
     .from('class_attendance')
-    .update({ status: status || null, recorded_by: auth.user.id })
+    .update(updates)
     .eq('class_id', classId)
     .eq('profile_id', profileId)
 

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -185,8 +185,8 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
   'class-attendance': {
     label: 'Class Attendance',
     table: 'class_attendance',
-    select: 'id, class_id, profile_id, status, recorded_by, created_at',
-    columns: ['class_display', 'profile_display', 'status', 'recorded_by_email', 'created_at'],
+    select: 'id, class_id, profile_id, status, camera_on, recorded_by, created_at',
+    columns: ['class_display', 'profile_display', 'status', 'camera_on', 'recorded_by_email', 'created_at'],
     order: 'created_at',
     lookupMappings: [
       {

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -317,6 +317,19 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
     statusFetcher.submit(formData, { method: 'post' })
   }
 
+  const updateAttendanceCameraOn = (row: Record<string, unknown>, value: string) => {
+    if (!isClassAttendance || !canEditStatus) return
+    const classId = typeof row.class_id === 'string' ? row.class_id : ''
+    const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+    if (!classId || !profileId) return
+    const formData = new FormData()
+    formData.set('intent', 'update-camera-on')
+    formData.set('class_id', classId)
+    formData.set('profile_id', profileId)
+    formData.set('camera_on', value)
+    statusFetcher.submit(formData, { method: 'post' })
+  }
+
   const updateWorkshopEnrollmentStatus = (row: Record<string, unknown>, value: string) => {
     if (!isWorkshopEnrollment || !canEditStatus || !value) return
     const enrollmentId = typeof row.id === 'string' ? row.id : ''
@@ -633,6 +646,31 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                               <option value="unknown">unknown</option>
                               <option value="present">present</option>
                               <option value="absent">absent</option>
+                            </select>
+                          </td>
+                        )
+                      }
+
+                      if (isClassAttendance && column === 'camera_on' && canEditStatus) {
+                        const rawCameraOn = row.camera_on
+                        const cameraValue =
+                          typeof rawCameraOn === 'boolean'
+                            ? String(rawCameraOn)
+                            : typeof rawCameraOn === 'string' &&
+                                (rawCameraOn === 'true' || rawCameraOn === 'false')
+                              ? rawCameraOn
+                              : ''
+
+                        return (
+                          <td key={`cell-${rowIndex}-${column}`} className="px-4 py-2 font-mono">
+                            <select
+                              value={cameraValue}
+                              onChange={event => updateAttendanceCameraOn(row, event.target.value)}
+                              className="h-8 w-full rounded border border-input bg-background px-2 text-xs"
+                            >
+                              <option value="">(none)</option>
+                              <option value="true">true</option>
+                              <option value="false">false</option>
                             </select>
                           </td>
                         )


### PR DESCRIPTION
## Summary
- Adds `camera_on` support to class attendance data and manage table display.
- Adds a staff-editable dropdown in Manage Class Attendance for `camera_on` (`none`, `true`, `false`).
- Includes Supabase migration and type updates for the new column.

## Validation
- Ran `npm run typecheck` from `web/`.
- Ran `supabase migration up --include-all` locally.