### PR TITLE
Merge sai/main updates into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Update this file whenever commands, conventions, or workflows change.
 - Do not stage secrets (`.env.local`, Supabase service-role keys, other credentials).
 - Treat `supabase/migrations/` as generated output from schema changes.
 
-2) AI instruction files (checked)
+2) AI instruction files (checked on 2026-05-19)
 - No Cursor rules found at `.cursor/rules/`.
 - No `.cursorrules` file found.
 - No Copilot rules found at `.github/copilot-instructions.md`.
@@ -32,8 +32,8 @@ Update this file whenever commands, conventions, or workflows change.
 - Root `package.json` is not the app runtime source of truth; `web/package.json` is.
 - Local default dev URL is `http://localhost:5173`.
 
-5) Build, lint, and test commands
-- Install deps: `npm install` (inside `web/`).
+5) Build/lint/test commands (from `web/`)
+- Install deps: `npm install`.
 - Dev server: `npm run dev`.
 - Type/lint gate: `npm run typecheck` (`react-router typegen && tsc`).
 - There is no dedicated eslint/prettier script in `web/package.json`.
@@ -44,26 +44,24 @@ Update this file whenever commands, conventions, or workflows change.
 - Headed tests: `npm run test:e2e:headed`.
 
 6) Single-test command patterns (important)
-- Single spec file: `npm run test:e2e -- tests/e2e/create-guardian.spec.ts`.
-- Single unit-style spec file: `npm run test:e2e -- tests/unit/gift-card-csv.spec.ts`.
-- Filter by title: `npm run test:e2e -- --grep "guardian sign-up creates a guardian profile"`.
+- Single e2e file: `npm run test:e2e -- tests/e2e/create-guardian.spec.ts`.
+- Single unit-style file: `npm run test:e2e -- tests/unit/gift-card-csv.spec.ts`.
+- Filter by title only: `npm run test:e2e -- --grep "guardian sign-up creates a guardian profile"`.
 - File + title filter: `npm run test:e2e -- tests/unit/gift-card-csv.spec.ts --grep "reports missing fields"`.
 - Playwright auto-starts `npm run dev -- --port 5173` when `PLAYWRIGHT_BASE_URL` is unset.
 
 7) Supabase and schema workflow
 - Start local Supabase: `supabase start --debug`.
 - Check local status/keys: `supabase status -o json`.
-- Migration creation (required): always run `supabase migration new <name>` for any manual SQL migration.
+- Migration creation (required): run `supabase migration new <name>` for manual SQL migrations.
 - Never hand-create files in `supabase/migrations/` and never rename migration versions manually.
 - Never edit an existing migration file once committed/shared; create a new migration for follow-up changes.
 - Keep migration versions unique and strictly increasing to avoid collisions/skipped applies.
-- Schema flow: edit `supabase/schemas/*.sql` -> `supabase db diff -f <name>` (or `supabase migration new <name>` for manual SQL) -> `supabase migration up`.
+- Schema flow: edit `supabase/schemas/*.sql` -> `supabase db diff -f <name>` (or manual migration) -> `supabase migration up`.
 - If a migration failed after partial changes, do not mutate old files; add a new migration that fixes forward.
-- Verify migration application with `supabase migration list` and confirm the new version appears in both local/remote when relevant.
-- Regenerate DB types (local):
-  `supabase gen types typescript --local > web/app/lib/database.types.ts`.
-- Regenerate DB types (remote ref):
-  `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
+- Verify migration application with `supabase migration list` and confirm new versions appear where expected.
+- Regenerate DB types (local): `supabase gen types typescript --local > web/app/lib/database.types.ts`.
+- Regenerate DB types (remote): `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
 
 8) Import conventions
 - Prefer 3 import blocks with blank lines: external, alias (`@/` or `~/`), then relative.
@@ -73,7 +71,7 @@ Update this file whenever commands, conventions, or workflows change.
 
 9) Formatting conventions
 - Match local style in each touched file (many files use 2 spaces and no semicolons).
-- Quote style is mixed; preserve existing style in the file you edit.
+- Quote style is mixed; preserve existing quote style in the file you edit.
 - Avoid mass import sorting or quote normalization unless requested.
 - Keep Tailwind class strings literal and token-based.
 - Avoid computed class fragments that could break Tailwind scanning.
@@ -93,7 +91,7 @@ Update this file whenever commands, conventions, or workflows change.
 - Route filenames: hyphenated (for example `forgot-password.tsx`); use `index.tsx` only for index routes.
 
 12) Router and route-module patterns
-- Route modules typically export `loader`, `action`, and a default component in one file.
+- Route modules usually export `loader`, `action`, and a default component in one file.
 - After adding/removing routes, update `web/app/routes.ts`.
 - Run `npm run typecheck` after route changes to refresh router-generated types.
 - Keep route-specific helpers near the route unless reused broadly.
