### PR TITLE
Update federal riding whitelist and meal-kit flags

### DIFF
--- a/supabase/migrations/20260521165807_set_greenlit_and_meal_kit_ridings.sql
+++ b/supabase/migrations/20260521165807_set_greenlit_and_meal_kit_ridings.sql
@@ -1,0 +1,25 @@
+update public.federal_electoral_district
+set whitelist = true
+where name in (
+  'Surrey Centre',
+  'Winnipeg Centre',
+  'Winnipeg North',
+  'Kings—Hants',
+  'Beaches—East York',
+  'Don Valley West',
+  'Scarborough Centre—Don Valley East',
+  'Dufferin—Caledon',
+  'Hamilton Centre',
+  'Burlington North—Milton West',
+  'Ottawa—Vanier—Gloucester',
+  'Taiaiako''n—Parkdale—High Park',
+  'Toronto Centre',
+  'Whitby'
+);
+
+update public.federal_electoral_district
+set meal_kit = true
+where name in (
+  'Don Valley West',
+  'Scarborough Centre—Don Valley East'
+);


### PR DESCRIPTION
## Summary
- add a migration to greenlight the requested federal electoral districts by setting `whitelist = true`
- mark `Don Valley West` and `Scarborough Centre—Don Valley East` as meal-kit ridings
- use current federal riding names from the seeded Elections Canada list