### PR TITLE
Update signup and enrollment flow behavior

### DIFF
--- a/web/app/routes/auth/sign-up-details.tsx
+++ b/web/app/routes/auth/sign-up-details.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/card'
 import FormQuestion, { type FormQuestionData } from '@/components/forms/form-question'
 import type { Database, Json } from '@/lib/database.types'
-import { isAllowedEmailDomain, normalizeEmail } from '@/lib/email-domain'
+import { normalizeEmail } from '@/lib/email-domain'
 import { getProfileSignUpCompletionWithContext } from '@/lib/onboarding.server'
 import { extractRequestMetadata } from '@/lib/request-metadata.server'
 import { getSignUpFlowContext } from '@/lib/sign-up-flow-context.server'
@@ -650,9 +650,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     if (inputType === 'email' && typeof value === 'string') {
       const normalized = normalizeEmail(value)
-      if (!isAllowedEmailDomain(normalized)) {
-        return { error: 'Please enter a valid Gmail address' }
-      }
       value = normalized
       submittedAnswers[question.question_code] = normalized
       combinedAnswers[question.question_code] = normalized

--- a/web/app/routes/sign-up/index.tsx
+++ b/web/app/routes/sign-up/index.tsx
@@ -10,8 +10,6 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
-  ALLOWED_EMAIL_PATTERN,
-  isAllowedEmailDomain,
   normalizeEmail,
 } from '@/lib/email-domain'
 import {
@@ -99,12 +97,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   if (!password) {
     return {
       error: 'Password is required',
-    }
-  }
-
-  if (!isAllowedEmailDomain(email)) {
-    return {
-      error: 'Please enter a valid Gmail address',
     }
   }
 
@@ -197,7 +189,6 @@ export default function SignUp() {
                 name="email"
                 type="email"
                 placeholder="name@gmail.com"
-                pattern={ALLOWED_EMAIL_PATTERN}
                 title="Use a valid Gmail address"
                 value={email}
                 onChange={event => setEmail(event.target.value)}


### PR DESCRIPTION
## Summary
- remove signup email domain restrictions so account creation and sign-up details accept any valid email format while keeping existing UI copy
- update sign-up details form behavior by hiding student phone prompt and switching address province to a 2-character dropdown
- redirect enrollment outcomes to family workshops and align related e2e coverage updates