### PR TITLE
Use riding lookup for signup branching and add discrepancy signals

### DIFF
--- a/supabase/migrations/20260521174054_riding_lookup_profile_and_fed_pk_refactor.sql
+++ b/supabase/migrations/20260521174054_riding_lookup_profile_and_fed_pk_refactor.sql
@@ -1,0 +1,49 @@
+alter table public.profile
+  add column if not exists federal_electoral_district_name text,
+  add column if not exists riding_lookup_status text,
+  add column if not exists riding_lookup_last_attempt_at timestamptz,
+  add column if not exists riding_lookup_error text;
+
+alter table public.federal_electoral_district
+  alter column name set not null;
+
+alter table public.federal_electoral_district
+  drop constraint if exists federal_electoral_district_pkey;
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'federal_electoral_district'
+      and column_name = 'id'
+  ) then
+    alter table public.federal_electoral_district drop column id;
+  end if;
+end $$;
+
+alter table public.federal_electoral_district
+  add constraint federal_electoral_district_pkey primary key (name);
+
+alter table public.profile
+  drop constraint if exists profile_federal_electoral_district_name_fkey;
+
+alter table public.profile
+  add constraint profile_federal_electoral_district_name_fkey
+  foreign key (federal_electoral_district_name)
+  references public.federal_electoral_district(name)
+  on delete set null;
+
+create index if not exists profile_federal_electoral_district_name_idx
+  on public.profile (federal_electoral_district_name);
+
+alter table public.profile
+  drop constraint if exists profile_riding_lookup_status_chk;
+
+alter table public.profile
+  add constraint profile_riding_lookup_status_chk
+  check (
+    riding_lookup_status is null
+    or riding_lookup_status in ('matched', 'not_found', 'error', 'skipped')
+  );

--- a/supabase/migrations/20260521174055_signup_flow_riding_based_mealkit_conditions.sql
+++ b/supabase/migrations/20260521174055_signup_flow_riding_based_mealkit_conditions.sql
@@ -1,0 +1,53 @@
+with partner_form as (
+  select id
+  from public.form
+  where name = 'Partner Organization'
+), guardian_form as (
+  select id
+  from public.form
+  where name = 'Guardian Consent'
+)
+delete from public.form_question_map fqm
+using partner_form pf
+where fqm.form_id = pf.id
+  and fqm.question_code in ('partner_organization', 'partner_organization_other');
+
+with guardian_form as (
+  select id
+  from public.form
+  where name = 'Guardian Consent'
+)
+update public.form_question_map fqm
+set visibility_condition = case
+  when fqm.question_code in (
+    'guardian_consent_thorncliffe_meal_kit',
+    'guardian_consent_thorncliffe_pickup_schedule'
+  ) then '{"question_code":"derived_is_meal_kit_riding","equals":true}'::jsonb
+  when fqm.question_code = 'guardian_consent_gift_card' then '{"question_code":"derived_is_meal_kit_riding","not_equals":true}'::jsonb
+  when fqm.question_code = 'gift_card_store_preference' then '{
+    "all": [
+      { "question_code": "derived_is_meal_kit_riding", "not_equals": true },
+      { "question_code": "guardian_consent_gift_card", "equals": true }
+    ]
+  }'::jsonb
+  else fqm.visibility_condition
+end
+from guardian_form gf
+where fqm.form_id = gf.id
+  and fqm.question_code in (
+    'guardian_consent_thorncliffe_meal_kit',
+    'guardian_consent_thorncliffe_pickup_schedule',
+    'guardian_consent_gift_card',
+    'gift_card_store_preference'
+  );
+
+delete from public.sign_up_flow sf
+using public.form f
+where sf.form_id = f.id
+  and f.name = 'Partner Organization';
+
+update public.sign_up_flow sf
+set step_order = 8
+from public.form f
+where sf.form_id = f.id
+  and f.name = 'Guardian Consent';