@@ -114,7 +112,7 @@ Update this file whenever commands, conventions, or workflows change.
 - Fail early in protected loaders/actions (redirect unauthenticated users).
 - Return user-friendly messages for expected failures.
 - For unexpected failures, log with `console.error` and return/throw controlled responses.
-- Use route error boundaries with `isRouteErrorResponse` patterns when possible.
+- Use route error boundaries with `isRouteErrorResponse` when possible.
 
 16) UI and accessibility practices
 - Reuse primitives in `web/app/components/ui/*` before creating new ones.
@@ -123,6 +121,7 @@ Update this file whenever commands, conventions, or workflows change.
 - Keep responsive behavior aligned to existing breakpoints/tokens.
 - Use `cn()` from `web/app/lib/utils.ts` for conditional class composition.
 - For auth sticker backdrops, use solid backgrounds only (no gradient backgrounds).
+- For emails, apply all styling inline (`style="..."`) and do not rely on `<style>` blocks; inline styles are required to preserve formatting during forwarding.
 
 17) Testing and QA expectations
 - Test files live under `web/tests/e2e` and `web/tests/unit` (both run via Playwright).
@@ -140,18 +139,18 @@ Update this file whenever commands, conventions, or workflows change.
 19) Pre-handoff checklist
 - Minimum for substantial code changes: run `npm run typecheck`.
 - If dependencies/config/build behavior changed: run `npm run build`.
-- If behavior changed: run relevant targeted tests (prefer single-file/test filters first).
+- If behavior changed: run relevant targeted tests (single-file/test-title filters first).
 - If schema changed: regenerate `web/app/lib/database.types.ts`.
 
-20) Maintenance note
-- Keep this handbook near 150 lines.
-- Keep command examples current with `web/package.json` and `web/playwright.config.ts`.
-- Update this file whenever workflows, conventions, or tooling change.
-
-21) Default decision rules for agents
+20) Default decision rules for agents
 - If a rule is ambiguous, follow existing nearby code patterns first.
 - If a change touches auth/session behavior, preserve headers and test redirects.
 - If a change touches routes or schemas, run regeneration commands before handoff.
 - If uncertain about style, prefer minimal edits over broad cleanup.
+
+21) Maintenance note
+- Keep this handbook near 150 lines.
+- Keep command examples current with `web/package.json` and `web/playwright.config.ts`.
+- Update this file whenever workflows, conventions, or tooling change.
 
 End of handbook.

