### PR TITLE
refresh enrollment and invite email copy

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -223,7 +223,7 @@ admin_email = "hub@summerlunchplus.com"
 sender_name = "Summerlunch+ Hub"
 
 [auth.email.template.invite]
-subject = "You have been invited"
+subject = "You've been invited to join summerlunch+"
 content_path = "./templates/invite.html"
 
 [auth.email.template.confirmation]

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -12,10 +12,17 @@
             </tr>
             <tr>
               <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
-                <p style="margin:0 0 16px 0;">You have been invited to join SummerLunch Plus.</p>
-                <p style="margin:0 0 24px 0;">Click below to accept your invitation.</p>
+                <p style="margin:0 0 16px 0;">Hi,</p>
+                <p style="margin:0 0 16px 0;">A member of your family has invited you to join <span style="color:#eb1970;">summerlunch+</span>, a virtual cooking skills and food literacy program designed to help families cook, learn, and connect together.</p>
+                <p style="margin:0 0 8px 0;">By creating your account, you'll be able to:</p>
+                <p style="margin:0 0 4px 0;">- Access weekly recipes, grocery lists, and program content</p>
+                <p style="margin:0 0 4px 0;">- Receive Zoom links and class reminders</p>
+                <p style="margin:0 0 4px 0;">- Stay up to date on program announcements</p>
+                <p style="margin:0 0 16px 0;">- Participate fully in classes and family activities</p>
+                <p style="margin:0 0 16px 0;">We're excited to welcome you to the <span style="color:#eb1970;">summerlunch+</span> community and look forward to cooking with your family this summer!</p>
+                <p style="margin:0 0 24px 0;color:#eb1970;"><strong>- The <span style="color:#eb1970;">summerlunch+</span> Team</strong></p>
                 <p style="margin:0;">
-                  <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 18px;background-color:#eb1970;color:#ffffff;text-decoration:none;border-radius:8px;">Accept Invitation</a>
+                  <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 18px;background-color:#eb1970;color:#ffffff;text-decoration:none;border-radius:8px;">Create Your Account</a>
                 </p>
               </td>
             </tr>

--- a/templates/invite.html
+++ b/templates/invite.html
@@ -12,10 +12,17 @@
             </tr>
             <tr>
               <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
-                <p style="margin:0 0 16px 0;">You have been invited to join SummerLunch Plus.</p>
-                <p style="margin:0 0 24px 0;">Click below to accept your invitation.</p>
+                <p style="margin:0 0 16px 0;">Hi,</p>
+                <p style="margin:0 0 16px 0;">A member of your family has invited you to join <span style="color:#eb1970;">summerlunch+</span>, a virtual cooking skills and food literacy program designed to help families cook, learn, and connect together.</p>
+                <p style="margin:0 0 8px 0;">By creating your account, you'll be able to:</p>
+                <p style="margin:0 0 4px 0;">- Access weekly recipes, grocery lists, and program content</p>
+                <p style="margin:0 0 4px 0;">- Receive Zoom links and class reminders</p>
+                <p style="margin:0 0 4px 0;">- Stay up to date on program announcements</p>
+                <p style="margin:0 0 16px 0;">- Participate fully in classes and family activities</p>
+                <p style="margin:0 0 16px 0;">We're excited to welcome you to the <span style="color:#eb1970;">summerlunch+</span> community and look forward to cooking with your family this summer!</p>
+                <p style="margin:0 0 24px 0;color:#eb1970;"><strong>- The <span style="color:#eb1970;">summerlunch+</span> Team</strong></p>
                 <p style="margin:0;">
-                  <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 18px;background-color:#eb1970;color:#ffffff;text-decoration:none;border-radius:8px;">Accept Invitation</a>
+                  <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 18px;background-color:#eb1970;color:#ffffff;text-decoration:none;border-radius:8px;">Create Your Account</a>
                 </p>
               </td>
             </tr>

--- a/web/app/lib/email/templates/family-enrollment-requested.ts
+++ b/web/app/lib/email/templates/family-enrollment-requested.ts
@@ -22,18 +22,22 @@ export const renderFamilyEnrollmentRequestedEmail = ({
   const safeWorkshopName = escapeHtml(workshopName)
 
   return {
-    subject: 'Your summerlunch+ registration is pending approval',
+    subject: "We've received your summerlunch+ registration!",
     text: `Hi,
 
 Thank you for registering for summerlunch+! We're excited to welcome your family this summer.
 
 Your registration has been received and is currently pending approval. Our team will review your information and send you a confirmation email shortly with your program details, class schedule, and next steps.
 
+While you wait, we encourage you to invite additional family members to join your profile.
+
+As a reminder, to help maintain a safe and engaging class environment, all participants must be supervised by a parent or guardian during classes and are expected to keep their cameras on throughout the session.
+
 Registration details:
 - Registered by: ${actorName} (${actorEmail})
 - Workshop: ${workshopName}
 
-If you have any questions in the meantime, feel free to email us at hello@summerplus.com.
+If you have any questions in the meantime, feel free to email us at hello@summerlunchplus.com.
 
 We're looking forward to cooking with you soon!
 
@@ -53,14 +57,16 @@ We're looking forward to cooking with you soon!
             <tr>
               <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;font-size:16px;line-height:24px;">
                 <p style="margin:0 0 16px 0;">Hi,</p>
-                <p style="margin:0 0 16px 0;">Thank you for registering for summerlunch+! We're excited to welcome your family this summer.</p>
+                <p style="margin:0 0 16px 0;">Thank you for registering for <span style="color:#eb1970;">summerlunch+</span>! We're excited to welcome your family this summer.</p>
                 <p style="margin:0 0 16px 0;">Your registration has been received and is currently pending approval. Our team will review your information and send you a confirmation email shortly with your program details, class schedule, and next steps.</p>
+                <p style="margin:0 0 16px 0;">While you wait, we encourage you to invite additional family members to join your profile.</p>
+                <p style="margin:0 0 16px 0;">As a reminder, to help maintain a safe and engaging class environment, all participants must be supervised by a parent or guardian during classes and are expected to keep their cameras on throughout the session.</p>
                 <p style="margin:0 0 8px 0;"><strong>Registration details:</strong></p>
                 <p style="margin:0 0 4px 0;">Registered by: ${safeActorName} (${safeActorEmail})</p>
                 <p style="margin:0 0 16px 0;">Workshop: ${safeWorkshopName}</p>
-                <p style="margin:0 0 16px 0;">If you have any questions in the meantime, feel free to email us at <a href="mailto:hello@summerplus.com" style="color:#eb1970;text-decoration:underline;">hello@summerplus.com</a>.</p>
+                <p style="margin:0 0 16px 0;">If you have any questions in the meantime, feel free to email us at <a href="mailto:hello@summerlunchplus.com" style="color:#eb1970;text-decoration:underline;">hello@summerlunchplus.com</a>.</p>
                 <p style="margin:0 0 16px 0;">We're looking forward to cooking with you soon!</p>
-                <p style="margin:0;color:#eb1970;"><strong>- The summerlunch+ Team</strong></p>
+                <p style="margin:0;color:#eb1970;"><strong>- The <span style="color:#eb1970;">summerlunch+</span> Team</strong></p>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
## What changed
- Updated family enrollment notification copy and subject to the latest approved messaging
- Styled `summerlunch+` in pink inline within email HTML content
- Updated family invite email copy and CTA text in both `templates/invite.html` and `supabase/templates/invite.html`
- Updated Supabase invite subject in `supabase/config.toml`

## Notes
- Kept all email styles inline
- Preserved logo usage via CDN URL