--- a/supabase/migrations/20260521174056_non_whitelisted_riding_signal_type.sql
+++ b/supabase/migrations/20260521174056_non_whitelisted_riding_signal_type.sql
@@ -1,0 +1,12 @@
+alter table public.suspicious_signal
+  drop constraint if exists suspicious_signal_signal_type_chk;
+
+alter table public.suspicious_signal
+  add constraint suspicious_signal_signal_type_chk
+  check (
+    signal_type in (
+      'address_mismatch',
+      'network_distance_anomaly',
+      'non_whitelisted_riding'
+    )
+  );

--- a/supabase/migrations/20260521174107_class_unique_workshop_start.sql
+++ b/supabase/migrations/20260521174107_class_unique_workshop_start.sql
@@ -1,0 +1,10 @@
+delete from public.class c
+using public.class duplicate
+where c.workshop_id is not null
+  and duplicate.workshop_id is not null
+  and c.workshop_id = duplicate.workshop_id
+  and c.starts_at = duplicate.starts_at
+  and c.id > duplicate.id;
+
+create unique index if not exists class_workshop_start_unique_idx
+  on public.class (workshop_id, starts_at);

--- a/supabase/schemas/01_create_profile.sql
+++ b/supabase/schemas/01_create_profile.sql
@@ -13,11 +13,19 @@ create table public.profile (
   province text,
   postcode text,
   partner_program text,
+  federal_electoral_district_name text references public.federal_electoral_district(name) on delete set null,
+  riding_lookup_status text,
+  riding_lookup_last_attempt_at timestamptz,
+  riding_lookup_error text,
   household_size integer,
   household_children_count integer,
   password_set boolean not null default false,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
+  ,constraint profile_riding_lookup_status_chk check (
+    riding_lookup_status is null
+    or riding_lookup_status in ('matched', 'not_found', 'error', 'skipped')
+  )
 );
 
 alter table public.profile enable row level security;

--- a/supabase/schemas/08_suspicious_signals.sql
+++ b/supabase/schemas/08_suspicious_signals.sql
@@ -12,7 +12,7 @@ create table if not exists public.suspicious_signal (
   resolved_at timestamptz,
   resolved_by uuid references auth.users(id) on delete set null,
   resolution_note text,
-  constraint suspicious_signal_signal_type_chk check (signal_type in ('address_mismatch', 'network_distance_anomaly')),
+  constraint suspicious_signal_signal_type_chk check (signal_type in ('address_mismatch', 'network_distance_anomaly', 'non_whitelisted_riding')),
   constraint suspicious_signal_severity_chk check (severity in ('low', 'medium', 'high')),
   constraint suspicious_signal_status_chk check (status in ('open', 'resolved'))
 );

