### PR TITLE
Tighten top spacing above tab navigation

### DIFF
--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -325,7 +325,7 @@ export default function EnrollPage() {
   const semesterEnrollment = semesterId ? enrollments.find(enrollment => enrollment.semester_id === semesterId) : null
 
   return (
-    <main className="flex w-full flex-col gap-6 px-6 py-10">
+    <main className="flex w-full flex-col gap-6 px-6 pt-6 pb-10">
       <div className="flex gap-2">
         <Button asChild variant="outline">
           <Link to="/home">Family Workshops</Link>

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -551,7 +551,7 @@ export default function Home() {
   }
 
   return (
-    <main className="w-full px-6 py-10 space-y-6">
+    <main className="w-full px-6 pt-6 pb-10 space-y-6">
       <div className="flex gap-2">
         <Button asChild variant={tab === 'family-workshops' ? 'default' : 'outline'}>
           <Link to="/home">Family Workshops</Link>


### PR DESCRIPTION
## Summary
- Reduces top padding above the primary tab navigation on Home and Enroll pages.
- Keeps bottom spacing unchanged so page rhythm remains consistent.

## Validation
- Ran `npm run typecheck` from `web/`.