### PR TITLE
Fix pre-survey return flow and table hover readability

### DIFF
--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -66,6 +66,9 @@ const getFamilyEnrollmentProfileId = (family: Awaited<ReturnType<typeof resolveF
   return family.profileId
 }
 
+const semesterSurveyPath = (semesterId: string) =>
+  `/semester-surveys/${semesterId}/pre?returnTo=${encodeURIComponent(`/enroll?semester=${semesterId}`)}`
+
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   const { supabase, headers } = createClient(request)
@@ -174,7 +177,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         {
           required,
           completed: Boolean(formId && completedPreSurveyFormIds.has(formId)),
-          preSurveyPath: formId ? `/semester-surveys/${semesterId}/pre` : null,
+          preSurveyPath: formId ? semesterSurveyPath(semesterId) : null,
         },
       ]
     })
@@ -265,12 +268,12 @@ export async function action({ request }: Route.ActionArgs) {
     : { data: { id: 'not-required' } }
 
   if (preSurveyForm.required && !preSurveySubmission?.id) {
-    return {
-      ok: false,
-      error: 'Please complete the pre-semester survey before enrolling.',
-      surveyPath: `/semester-surveys/${workshopRow.semester_id}/pre`,
-    } satisfies ActionData
-  }
+      return {
+        ok: false,
+        error: 'Please complete the pre-semester survey before enrolling.',
+        surveyPath: semesterSurveyPath(workshopRow.semester_id),
+      } satisfies ActionData
+    }
 
   const { data: workshopEnrollments } = await supabase
     .from('workshop_enrollment')

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -326,8 +326,20 @@ export default function EnrollPage() {
 
   return (
     <main className="flex w-full flex-col gap-6 px-6 py-10">
+      <div className="flex gap-2">
+        <Button asChild variant="outline">
+          <Link to="/home">Family Workshops</Link>
+        </Button>
+        <Button asChild>
+          <Link to="/enroll">Manage Enrollments</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link to="/home?tab=manage-family">Manage Family</Link>
+        </Button>
+      </div>
+
       <div className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold">Enroll in a workshop</h1>
+        <h1 className="text-2xl font-semibold">Manage Enrollments</h1>
         <p className="text-sm text-muted-foreground">Step 1: select a semester. Step 2: complete pre-survey. Step 3: choose one workshop.</p>
       </div>
 

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -556,6 +556,9 @@ export default function Home() {
         <Button asChild variant={tab === 'family-workshops' ? 'default' : 'outline'}>
           <Link to="/home">Family Workshops</Link>
         </Button>
+        <Button asChild variant="outline">
+          <Link to="/enroll">Manage Enrollments</Link>
+        </Button>
         <Button asChild variant={tab === 'manage-family' ? 'default' : 'outline'}>
           <Link to="/home?tab=manage-family">Manage Family</Link>
         </Button>
@@ -585,18 +588,13 @@ export default function Home() {
             <section className="rounded-lg border bg-card p-6 text-center shadow-sm space-y-4">
               <h2 className="text-xl font-semibold">Your family has not enrolled in any workshops</h2>
               <Button asChild>
-                <Link to="/enroll">Enroll in a workshop</Link>
+                <Link to="/enroll">Manage enrollments</Link>
               </Button>
             </section>
           ) : (
             <>
               <section className="rounded-lg border bg-card p-4 shadow-sm space-y-3">
-                <div className="flex items-center justify-between gap-3">
-                  <h2 className="text-lg font-semibold">Enrolled workshops</h2>
-                  <Button asChild variant="outline" size="sm">
-                    <Link to="/enroll">Enroll in a workshop</Link>
-                  </Button>
-                </div>
+                <h2 className="text-lg font-semibold">Enrolled workshops</h2>
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -624,7 +622,18 @@ export default function Home() {
                             </a>
                           </TableCell>
                           <TableCell>{semester?.name ?? (semester ? `${formatDate(semester.starts_at)} - ${formatDate(semester.ends_at)}` : enrollment.semester_id.slice(0, 8))}</TableCell>
-                          <TableCell className="capitalize">{enrollment.status}</TableCell>
+                          <TableCell>
+                            {enrollment.status === 'pending' ? (
+                              <span
+                                className="cursor-help capitalize"
+                                title="Your enrollment is under review. Thank you for your patience."
+                              >
+                                {enrollment.status}
+                              </span>
+                            ) : (
+                              <span className="capitalize">{enrollment.status}</span>
+                            )}
+                          </TableCell>
                           <TableCell>{next ? formatDateTime(next.starts_at) : 'No upcoming class'}</TableCell>
                           <TableCell>{`Present: ${attendance.present} · Absent: ${attendance.absent}`}</TableCell>
                         </TableRow>

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -573,7 +573,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                   <button
                     type="button"
                     onClick={() => updateSort(column)}
-                    className="flex items-center gap-1 font-semibold"
+                    className="flex items-center gap-1 font-semibold hover:underline hover:underline-offset-4"
                   >
                     {(columnMeta[column]?.label ?? column).replace(/_/g, ' ')}
                     {getDirectionIndicator(sortColumn === column ? sortStage : 0)}
@@ -700,10 +700,12 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                       const personLink = personLinkForCell(tableName, column, row)
                       const shouldTruncate = columnMeta[column]?.truncate ?? tableVariant !== 'pivot'
                       const filterable = columnMeta[column]?.filterable ?? true
+                      const cellValue = getCellValue(column, row, tableName)
 
                       return (
                         <td
                           key={`cell-${rowIndex}-${column}`}
+                          title={cellValue}
                           className={
                             isNumericColumn(column)
                               ? 'w-24 cursor-pointer whitespace-nowrap px-4 py-2 text-right font-mono tabular-nums hover:bg-muted/30'
@@ -711,7 +713,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                           }
                           onClick={() => {
                             if (!filterable) return
-                            appendFilter(column, getCellValue(column, row, tableName))
+                            appendFilter(column, cellValue)
                           }}
                         >
                           {isFormNameLink ? (
@@ -725,7 +727,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                               onClick={event => event.stopPropagation()}
                               className="underline decoration-dotted underline-offset-2 hover:text-primary"
                             >
-                              {getCellValue(column, row, tableName)}
+                              {cellValue}
                             </Link>
                           ) : isFormAnswersLink ? (
                             <Link
@@ -738,7 +740,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                               onClick={event => event.stopPropagation()}
                               className="underline decoration-dotted underline-offset-2 hover:text-primary"
                             >
-                              {getCellValue(column, row, tableName)}
+                              {cellValue}
                             </Link>
                           ) : personLink ? (
                             <Link
@@ -746,10 +748,10 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                               onClick={event => event.stopPropagation()}
                               className="underline decoration-dotted underline-offset-2 hover:text-primary"
                             >
-                              {getCellValue(column, row, tableName)}
+                              {cellValue}
                             </Link>
                           ) : (
-                            getCellValue(column, row, tableName)
+                            cellValue
                           )}
                         </td>
                       )

--- a/web/app/routes/semester-surveys.pre.tsx
+++ b/web/app/routes/semester-surveys.pre.tsx
@@ -26,6 +26,7 @@ type LoaderData = {
   questions: FormQuestionData[]
   answers: Record<string, Json>
   familyProfileId: string
+  returnTo: string
 }
 
 type ActionData = {
@@ -64,6 +65,12 @@ const getFamilyEnrollmentProfileId = (family: Awaited<ReturnType<typeof resolveF
   return family.profileId
 }
 
+const sanitizeReturnTo = (value: string | null, semesterId: string) => {
+  if (!value) return `/enroll?semester=${semesterId}`
+  if (!value.startsWith('/') || value.startsWith('//')) return `/enroll?semester=${semesterId}`
+  return value
+}
+
 export async function loader({ request, params }: Route.LoaderArgs) {
   const semesterId = params.semesterId
   if (!semesterId) {
@@ -72,6 +79,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const auth = await enforceOnboardingGuard(request)
   const { supabase, headers } = createClient(request)
+  const url = new URL(request.url)
+  const returnTo = sanitizeReturnTo(url.searchParams.get('returnTo'), semesterId)
   const family = await resolveFamilyGraph(supabase, auth.user.id)
   const familyProfileId = getFamilyEnrollmentProfileId(family)
 
@@ -142,6 +151,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     questions: normalizedQuestions,
     answers,
     familyProfileId,
+    returnTo,
   } satisfies LoaderData
 }
 
@@ -193,6 +203,10 @@ export async function action({ request, params }: Route.ActionArgs) {
   })
 
   const formData = await request.formData()
+  const returnTo = sanitizeReturnTo(
+    typeof formData.get('return_to') === 'string' ? String(formData.get('return_to')) : null,
+    semesterId
+  )
   const answersToSave: { question_code: string; value: Json }[] = []
 
   for (const question of questions) {
@@ -270,11 +284,11 @@ export async function action({ request, params }: Route.ActionArgs) {
     }
   }
 
-  throw redirect('/home', { headers })
+  throw redirect(returnTo, { headers })
 }
 
 export default function SemesterPreSurveyPage() {
-  const { semesterId, formName, formId, questions, answers } = useLoaderData() as LoaderData
+  const { semesterId, formName, formId, questions, answers, returnTo } = useLoaderData() as LoaderData
   const actionData = useActionData() as ActionData | undefined
   const navigation = useNavigation()
   const isSubmitting = navigation.state === 'submitting'
@@ -290,6 +304,7 @@ export default function SemesterPreSurveyPage() {
         </CardHeader>
         <CardContent>
           <Form method="post" className="space-y-6">
+            <input type="hidden" name="return_to" value={returnTo} />
             <p className="text-sm text-slate-500">Semester: {semesterId}</p>
 
             {questions.map(question => {


### PR DESCRIPTION
## Summary
- Preserves return-to context when completing semester pre-surveys so users return to enrollment selection instead of home.
- Adds safe return target sanitization for pre-survey redirects.
- Improves manage table UX by underlining sortable headers on hover and showing full cell values via hover tooltips.

## Validation
- Ran `npm run typecheck` from `web/`.