--- a/supabase/schemas/09_semester_form_requirements.sql
+++ b/supabase/schemas/09_semester_form_requirements.sql
@@ -1,6 +1,6 @@
 create type semester_survey_kind as enum (
-  'pre_survey',
-  'post_survey'
+  'pre_program_survey',
+  'post_program_survey'
 );
 
 create table public.semester_form_requirement (

--- a/web/app/app.css
+++ b/web/app/app.css
@@ -10,7 +10,7 @@
 
 html,
 body {
-  @apply bg-white dark:bg-gray-950;
+  background-color: #fff7ef;
 
   @media (prefers-color-scheme: dark) {
     color-scheme: dark;
@@ -64,7 +64,7 @@ body {
   --brand-blue: #2d91cf;
   --brand-green: #24b683;
   --brand-purple-dark: #2b2258;
-  --background: oklch(1 0 0);
+  --background: #fff7ef;
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);

--- a/web/app/components/auth/sticker-background.tsx
+++ b/web/app/components/auth/sticker-background.tsx
@@ -101,7 +101,11 @@ export default function AuthStickerBackground({
   const allStickers = dense ? createDenseStickers() : STICKERS
 
   return (
-    <div className="relative flex h-svh w-full items-center justify-center overflow-hidden bg-[#fff7ef] p-4 md:p-8">
+    <div
+      className={`relative flex h-svh w-full justify-center overflow-hidden bg-[#fff7ef] p-4 md:p-8 ${
+        scrollContent ? 'items-start' : 'items-center'
+      }`}
+    >
       <div aria-hidden="true" className={`pointer-events-none absolute inset-0 ${dense ? 'z-20' : ''}`}>
         {allStickers.map((sticker, index) => (
           <img

--- a/web/app/components/forms/form-question.tsx
+++ b/web/app/components/forms/form-question.tsx
@@ -65,6 +65,11 @@ export function FormQuestion({ question, value, required }: FormQuestionProps) {
     return value === option
   }
 
+  const isPostcodeField =
+    metadata.field === 'postcode' ||
+    autoComplete === 'postal-code' ||
+    question.question_code.toLowerCase().includes('postcode')
+
   const renderRadioGroup = (items: string[]) => (
     <fieldset className="space-y-2">
       <Label className="text-base">
@@ -187,11 +192,27 @@ export function FormQuestion({ question, value, required }: FormQuestionProps) {
         name={name}
         type={resolvedInputType}
         defaultValue={typeof value === 'string' ? value : ''}
-        placeholder={placeholder}
+        placeholder={isPostcodeField ? 'ANA NAN' : placeholder}
         autoComplete={autoComplete}
         min={min}
         max={max}
         step={step}
+        pattern={isPostcodeField ? '[A-Za-z][0-9][A-Za-z] [0-9][A-Za-z][0-9]' : undefined}
+        title={isPostcodeField ? 'Use format ANA NAN (for example K1A 0B1)' : undefined}
+        maxLength={isPostcodeField ? 7 : undefined}
+        className={isPostcodeField ? 'uppercase' : undefined}
+        onInput={
+          isPostcodeField
+            ? event => {
+                const input = event.currentTarget
+                let next = input.value.toUpperCase().replace(/[^A-Z0-9]/g, '')
+                if (next.length > 3) {
+                  next = `${next.slice(0, 3)} ${next.slice(3, 6)}`
+                }
+                input.value = next.slice(0, 7)
+              }
+            : undefined
+        }
         required={required}
       />
     </div>

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -644,93 +644,6 @@ export type Database = {
         }
         Relationships: []
       }
-      sign_up_terms: {
-        Row: {
-          content: string
-          created_at: string
-          id: string
-          is_active: boolean
-          slug: string
-          title: string
-          updated_at: string
-          version: number
-        }
-        Insert: {
-          content: string
-          created_at?: string
-          id?: string
-          is_active?: boolean
-          slug: string
-          title: string
-          updated_at?: string
-          version?: number
-        }
-        Update: {
-          content?: string
-          created_at?: string
-          id?: string
-          is_active?: boolean
-          slug?: string
-          title?: string
-          updated_at?: string
-          version?: number
-        }
-        Relationships: []
-      }
-      sign_up_terms_consent: {
-        Row: {
-          accepted_at: string
-          email: string
-          id: string
-          metadata: Json
-          profile_id: string | null
-          role: Database["public"]["Enums"]["app_role"]
-          sign_up_terms_id: string
-          terms_content: string
-          terms_version: number
-          user_id: string | null
-        }
-        Insert: {
-          accepted_at?: string
-          email: string
-          id?: string
-          metadata?: Json
-          profile_id?: string | null
-          role: Database["public"]["Enums"]["app_role"]
-          sign_up_terms_id: string
-          terms_content: string
-          terms_version: number
-          user_id?: string | null
-        }
-        Update: {
-          accepted_at?: string
-          email?: string
-          id?: string
-          metadata?: Json
-          profile_id?: string | null
-          role?: Database["public"]["Enums"]["app_role"]
-          sign_up_terms_id?: string
-          terms_content?: string
-          terms_version?: number
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "sign_up_terms_consent_profile_id_fkey"
-            columns: ["profile_id"]
-            isOneToOne: false
-            referencedRelation: "profile"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "sign_up_terms_consent_sign_up_terms_id_fkey"
-            columns: ["sign_up_terms_id"]
-            isOneToOne: false
-            referencedRelation: "sign_up_terms"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       role_permission: {
         Row: {
           permission: Database["public"]["Enums"]["app_permissions"]
@@ -867,6 +780,93 @@ export type Database = {
             columns: ["form_id"]
             isOneToOne: true
             referencedRelation: "form"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sign_up_terms: {
+        Row: {
+          content: string
+          created_at: string
+          id: string
+          is_active: boolean
+          slug: string
+          title: string
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          slug: string
+          title: string
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          slug?: string
+          title?: string
+          updated_at?: string
+          version?: number
+        }
+        Relationships: []
+      }
+      sign_up_terms_consent: {
+        Row: {
+          accepted_at: string
+          email: string
+          id: string
+          metadata: Json
+          profile_id: string | null
+          role: Database["public"]["Enums"]["app_role"]
+          sign_up_terms_id: string
+          terms_content: string
+          terms_version: number
+          user_id: string | null
+        }
+        Insert: {
+          accepted_at?: string
+          email: string
+          id?: string
+          metadata?: Json
+          profile_id?: string | null
+          role: Database["public"]["Enums"]["app_role"]
+          sign_up_terms_id: string
+          terms_content: string
+          terms_version: number
+          user_id?: string | null
+        }
+        Update: {
+          accepted_at?: string
+          email?: string
+          id?: string
+          metadata?: Json
+          profile_id?: string | null
+          role?: Database["public"]["Enums"]["app_role"]
+          sign_up_terms_id?: string
+          terms_content?: string
+          terms_version?: number
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sign_up_terms_consent_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profile"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "sign_up_terms_consent_sign_up_terms_id_fkey"
+            columns: ["sign_up_terms_id"]
+            isOneToOne: false
+            referencedRelation: "sign_up_terms"
             referencedColumns: ["id"]
           },
         ]
@@ -1076,6 +1076,10 @@ export type Database = {
         Args: { p_user_id: string }
         Returns: boolean
       }
+      profile_in_same_family: {
+        Args: { target_profile_id: string }
+        Returns: boolean
+      }
       should_auto_promote_onboarding: { Args: never; Returns: boolean }
       sync_auto_assigned_forms_for_form: {
         Args: { p_form_id: string }
@@ -1161,13 +1165,13 @@ export type Database = {
         | "failed"
       gift_card_upload_type: "pdf_per_page" | "pdf_per_4_pages" | "csv_link"
       invite_status: "pending" | "confirmed" | "revoked"
+      semester_survey_kind: "pre_survey" | "post_survey"
       workshop_enrollment_status:
         | "pending"
         | "waitlisted"
         | "approved"
         | "rejected"
         | "revoked"
-      semester_survey_kind: "pre_survey" | "post_survey"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1376,6 +1380,7 @@ export const Constants = {
       ],
       gift_card_upload_type: ["pdf_per_page", "pdf_per_4_pages", "csv_link"],
       invite_status: ["pending", "confirmed", "revoked"],
+      semester_survey_kind: ["pre_survey", "post_survey"],
       workshop_enrollment_status: [
         "pending",
         "waitlisted",
@@ -1383,7 +1388,7 @@ export const Constants = {
         "rejected",
         "revoked",
       ],
-      semester_survey_kind: ["pre_survey", "post_survey"],
     },
   },
 } as const
+

--- a/web/app/lib/semester-survey.server.ts
+++ b/web/app/lib/semester-survey.server.ts
@@ -1,6 +1,6 @@
 import { adminClient } from '@/lib/supabase/adminClient'
 
-export type SemesterSurveyKind = 'pre_survey' | 'post_survey'
+export type SemesterSurveyKind = 'pre_program_survey' | 'post_program_survey'
 
 type SemesterSurveyForm = {
   formId: string | null

--- a/web/app/lib/semester-survey.server.ts
+++ b/web/app/lib/semester-survey.server.ts
@@ -2,6 +2,11 @@ import { adminClient } from '@/lib/supabase/adminClient'
 
 export type SemesterSurveyKind = 'pre_program_survey' | 'post_program_survey'
 
+const legacyKindFor = (kind: SemesterSurveyKind) => {
+  if (kind === 'pre_program_survey') return 'pre_survey'
+  return 'post_survey'
+}
+
 type SemesterSurveyForm = {
   formId: string | null
   required: boolean
@@ -11,19 +16,32 @@ export const resolveSemesterSurveyForm = async (
   semesterId: string,
   kind: SemesterSurveyKind
 ): Promise<SemesterSurveyForm> => {
-  const { data: mapped } = await adminClient
-    .from('semester_form_requirement')
-    .select('form_id, is_required')
-    .eq('semester_id', semesterId)
-    .eq('kind', kind)
-    .eq('is_active', true)
-    .limit(1)
-    .maybeSingle()
+  const kindCandidates = [kind, legacyKindFor(kind)]
 
-  if (mapped?.form_id) {
-    return {
-      formId: mapped.form_id,
-      required: mapped.is_required !== false,
+  for (const candidateKind of kindCandidates) {
+    const { data: mapped, error } = await adminClient
+      .from('semester_form_requirement')
+      .select('form_id, is_required')
+      .eq('semester_id', semesterId)
+      .eq('kind', candidateKind as never)
+      .eq('is_active', true)
+      .limit(1)
+      .maybeSingle()
+
+    if (mapped?.form_id) {
+      return {
+        formId: mapped.form_id,
+        required: mapped.is_required !== false,
+      }
+    }
+
+    if (!error) {
+      continue
+    }
+
+    const code = typeof error.code === 'string' ? error.code : ''
+    if (code !== '22P02') {
+      break
     }
   }
 

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -8,7 +8,8 @@ export default [
   route("enroll", "routes/enroll.tsx"),
   route("my-forms", "routes/my-forms.tsx"),
   route("my-forms/:formId", "routes/my-forms.$formId.tsx"),
-  route("semester-surveys/:semesterId/pre", "routes/semester-surveys.pre.tsx"),
+  route("semester-surveys/:semesterId/pre-program", "routes/semester-surveys.pre.tsx"),
+  route("semester-surveys/:semesterId/pre", "routes/semester-surveys.pre-redirect.tsx"),
   route("login", "routes/auth/login.tsx"),
   route(
     "sign-up",

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -6,6 +6,7 @@ export default [
   route("info", "routes/info.tsx"),
   route("forms", "routes/forms.tsx"),
   route("enroll", "routes/enroll.tsx"),
+  route("enroll/:semesterId", "routes/enroll.$semesterId.tsx"),
   route("my-forms", "routes/my-forms.tsx"),
   route("my-forms/:formId", "routes/my-forms.$formId.tsx"),
   route("semester-surveys/:semesterId/pre-program", "routes/semester-surveys.pre.tsx"),

--- a/web/app/routes/enroll.$semesterId.tsx
+++ b/web/app/routes/enroll.$semesterId.tsx
@@ -1,0 +1,1 @@
+export { loader, action, default } from './enroll'

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -1,4 +1,4 @@
-import { Link, redirect, useActionData, useLoaderData, useSearchParams } from 'react-router'
+import { Link, redirect, useActionData, useLoaderData } from 'react-router'
 
 import type { Route } from './+types/enroll'
 import { Button } from '@/components/ui/button'
@@ -67,7 +67,7 @@ const getFamilyEnrollmentProfileId = (family: Awaited<ReturnType<typeof resolveF
 }
 
 const semesterSurveyPath = (semesterId: string) =>
-  `/semester-surveys/${semesterId}/pre-program?returnTo=${encodeURIComponent(`/enroll?semester=${semesterId}`)}`
+  `/semester-surveys/${semesterId}/pre-program?returnTo=${encodeURIComponent(`/enroll/${semesterId}`)}`
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
@@ -82,7 +82,14 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const url = new URL(request.url)
-  const selectedSemesterId = url.searchParams.get('semester')
+  const enrollPathMatch = url.pathname.match(/^\/enroll\/([^/]+)$/)
+  const pathSemesterId = enrollPathMatch?.[1] ? decodeURIComponent(enrollPathMatch[1]) : null
+  const querySemesterId = url.searchParams.get('semester')
+  const selectedSemesterId = pathSemesterId ?? querySemesterId
+
+  if (!pathSemesterId && querySemesterId) {
+    throw redirect(`/enroll/${querySemesterId}`, { headers })
+  }
 
   const [{ data: semesterData }, { data: enrollmentsData }] = await Promise.all([
     supabase
@@ -122,7 +129,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     })
 
     if (openSemesters.length === 1) {
-      throw redirect(`/enroll?semester=${openSemesters[0].id}`, { headers })
+      throw redirect(`/enroll/${openSemesters[0].id}`, { headers })
     }
   }
 
@@ -318,9 +325,8 @@ export async function action({ request }: Route.ActionArgs) {
 export default function EnrollPage() {
   const { semesters, enrollments, workshopCapacityById, preSurveyBySemester, selectedSemesterId } = useLoaderData<LoaderData>()
   const actionData = useActionData<ActionData>()
-  const [searchParams] = useSearchParams()
 
-  const semesterId = selectedSemesterId ?? searchParams.get('semester')
+  const semesterId = selectedSemesterId
   const selectedSemester = semesterId ? semesters.find(semester => semester.id === semesterId) : null
   const semesterEnrollment = semesterId ? enrollments.find(enrollment => enrollment.semester_id === semesterId) : null
 
@@ -375,7 +381,7 @@ export default function EnrollPage() {
                     <TableCell className="capitalize">{status ?? 'Not enrolled'}</TableCell>
                     <TableCell className="text-right">
                       <Button asChild size="sm" variant="outline">
-                        <Link to={`/enroll?semester=${semester.id}`}>Select semester</Link>
+                        <Link to={`/enroll/${semester.id}`}>Select semester</Link>
                       </Button>
                     </TableCell>
                   </TableRow>

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -67,7 +67,7 @@ const getFamilyEnrollmentProfileId = (family: Awaited<ReturnType<typeof resolveF
 }
 
 const semesterSurveyPath = (semesterId: string) =>
-  `/semester-surveys/${semesterId}/pre?returnTo=${encodeURIComponent(`/enroll?semester=${semesterId}`)}`
+  `/semester-surveys/${semesterId}/pre-program?returnTo=${encodeURIComponent(`/enroll?semester=${semesterId}`)}`
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
@@ -147,7 +147,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const preSurveyFormBySemester = new Map<string, { formId: string | null; required: boolean }>()
   await Promise.all(
     semesterIds.map(async semesterId => {
-      preSurveyFormBySemester.set(semesterId, await resolveSemesterSurveyForm(semesterId, 'pre_survey'))
+      preSurveyFormBySemester.set(semesterId, await resolveSemesterSurveyForm(semesterId, 'pre_program_survey'))
     })
   )
 
@@ -250,10 +250,10 @@ export async function action({ request }: Route.ActionArgs) {
     return { ok: false, error: 'Family enrollment profile not found.' } satisfies ActionData
   }
 
-  const preSurveyForm = await resolveSemesterSurveyForm(workshopRow.semester_id, 'pre_survey')
+  const preSurveyForm = await resolveSemesterSurveyForm(workshopRow.semester_id, 'pre_program_survey')
 
   if (!preSurveyForm.formId) {
-    return { ok: false, error: 'Pre-semester survey is not configured for this semester.' } satisfies ActionData
+    return { ok: false, error: 'Pre-program survey is not configured for this semester.' } satisfies ActionData
   }
 
   const { data: preSurveySubmission } = preSurveyForm.required
@@ -270,7 +270,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (preSurveyForm.required && !preSurveySubmission?.id) {
       return {
         ok: false,
-        error: 'Please complete the pre-semester survey before enrolling.',
+        error: 'Please complete the pre-program survey before enrolling.',
         surveyPath: semesterSurveyPath(workshopRow.semester_id),
       } satisfies ActionData
     }
@@ -340,7 +340,7 @@ export default function EnrollPage() {
 
       <div className="flex flex-col gap-2">
         <h1 className="text-2xl font-semibold">Manage Enrollments</h1>
-        <p className="text-sm text-muted-foreground">Step 1: select a semester. Step 2: complete pre-survey. Step 3: choose one workshop.</p>
+        <p className="text-sm text-muted-foreground">Step 1: select a semester. Step 2: complete pre-program survey. Step 3: choose one workshop.</p>
       </div>
 
       {!selectedSemester ? (
@@ -351,7 +351,7 @@ export default function EnrollPage() {
                 <TableHead>Semester ID</TableHead>
                 <TableHead>Name</TableHead>
                 <TableHead>Dates</TableHead>
-                <TableHead>Pre-survey</TableHead>
+                <TableHead>Pre-program survey</TableHead>
                 <TableHead>Enrollment</TableHead>
                 <TableHead className="text-right">Action</TableHead>
               </TableRow>
@@ -406,13 +406,18 @@ export default function EnrollPage() {
           ) : preSurveyBySemester[selectedSemester.id]?.required &&
             !preSurveyBySemester[selectedSemester.id]?.completed ? (
             <div className="rounded-lg border bg-card p-4 shadow-sm space-y-2">
-              <p className="font-medium">Complete pre-survey before choosing a workshop.</p>
+              <p className="font-medium">Complete pre-program survey before choosing a workshop.</p>
+              <p className="text-sm text-muted-foreground">
+                As part of summerlunch+, we&apos;ll ask a few questions about your family&apos;s nutrition
+                knowledge, cooking skills, eating habits, and more. Parents or caregivers are invited to
+                complete this survey together with their Jr. Chef.
+              </p>
               {preSurveyBySemester[selectedSemester.id]?.preSurveyPath ? (
                 <Button asChild>
-                  <Link to={preSurveyBySemester[selectedSemester.id].preSurveyPath as string}>Complete pre-survey</Link>
+                  <Link to={preSurveyBySemester[selectedSemester.id].preSurveyPath as string}>Complete pre-program survey</Link>
                 </Button>
               ) : (
-                <p className="text-sm text-muted-foreground">Pre-survey is not configured yet for this semester.</p>
+                <p className="text-sm text-muted-foreground">Pre-program survey is not configured yet for this semester.</p>
               )}
             </div>
           ) : (
@@ -478,7 +483,7 @@ export default function EnrollPage() {
           <p className="text-sm text-destructive">{actionData.error}</p>
           {actionData.surveyPath ? (
             <Button asChild variant="outline" size="sm">
-              <Link to={actionData.surveyPath}>Complete pre-survey</Link>
+              <Link to={actionData.surveyPath}>Complete pre-program survey</Link>
             </Button>
           ) : null}
         </div>

--- a/web/app/routes/manage/semester.tsx
+++ b/web/app/routes/manage/semester.tsx
@@ -39,7 +39,7 @@ const parseSemesterField = (
 const setSemesterSurveyMapping = async (
   supabase: ReturnType<typeof createClient>['supabase'],
   semesterId: string,
-  kind: 'pre_survey' | 'post_survey',
+  kind: 'pre_program_survey' | 'post_program_survey',
   formId: string | null
 ) => {
   if (!formId) {
@@ -122,8 +122,8 @@ export async function loader(args: LoaderFunctionArgs) {
 
   for (const row of rows) {
     const semesterId = typeof row.id === 'string' ? row.id : ''
-    const pre = mappingBySemesterKind.get(`${semesterId}:pre_survey`)
-    const post = mappingBySemesterKind.get(`${semesterId}:post_survey`)
+    const pre = mappingBySemesterKind.get(`${semesterId}:pre_program_survey`)
+    const post = mappingBySemesterKind.get(`${semesterId}:post_program_survey`)
     row.pre_survey_form_id = pre?.formId ?? ''
     row.post_survey_form_id = post?.formId ?? ''
     row.pre_survey_form_name = pre?.formName ?? ''
@@ -146,8 +146,8 @@ export async function loader(args: LoaderFunctionArgs) {
     columns,
     columnMeta: {
       ...(base.columnMeta ?? {}),
-      pre_survey_form_name: { label: 'Pre survey form' },
-      post_survey_form_name: { label: 'Post survey form' },
+      pre_survey_form_name: { label: 'Pre-program survey form' },
+      post_survey_form_name: { label: 'Post-program survey form' },
     },
     editorConfig: base.editorConfig
       ? {
@@ -155,12 +155,12 @@ export async function loader(args: LoaderFunctionArgs) {
           fields: {
             ...base.editorConfig.fields,
             pre_survey_form_id: {
-              label: 'Pre survey form',
+              label: 'Pre-program survey form',
               type: 'foreign_key' as const,
               nullable: true,
             },
             post_survey_form_id: {
-              label: 'Post survey form',
+              label: 'Post-program survey form',
               type: 'foreign_key' as const,
               nullable: true,
             },
@@ -226,7 +226,7 @@ export async function action({ request }: ActionFunctionArgs) {
     const preError = await setSemesterSurveyMapping(
       supabase,
       inserted.id,
-      'pre_survey',
+      'pre_program_survey',
       preSurveyFormId
     )
     if (preError) {
@@ -236,7 +236,7 @@ export async function action({ request }: ActionFunctionArgs) {
     const postError = await setSemesterSurveyMapping(
       supabase,
       inserted.id,
-      'post_survey',
+      'post_program_survey',
       postSurveyFormId
     )
     if (postError) {
@@ -259,7 +259,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const preError = await setSemesterSurveyMapping(
     supabase,
     semesterId,
-    'pre_survey',
+    'pre_program_survey',
     preSurveyFormId
   )
   if (preError) {
@@ -269,7 +269,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const postError = await setSemesterSurveyMapping(
     supabase,
     semesterId,
-    'post_survey',
+    'post_program_survey',
     postSurveyFormId
   )
   if (postError) {

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -6,7 +6,7 @@ export type LookupMapping = {
   resultColumn: string
   keyColumnInTable?: string
   select?: string
-  format?: 'profile_display' | 'semester_range' | 'class_display' | 'submission_display'
+  format?: 'profile_display' | 'semester_range' | 'semester_title' | 'class_display' | 'submission_display'
 }
 
 export type EditorFieldType = 'text' | 'number' | 'boolean' | 'date' | 'datetime' | 'foreign_key' | 'enum' | 'json'
@@ -364,15 +364,15 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
     label: 'Semester Survey Mapping',
     table: 'semester_form_requirement',
     select: 'id, semester_id, form_id, kind, is_required, is_active, updated_at',
-    columns: ['semester_range', 'kind', 'form_name', 'is_required', 'is_active', 'updated_at'],
+    columns: ['semester_title', 'kind', 'form_name', 'is_required', 'is_active', 'updated_at'],
     order: 'updated_at',
     lookupMappings: [
       {
         keyColumn: 'semester_id',
         table: 'semester',
-        resultColumn: 'semester_range',
-        select: 'id, name, starts_at, ends_at',
-        format: 'semester_range',
+        resultColumn: 'semester_title',
+        select: 'id, name, description',
+        format: 'semester_title',
       },
       {
         keyColumn: 'form_id',

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -392,7 +392,7 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
           label: 'Survey Type',
           type: 'enum',
           required: true,
-          enumValues: ['pre_survey', 'post_survey'],
+          enumValues: ['pre_program_survey', 'post_program_survey'],
         },
         is_required: { label: 'Required', type: 'boolean', required: true },
         is_active: { label: 'Active', type: 'boolean', required: true },

--- a/web/app/routes/manage/table-loader.ts
+++ b/web/app/routes/manage/table-loader.ts
@@ -63,6 +63,14 @@ const semesterDisplay = (semesterRow: Record<string, unknown> | null, fallbackId
   return range || fallbackId
 }
 
+const semesterTitleDisplay = (semesterRow: Record<string, unknown> | null, fallbackId: string) => {
+  const name = typeof semesterRow?.name === 'string' ? semesterRow.name.trim() : ''
+  if (name) return name
+  const description = typeof semesterRow?.description === 'string' ? semesterRow.description.trim() : ''
+  if (description) return description
+  return 'Unnamed semester'
+}
+
 const workshopDisplay = (workshopRow: Record<string, unknown> | null, fallbackId: string) => {
   const description = typeof workshopRow?.description === 'string' ? workshopRow.description.trim() : ''
   return description || fallbackId
@@ -198,7 +206,7 @@ const foreignKeyOptions = async (
       supabase.from('form').select('id, name').order('name', { ascending: true }),
       supabase
         .from('semester')
-        .select('id, name, starts_at, ends_at')
+        .select('id, name, description, starts_at, ends_at')
         .order('starts_at', { ascending: true }),
     ])
 
@@ -209,7 +217,7 @@ const foreignKeyOptions = async (
 
     const semesterOptions = ((semesters ?? []) as unknown as Record<string, unknown>[]).map(row => {
       const id = typeof row.id === 'string' ? row.id : ''
-      return { value: id, label: semesterDisplay(row, id) }
+      return { value: id, label: semesterTitleDisplay(row, id) }
     })
 
     return {
@@ -317,6 +325,10 @@ export function createTableLoader(tableName: string) {
             }
             if (mapping.format === 'semester_range') {
               row[mapping.resultColumn] = semesterDisplay(lookupRow, idValue)
+              continue
+            }
+            if (mapping.format === 'semester_title') {
+              row[mapping.resultColumn] = semesterTitleDisplay(lookupRow, idValue)
               continue
             }
             if (mapping.format === 'class_display') {

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -56,14 +56,14 @@ export default function TeamLayout() {
   }
 
   return (
-    <main className="flex w-full">
+    <main className="flex h-[calc(100svh-4rem)] w-full overflow-hidden">
       <aside
         className={cn(
-          'relative z-50 shrink-0 overflow-visible border-r bg-card transition-[width] duration-200',
+          'relative z-50 shrink-0 overflow-hidden border-r bg-card transition-[width] duration-200',
           sidebarCollapsed ? 'w-16' : 'w-64'
         )}
       >
-        <div className="sticky top-0 z-50 flex h-[calc(100vh-4rem)] flex-col overflow-visible p-2">
+        <div className="flex h-full flex-col overflow-y-auto overflow-x-hidden p-2">
           <div className={cn('flex items-center', sidebarCollapsed ? 'justify-center' : 'justify-between')}>
             {!sidebarCollapsed ? (
               <NavLink
@@ -178,7 +178,7 @@ export default function TeamLayout() {
         </div>
       </aside>
 
-      <section className="min-w-0 flex-1 space-y-6 p-6">
+      <section className="min-w-0 flex-1 space-y-6 overflow-y-auto p-6">
         <Outlet />
       </section>
     </main>

--- a/web/app/routes/semester-surveys.pre-redirect.tsx
+++ b/web/app/routes/semester-surveys.pre-redirect.tsx
@@ -1,0 +1,19 @@
+import type { LoaderFunctionArgs } from 'react-router'
+import { redirect } from 'react-router'
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const semesterId = params.semesterId
+  if (!semesterId) {
+    throw redirect('/enroll')
+  }
+
+  const url = new URL(request.url)
+  const returnTo = url.searchParams.get('returnTo')
+  const query = returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : ''
+
+  throw redirect(`/semester-surveys/${semesterId}/pre-program${query}`)
+}
+
+export default function SemesterSurveyPreRedirectPage() {
+  return null
+}

--- a/web/app/routes/semester-surveys.pre.tsx
+++ b/web/app/routes/semester-surveys.pre.tsx
@@ -88,7 +88,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/home', { headers })
   }
 
-  const preSurveyForm = await resolveSemesterSurveyForm(semesterId, 'pre_survey')
+  const preSurveyForm = await resolveSemesterSurveyForm(semesterId, 'pre_program_survey')
   if (!preSurveyForm.formId) {
     throw redirect('/home', { headers })
   }
@@ -169,11 +169,11 @@ export async function action({ request, params }: Route.ActionArgs) {
     return { error: 'Family enrollment profile is missing' } satisfies ActionData
   }
 
-  const preSurveyForm = await resolveSemesterSurveyForm(semesterId, 'pre_survey')
+  const preSurveyForm = await resolveSemesterSurveyForm(semesterId, 'pre_program_survey')
   const formId = preSurveyForm.formId
 
   if (!formId) {
-    return { error: 'Pre-semester survey is not configured' } satisfies ActionData
+    return { error: 'Pre-program survey is not configured' } satisfies ActionData
   }
 
   const { data: formRow } = await adminClient
@@ -183,7 +183,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     .maybeSingle()
 
   if (!formRow?.id) {
-    return { error: 'Pre-semester survey is not configured' } satisfies ActionData
+    return { error: 'Pre-program survey is not configured' } satisfies ActionData
   }
 
   const { data: questionRows } = await adminClient
@@ -260,7 +260,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       accept_language: requestMetadata.acceptLanguage,
       referer: requestMetadata.referer,
       origin: requestMetadata.origin,
-      metadata: { source: 'semester_pre_survey' },
+      metadata: { source: 'semester_pre_program_survey' },
     })
     .select('id')
     .single()
@@ -299,7 +299,7 @@ export default function SemesterPreSurveyPage() {
         <CardHeader>
           <CardTitle className="text-2xl">{formName}</CardTitle>
           <CardDescription>
-            Complete this family survey before enrolling in classes for this semester.
+            Complete this pre-program survey before enrolling in workshops for this semester.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/web/app/routes/semester-surveys.pre.tsx
+++ b/web/app/routes/semester-surveys.pre.tsx
@@ -66,8 +66,8 @@ const getFamilyEnrollmentProfileId = (family: Awaited<ReturnType<typeof resolveF
 }
 
 const sanitizeReturnTo = (value: string | null, semesterId: string) => {
-  if (!value) return `/enroll?semester=${semesterId}`
-  if (!value.startsWith('/') || value.startsWith('//')) return `/enroll?semester=${semesterId}`
+  if (!value) return `/enroll/${semesterId}`
+  if (!value.startsWith('/') || value.startsWith('//')) return `/enroll/${semesterId}`
   return value
 }
 


### PR DESCRIPTION
## Summary
- ship the accumulated `sai/main` work including auth flow improvements, enrollment UX updates, manage dashboard/table enhancements, and signup-term/survey tooling
- standardize semester survey naming to pre/post program terminology, add enroll subroutes (`/enroll/:semesterId`), and keep compatibility fallbacks for legacy survey-kind values
- include auth visual/background refinements, postcode input normalization, and related schema/migration updates already validated in this branch

## Verification
- npm run typecheck
- supabase migration up
- supabase gen types typescript --local > web/app/lib/database.types.ts