### PR TITLE
add resend action for email message logs

### DIFF
--- a/web/app/lib/email/send-email.server.ts
+++ b/web/app/lib/email/send-email.server.ts
@@ -181,3 +181,51 @@ export const sendTemplateEmail = async <K extends EmailTemplateKey>({
     workshopEnrollmentId,
   })
 }
+
+export const resendEmailMessageById = async ({
+  emailMessageId,
+  triggeredByUserId,
+}: {
+  emailMessageId: string
+  triggeredByUserId: string
+}) => {
+  const { data: message, error } = await adminClient
+    .from('email_message')
+    .select(
+      'id, to_email, template_key, template_data, recipient_user_id, profile_id, family_profile_id, workshop_enrollment_id'
+    )
+    .eq('id', emailMessageId)
+    .single()
+
+  if (error || !message) {
+    return { ok: false, error: error?.message ?? 'Email message not found' }
+  }
+
+  const templateEntry = (emailTemplates as Record<string, { render: (data: unknown) => { subject: string; html: string; text: string } }>)[message.template_key]
+
+  if (!templateEntry) {
+    return { ok: false, error: `Unknown template key: ${message.template_key}` }
+  }
+
+  const rendered = templateEntry.render(message.template_data)
+  const resendResult = await sendTransactionalEmail({
+    toEmail: message.to_email,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+    templateKey: message.template_key,
+    templateData: message.template_data,
+    eventKey: null,
+    triggeredByUserId,
+    recipientUserId: message.recipient_user_id,
+    profileId: message.profile_id,
+    familyProfileId: message.family_profile_id,
+    workshopEnrollmentId: message.workshop_enrollment_id,
+  })
+
+  if (resendResult.status === 'failed') {
+    return { ok: false, error: resendResult.error ?? 'Resend failed' }
+  }
+
+  return { ok: true }
+}

--- a/web/app/routes/manage/email-message.tsx
+++ b/web/app/routes/manage/email-message.tsx
@@ -1,7 +1,55 @@
+import { requireAuth } from '@/lib/auth.server'
+import { resendEmailMessageById } from '@/lib/email/send-email.server'
+import { isRoleAtLeast } from '@/lib/roles'
+
+import type { Route } from './+types/email-message'
 import TableDisplay from './table-display'
 import { createTableLoader } from './table-loader'
 
-export const loader = createTableLoader('email-message')
+const baseLoader = createTableLoader('email-message')
+
+export async function loader(args: Route.LoaderArgs) {
+  const base = await baseLoader(args)
+  return {
+    ...base,
+    columnMeta: {
+      ...(base.columnMeta ?? {}),
+      resend: {
+        label: 'resend',
+        filterable: false,
+      },
+    },
+  }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'staff')) {
+    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const formData = await request.formData()
+  const intent = formData.get('intent') as string | null
+  if (intent !== 'resend-email') {
+    return new Response('Unsupported action', { status: 400, headers: auth.headers })
+  }
+
+  const emailMessageId = formData.get('email_message_id') as string | null
+  if (!emailMessageId) {
+    return new Response('Missing email message id', { status: 400, headers: auth.headers })
+  }
+
+  const result = await resendEmailMessageById({
+    emailMessageId,
+    triggeredByUserId: auth.user.id,
+  })
+
+  if (!result.ok) {
+    return new Response(result.error ?? 'Unable to resend email', { status: 500, headers: auth.headers })
+  }
+
+  return { ok: true }
+}
 
 export default function EmailMessageTablePage() {
   return <TableDisplay />

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -562,6 +562,7 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
       'sent_at',
       'failed_at',
       'template_data',
+      'resend',
     ],
     order: 'created_at',
     lookupMappings: [

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -695,6 +695,29 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                         )
                       }
 
+                      if (tableName === 'email-message' && column === 'resend') {
+                        const emailMessageId = typeof row.id === 'string' ? row.id : ''
+                        return (
+                          <td key={`cell-${rowIndex}-${column}`} className="px-4 py-2">
+                            <button
+                              type="button"
+                              disabled={!emailMessageId || statusFetcher.state === 'submitting'}
+                              onClick={event => {
+                                event.stopPropagation()
+                                if (!emailMessageId) return
+                                const formData = new FormData()
+                                formData.set('intent', 'resend-email')
+                                formData.set('email_message_id', emailMessageId)
+                                statusFetcher.submit(formData, { method: 'post' })
+                              }}
+                              className="rounded border border-input px-2 py-1 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Resend
+                            </button>
+                          </td>
+                        )
+                      }
+
                       const isFormNameLink = tableName === 'form' && column === 'name' && typeof row.id === 'string'
                       const isFormAnswersLink = tableName === 'form' && column === 'answers' && typeof row.id === 'string'
                       const personLink = personLinkForCell(tableName, column, row)


### PR DESCRIPTION
## What changed
- Added a Resend button column to `/manage/email-message`
- Added route `action` handling for `intent=resend-email`
- Added server helper `resendEmailMessageById` to re-render and resend from stored `template_key` + `template_data`
- Resend creates a new `email_message` row by sending with `eventKey: null`

## Notes
- Staff-only access is enforced in the route action
- Unknown template keys return a safe error response