--- a/supabase/schemas/11_federal_electoral_district.sql
+++ b/supabase/schemas/11_federal_electoral_district.sql
@@ -1,7 +1,6 @@
 create table if not exists public.federal_electoral_district (
-  id uuid primary key default gen_random_uuid(),
+  name text primary key,
   code integer not null unique,
-  name text not null unique,
   whitelist boolean not null default false,
   meal_kit boolean not null default false,
   created_at timestamptz not null default now(),

--- a/supabase/seeds/app-data/sign-up-forms.sql
+++ b/supabase/seeds/app-data/sign-up-forms.sql
@@ -266,10 +266,6 @@ select id, 'household_total_people', 1, '{"target":"profile","role":"guardian","
 union all
 select id, 'household_total_children', 2, '{"target":"profile","role":"guardian","field":"household_children_count","input_type":"number","min":0}'::jsonb, null::jsonb from household_counts_form
 union all
-select id, 'partner_organization', 1, '{"target":"profile","role":"guardian","field":"partner_program","ui":"select"}'::jsonb, null::jsonb from partner_form
-union all
-select id, 'partner_organization_other', 2, '{"target":"profile","role":"guardian","field":"partner_program","placeholder":"Partner organization name"}'::jsonb, '{"question_code":"partner_organization","equals":"Other"}'::jsonb from partner_form
-union all
 select id, 'guardian_consent_privacy', 1, '{}'::jsonb, null::jsonb from guardian_form
 union all
 select id, 'guardian_consent_presence', 2, '{}'::jsonb, null::jsonb from guardian_form
@@ -280,43 +276,15 @@ select id, 'guardian_consent_attendance', 4, '{}'::jsonb, null::jsonb from guard
 union all
 select id, 'guardian_consent_photos', 5, '{}'::jsonb, null::jsonb from guardian_form
 union all
-select id, 'guardian_consent_thorncliffe_meal_kit', 6, '{}'::jsonb, '{"question_code":"partner_organization","equals":"Thorncliffe Park -TNO"}'::jsonb from guardian_form
+select id, 'guardian_consent_thorncliffe_meal_kit', 6, '{}'::jsonb, '{"question_code":"derived_is_meal_kit_riding","equals":true}'::jsonb from guardian_form
 union all
-select id, 'guardian_consent_thorncliffe_pickup_schedule', 7, '{}'::jsonb, '{"question_code":"partner_organization","equals":"Thorncliffe Park -TNO"}'::jsonb from guardian_form
+select id, 'guardian_consent_thorncliffe_pickup_schedule', 7, '{}'::jsonb, '{"question_code":"derived_is_meal_kit_riding","equals":true}'::jsonb from guardian_form
 union all
-select id, 'guardian_consent_gift_card', 8, '{}'::jsonb, '{
-  "any": [
-    { "question_code": "partner_organization", "equals": "Taylor-Massey & Oakridge" },
-    { "question_code": "partner_organization", "equals": "Milton Food for Life" },
-    { "question_code": "partner_organization", "equals": "Gloucester -GEFC" },
-    { "question_code": "partner_organization", "equals": "Orangeville Food Bank" },
-    { "question_code": "partner_organization", "equals": "Cresent Town Community" },
-    { "question_code": "partner_organization", "equals": "Eastview Community Centre" },
-    { "question_code": "partner_organization", "equals": "Greenest City" },
-    { "question_code": "partner_organization", "equals": "Partage Vanier" },
-    { "question_code": "partner_organization", "equals": "Parkdale Community Food Bank" },
-    { "question_code": "partner_organization", "equals": "Hamilton - Eva Rothwell Centre" },
-    { "question_code": "partner_organization", "equals": "Corktown Community" }
-  ]
-}'::jsonb from guardian_form
+select id, 'guardian_consent_gift_card', 8, '{}'::jsonb, '{"question_code":"derived_is_meal_kit_riding","not_equals":true}'::jsonb from guardian_form
 union all
 select id, 'gift_card_store_preference', 9, '{}'::jsonb, '{
   "all": [
-    {
-      "any": [
-        { "question_code": "partner_organization", "equals": "Taylor-Massey & Oakridge" },
-        { "question_code": "partner_organization", "equals": "Milton Food for Life" },
-        { "question_code": "partner_organization", "equals": "Gloucester -GEFC" },
-        { "question_code": "partner_organization", "equals": "Orangeville Food Bank" },
-        { "question_code": "partner_organization", "equals": "Cresent Town Community" },
-        { "question_code": "partner_organization", "equals": "Eastview Community Centre" },
-        { "question_code": "partner_organization", "equals": "Greenest City" },
-        { "question_code": "partner_organization", "equals": "Partage Vanier" },
-        { "question_code": "partner_organization", "equals": "Parkdale Community Food Bank" },
-        { "question_code": "partner_organization", "equals": "Hamilton - Eva Rothwell Centre" },
-        { "question_code": "partner_organization", "equals": "Corktown Community" }
-      ]
-    },
+    { "question_code": "derived_is_meal_kit_riding", "not_equals": true },
     { "question_code": "guardian_consent_gift_card", "equals": true }
   ]
 }'::jsonb from guardian_form
@@ -354,10 +322,6 @@ select id, 'household_counts', 7, array['guardian','student']::app_role[]
 from public.form
 where name = 'Household Counts'
 union all
-select id, 'partner_organization', 8, array['guardian']::app_role[]
-from public.form
-where name = 'Partner Organization'
-union all
 select id, 'guardian_consent', 9, array['guardian']::app_role[]
 from public.form
 where name = 'Guardian Consent'
@@ -366,7 +330,18 @@ on conflict (form_id) do update
       step_order = excluded.step_order,
       roles = excluded.roles;
 
+update public.sign_up_flow sf
+set step_order = 8
+from public.form f
+where sf.form_id = f.id
+  and f.name = 'Guardian Consent';
+
 delete from public.sign_up_flow sf
 using public.form f
 where sf.form_id = f.id
   and f.name = 'Additional Guardians';
+
+delete from public.sign_up_flow sf
+using public.form f
+where sf.form_id = f.id
+  and f.name = 'Partner Organization';

--- a/web/app/lib/riding-lookup.server.ts
+++ b/web/app/lib/riding-lookup.server.ts
@@ -1,0 +1,85 @@
+export type RidingLookupResult =
+  | {
+      status: 'matched'
+      districtName: string
+      districtCode: string | null
+      source: 'opennorth'
+    }
+  | {
+      status: 'not_found'
+      source: 'opennorth'
+    }
+  | {
+      status: 'error'
+      source: 'opennorth'
+      reason: 'rate_limited' | 'timeout' | 'upstream' | 'invalid_response' | 'network'
+      statusCode?: number
+    }
+
+export interface RidingLookupProvider {
+  lookupByPostcode(postcode: string): Promise<RidingLookupResult>
+}
+
+const LOOKUP_TIMEOUT_MS = 3000
+
+const normalizePostcode = (value: string) => value.replace(/\s+/g, '').toUpperCase()
+
+const buildOpenNorthUrl = (postcode: string) =>
+  `https://represent.opennorth.ca/postcodes/${postcode}/?sets=federal-electoral-districts-2023-representation-order`
+
+const opennorthProvider: RidingLookupProvider = {
+  async lookupByPostcode(postcode: string): Promise<RidingLookupResult> {
+    const normalized = normalizePostcode(postcode)
+    if (!normalized) {
+      return { status: 'not_found', source: 'opennorth' }
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), LOOKUP_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(buildOpenNorthUrl(normalized), {
+        method: 'GET',
+        signal: controller.signal,
+      })
+
+      if (response.status === 404) {
+        return { status: 'not_found', source: 'opennorth' }
+      }
+      if (response.status === 429) {
+        return { status: 'error', source: 'opennorth', reason: 'rate_limited', statusCode: response.status }
+      }
+      if (!response.ok) {
+        return { status: 'error', source: 'opennorth', reason: 'upstream', statusCode: response.status }
+      }
+
+      const payload = (await response.json()) as {
+        boundaries_centroid?: Array<{ name?: unknown; external_id?: unknown }>
+      }
+      const district = Array.isArray(payload.boundaries_centroid) ? payload.boundaries_centroid[0] : null
+
+      const districtName = typeof district?.name === 'string' ? district.name.trim() : ''
+      const districtCode = typeof district?.external_id === 'string' ? district.external_id.trim() : null
+
+      if (!districtName) {
+        return { status: 'error', source: 'opennorth', reason: 'invalid_response' }
+      }
+
+      return {
+        status: 'matched',
+        districtName,
+        districtCode,
+        source: 'opennorth',
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return { status: 'error', source: 'opennorth', reason: 'timeout' }
+      }
+      return { status: 'error', source: 'opennorth', reason: 'network' }
+    } finally {
+      clearTimeout(timeout)
+    }
+  },
+}
+
+export const ridingLookupProvider: RidingLookupProvider = opennorthProvider

--- a/web/app/lib/suspicious-signals.server.ts
+++ b/web/app/lib/suspicious-signals.server.ts
@@ -8,6 +8,11 @@ type FamilyEdge = {
   child_profile_id: string
 }
 
+type RidingRow = {
+  name: string
+  whitelist: boolean
+}
+
 const familyGraphForProfile = async (profileId: string) => {
   const seen = new Set<string>([profileId])
   const queue: string[] = [profileId]
@@ -39,9 +44,8 @@ export const refreshSuspiciousSignalsForProfile = async (profileId: string) => {
   if (!familyProfileIds.length) return
 
   const [{ data: profiles }, { data: submissions }] = await Promise.all([
-    adminClient
-      .from('profile')
-      .select('id, role, firstname, surname, email, street_address, city, province, postcode')
+    (adminClient.from('profile') as any)
+      .select('id, role, firstname, surname, email, street_address, city, province, postcode, federal_electoral_district_name')
       .in('id', familyProfileIds),
     adminClient
       .from('form_submission')
@@ -51,10 +55,25 @@ export const refreshSuspiciousSignalsForProfile = async (profileId: string) => {
       .limit(40),
   ])
 
-  const addressSignal = detectAddressMismatchSignal((profiles ?? []).map(profile => ({
-    ...profile,
-    role: profile.role ?? null,
-  })))
+  const normalizedProfiles = ((profiles ?? []) as Array<Record<string, unknown>>)
+    .map(profile => ({
+      id: typeof profile.id === 'string' ? profile.id : '',
+      role: typeof profile.role === 'string' ? profile.role : null,
+      firstname: typeof profile.firstname === 'string' ? profile.firstname : null,
+      surname: typeof profile.surname === 'string' ? profile.surname : null,
+      email: typeof profile.email === 'string' ? profile.email : null,
+      street_address: typeof profile.street_address === 'string' ? profile.street_address : null,
+      city: typeof profile.city === 'string' ? profile.city : null,
+      province: typeof profile.province === 'string' ? profile.province : null,
+      postcode: typeof profile.postcode === 'string' ? profile.postcode : null,
+      federal_electoral_district_name:
+        typeof profile.federal_electoral_district_name === 'string'
+          ? profile.federal_electoral_district_name
+          : null,
+    }))
+    .filter(profile => Boolean(profile.id))
+
+  const addressSignal = detectAddressMismatchSignal(normalizedProfiles)
 
   const networkSignal = detectNetworkDistanceSignal(
     (submissions ?? []).map(submission => ({
@@ -66,8 +85,37 @@ export const refreshSuspiciousSignalsForProfile = async (profileId: string) => {
     }))
   )
 
+  const districtNames = new Set(
+    normalizedProfiles
+      .map(profile =>
+        typeof profile.federal_electoral_district_name === 'string'
+          ? profile.federal_electoral_district_name.trim()
+          : ''
+      )
+      .filter(Boolean)
+  )
+
+  const districtByName = new Map<string, RidingRow>()
+  if (districtNames.size > 0) {
+    const { data: districts } = await adminClient
+      .from('federal_electoral_district' as any)
+      .select('name, whitelist')
+      .in('name', Array.from(districtNames))
+
+    for (const district of (districts ?? []) as RidingRow[]) {
+      districtByName.set(district.name, district)
+    }
+  }
+
+  const subjectProfile = normalizedProfiles.find(profile => profile.id === profileId)
+  const subjectDistrictName =
+    typeof subjectProfile?.federal_electoral_district_name === 'string'
+      ? subjectProfile.federal_electoral_district_name.trim()
+      : ''
+  const subjectDistrict = subjectDistrictName ? districtByName.get(subjectDistrictName) : null
+
   const signals: Array<{
-    signal_type: 'address_mismatch' | 'network_distance_anomaly'
+    signal_type: 'address_mismatch' | 'network_distance_anomaly' | 'non_whitelisted_riding'
     severity: string
     summary: string
     title: string
@@ -94,12 +142,25 @@ export const refreshSuspiciousSignalsForProfile = async (profileId: string) => {
     })
   }
 
+  if (subjectDistrictName && subjectDistrict && subjectDistrict.whitelist === false) {
+    signals.push({
+      signal_type: 'non_whitelisted_riding',
+      severity: 'medium',
+      summary: 'Profile riding is not currently whitelisted.',
+      title: 'Non-whitelisted riding',
+      details: {
+        district_name: subjectDistrictName,
+        whitelist: subjectDistrict.whitelist,
+      },
+    })
+  }
+
   await adminClient
     .from('suspicious_signal')
     .delete()
     .eq('status', 'open')
     .eq('subject_profile_id', profileId)
-    .in('signal_type', ['address_mismatch', 'network_distance_anomaly'])
+    .in('signal_type', ['address_mismatch', 'network_distance_anomaly', 'non_whitelisted_riding'])
 
   if (!signals.length) return
 

--- a/web/app/routes/auth/sign-up-details.tsx
+++ b/web/app/routes/auth/sign-up-details.tsx
@@ -14,6 +14,7 @@ import type { Database, Json } from '@/lib/database.types'
 import { normalizeEmail } from '@/lib/email-domain'
 import { getProfileSignUpCompletionWithContext } from '@/lib/onboarding.server'
 import { extractRequestMetadata } from '@/lib/request-metadata.server'
+import { ridingLookupProvider } from '@/lib/riding-lookup.server'
 import { getSignUpFlowContext } from '@/lib/sign-up-flow-context.server'
 import { refreshSuspiciousSignalsForProfile } from '@/lib/suspicious-signals.server'
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router'
@@ -77,6 +78,28 @@ const PROVINCE_CODES = [
 
 const isQuestionHiddenForRole = (role: 'guardian' | 'student', questionCode: string) => {
   return role === 'student' && questionCode === 'guardian_self_phone'
+}
+
+const MEAL_KIT_DERIVED_KEY = 'derived_is_meal_kit_riding'
+const RIDING_LOOKUP_FALLBACK_BRANCH = process.env.RIDING_LOOKUP_FALLBACK_BRANCH === 'meal_kit' ? 'meal_kit' : 'regular'
+
+const resolveMealKitEligibility = (mealKitFlag: boolean | null) => {
+  if (mealKitFlag === true) return true
+  if (mealKitFlag === false) return false
+  return RIDING_LOOKUP_FALLBACK_BRANCH === 'meal_kit'
+}
+
+const normalizePostcode = (value: string) => value.replace(/\s+/g, '').toUpperCase()
+
+const districtMealKitFlag = async (
+  districtName: string | null | undefined
+) => {
+  if (!districtName) return null
+  const { data } = await (adminClient.from('federal_electoral_district') as any)
+    .select('meal_kit')
+    .eq('name', districtName)
+    .maybeSingle()
+  return typeof data?.meal_kit === 'boolean' ? data.meal_kit : null
 }
 
 const isConditionMet = (condition: Json | null | undefined, answers: Record<string, Json>): boolean => {
@@ -214,10 +237,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }
   if (!pid) throw redirect('/sign-up', { headers })
 
-  const { data: profile } = await supabase
-    .from('profile')
+  const { data: profile } = await (supabase.from('profile') as any)
     .select(
-      'role, email, firstname, surname, phone, street_address, city, province, postcode, household_size, household_children_count, partner_program, date_of_birth'
+      'role, email, firstname, surname, phone, street_address, city, province, postcode, household_size, household_children_count, partner_program, federal_electoral_district_name, date_of_birth'
     )
     .eq('id', pid)
     .single()
@@ -236,6 +258,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     .eq('profile_id', pid)
     .order('submitted_at', { ascending: true })
   const submissionData = buildAnswerMapFromSubmissions(submissions ?? [])
+  const mealKitFlag = await districtMealKitFlag(
+    typeof profile.federal_electoral_district_name === 'string' ? profile.federal_electoral_district_name : null
+  )
+  submissionData.answers[MEAL_KIT_DERIVED_KEY] = resolveMealKitEligibility(mealKitFlag)
 
   const { data: flowEntries } = await supabase
     .from('sign_up_flow')
@@ -554,9 +580,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       ? (formData.get('additional_guardian_choice') as string | null) === 'yes'
       : true
 
-  const { data: profile } = await supabase
-    .from('profile')
-    .select('email')
+  const { data: profile } = await (supabase.from('profile') as any)
+    .select('email, federal_electoral_district_name')
     .eq('id', pid)
     .single()
 
@@ -618,6 +643,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   const combinedAnswers = mergeAnswerMaps(submissionData.answers, submittedAnswers)
+  const currentMealKitFlag = await districtMealKitFlag(
+    typeof profile?.federal_electoral_district_name === 'string' ? profile.federal_electoral_district_name : null
+  )
+  combinedAnswers[MEAL_KIT_DERIVED_KEY] = resolveMealKitEligibility(currentMealKitFlag)
   const answersToSave: { questionCode: string; value: Json }[] = []
   const hiddenQuestionCodes: string[] = []
   const additionalGuardianQuestionCodes: string[] = []
@@ -801,6 +830,40 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       if (typeof value === 'string' && value.trim()) {
         guardianInviteEmail = value.trim()
       }
+    }
+  }
+
+  const guardianPostcodeRaw = profileUpdates.guardian.postcode
+  const guardianPostcode = typeof guardianPostcodeRaw === 'string' ? normalizePostcode(guardianPostcodeRaw) : ''
+  if (guardianPostcode) {
+    const lookup = await ridingLookupProvider.lookupByPostcode(guardianPostcode)
+    profileUpdates.guardian.riding_lookup_last_attempt_at = new Date().toISOString()
+
+    if (lookup.status === 'matched') {
+      const { data: districtRow } = await (adminClient.from('federal_electoral_district') as any)
+        .select('name, meal_kit')
+        .eq('name', lookup.districtName)
+        .maybeSingle()
+
+      if (districtRow?.name) {
+        profileUpdates.guardian.federal_electoral_district_name = districtRow.name
+        profileUpdates.guardian.riding_lookup_status = 'matched'
+        profileUpdates.guardian.riding_lookup_error = null
+        combinedAnswers[MEAL_KIT_DERIVED_KEY] = resolveMealKitEligibility(
+          typeof districtRow.meal_kit === 'boolean' ? districtRow.meal_kit : null
+        )
+      } else {
+        profileUpdates.guardian.federal_electoral_district_name = null
+        profileUpdates.guardian.riding_lookup_status = 'not_found'
+        profileUpdates.guardian.riding_lookup_error = 'district_not_seeded'
+      }
+    } else if (lookup.status === 'not_found') {
+      profileUpdates.guardian.federal_electoral_district_name = null
+      profileUpdates.guardian.riding_lookup_status = 'not_found'
+      profileUpdates.guardian.riding_lookup_error = null
+    } else {
+      profileUpdates.guardian.riding_lookup_status = 'error'
+      profileUpdates.guardian.riding_lookup_error = lookup.reason
     }
   }
 
@@ -1300,7 +1363,12 @@ export default function SignUpDetails() {
                   </p>
                 ) : null}
                 {error && <p className="text-sm text-red-500">{error}</p>}
-                <Button type="submit" className="w-full" disabled={disableContinue}>
+                <Button
+                  type="submit"
+                  className={`w-full ${loading ? 'translate-y-px brightness-95' : ''}`}
+                  disabled={disableContinue}
+                  aria-busy={loading}
+                >
                   {loading ? 'Saving...' : 'Save and continue'}
                 </Button>
               </fetcher.Form>

--- a/web/app/routes/manage/person.discrepancies.tsx
+++ b/web/app/routes/manage/person.discrepancies.tsx
@@ -86,6 +86,22 @@ export default function ManagePersonDiscrepanciesPage() {
                       </ul>
                     </div>
                   ) : null}
+
+                  {signal.signal_type === 'non_whitelisted_riding' ? (
+                    <div className="mt-2 rounded border bg-background p-2 text-xs">
+                      <p className="font-medium">Riding evidence</p>
+                      <ul className="mt-1 space-y-1">
+                        <li>
+                          • Riding:{' '}
+                          {typeof details?.district_name === 'string' ? details.district_name : 'Unknown'}
+                        </li>
+                        <li>
+                          • Whitelisted:{' '}
+                          {typeof details?.whitelist === 'boolean' ? String(details.whitelist) : 'Unknown'}
+                        </li>
+                      </ul>
+                    </div>
+                  ) : null}
                 </article>
               )
             })}

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -614,11 +614,11 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
   'federal-electoral-district': {
     label: 'Federal Electoral Districts',
     table: 'federal_electoral_district',
-    select: 'id, code, name, whitelist, meal_kit, updated_at',
+    select: 'code, name, whitelist, meal_kit, updated_at',
     columns: ['code', 'name', 'whitelist', 'meal_kit', 'updated_at'],
     order: 'code',
     editor: {
-      primaryKey: ['id'],
+      primaryKey: ['name'],
       allowInsert: true,
       allowUpdate: true,
       fields: {

--- a/web/app/routes/manage/workshop.setup.tsx
+++ b/web/app/routes/manage/workshop.setup.tsx
@@ -225,7 +225,7 @@ export async function action({ request }: ActionFunctionArgs) {
     ends_at: new Date(startAt.getTime() + durationMs).toISOString(),
   }))
 
-  const { error: classError } = await supabase.from('class').insert(classRows)
+  const { error: classError } = await supabase.from('class').upsert(classRows, { onConflict: 'workshop_id,starts_at' })
   if (classError) {
     return { error: `Workshop created, but class generation failed: ${classError.message}`, values, byday } satisfies ActionData
   }
@@ -520,7 +520,10 @@ export default function WorkshopSetupPage() {
           <button
             type="submit"
             disabled={isSubmitting}
-            className="inline-flex h-11 items-center rounded-md bg-[var(--brand-pink)] px-5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+            aria-busy={isSubmitting}
+            className={`inline-flex h-11 items-center rounded-md bg-[var(--brand-pink)] px-5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 ${
+              isSubmitting ? 'translate-y-px brightness-95' : ''
+            }`}
           >
             {isSubmitting ? 'Creating workshop...' : 'Create workshop and classes'}
           </button>

--- a/web/app/routes/sign-up/index.tsx
+++ b/web/app/routes/sign-up/index.tsx
@@ -258,7 +258,12 @@ export default function SignUp() {
               </label>
             </div>
             {error && <p className="text-sm text-red-500">{error}</p>}
-            <Button type="submit" className="w-full" disabled={loading}>
+            <Button
+              type="submit"
+              className={`w-full ${loading ? 'translate-y-px brightness-95' : ''}`}
+              disabled={loading}
+              aria-busy={loading}
+            >
               {loading ? 'Creating an account...' : 'Next'}
             </Button>
             <div className="mt-4 text-center text-sm">

--- a/web/tests/e2e/guardian-signup-enroll.spec.ts
+++ b/web/tests/e2e/guardian-signup-enroll.spec.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@playwright/test'
 
-const PARTNER_PROGRAM = 'Taylor-Massey & Oakridge'
-
 const uniqueSuffix = () => {
   const now = new Date()
   return `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}${String(now.getMilliseconds()).padStart(3, '0')}`
@@ -200,10 +198,6 @@ test('guardian signs up, completes pre-program survey, and enrolls', async ({ pa
 
     if ((await page.locator('input[name="additional_guardian_choice"][value="no"]').count()) > 0) {
       await page.locator('input[name="additional_guardian_choice"][value="no"]').check()
-    }
-
-    if ((await page.locator('select[name="question_partner_organization"]').count()) > 0) {
-      await page.locator('select[name="question_partner_organization"]').selectOption({ label: PARTNER_PROGRAM })
     }
 
     if ((await page.getByText(/grocery gift card/i).count()) > 0) {


### PR DESCRIPTION
## Summary
- add resilient postcode riding lookup integration during signup and store district lookup metadata on profiles
- switch guardian consent branching from partner-organization inputs to riding-based meal-kit eligibility with a configurable fallback branch
- add non-whitelisted riding discrepancy signals, make federal electoral district use name-based keying, and harden submit UX/DB safeguards to reduce duplicate workshop submissions