### PR TITLE
Add giftcard fallback and profile hover cards for enrollments

### DIFF
--- a/docs/incident-template.md
+++ b/docs/incident-template.md
@@ -1,0 +1,100 @@
+# Performance Incident Template
+
+Use this template whenever a user reports slowness, timeouts, or failed submissions.
+
+## 1) Intake
+- Reporter:
+- User/account identifier:
+- Environment: `production` / `staging`
+- Timestamp (with timezone):
+- Route/page where issue occurred:
+- Action taken (button clicked / form submitted):
+- Error message shown to user:
+- Related identifiers (if available): `request_id`, `profile_id`, `workshop_id`, `semester_id`, `form_id`
+
+## 2) Quick Triage
+- Is this reproducible right now? `yes/no`
+- Is impact broad or isolated? `single user / cohort / global`
+- Severity: `low / medium / high / critical`
+
+## 3) Router Instrumentation Review
+Search logs for `[router-instrumentation]` in the incident time window.
+
+Capture:
+- `navigation_start` and `navigation_end`
+- `fetcher_start` and `fetcher_end`
+- `root_loader`
+
+Record:
+- Longest `fetcher_end` duration (ms):
+- Longest `navigation_end` duration (ms):
+- Longest `root_loader` duration (ms):
+
+Initial classification:
+- `POST/action slow`
+- `redirect/loader slow`
+- `both`
+- `likely client/network`
+
+## 4) Database Checks (same time window)
+Run and attach outputs for:
+- `pg_stat_statements` hot queries
+- `pg_stat_activity` active/waiting sessions
+- lock blocker query
+
+Record:
+- Slowest query fingerprint:
+- Mean/max execution times:
+- Any lock waits/blockers: `yes/no`
+- Any statement timeouts: `yes/no`
+
+DB classification:
+- `query cost/plan`
+- `lock/concurrency`
+- `unclear`
+
+## 5) Duplicate Submission Check
+- Was more than one mutation request sent from one user click? `yes/no`
+- Did submit lock hold for full transition (`submitting + loading`)? `yes/no`
+- Any duplicate rows created? `yes/no`
+
+## 6) Recoverability
+- Is the user interaction recoverable now? `yes/no`
+- Intended action:
+- Did write commit? `yes/no/unknown`
+- Manual remediation completed? `yes/no`
+- Remediation details:
+
+## 7) Root Cause Summary
+- Primary cause:
+- Contributing factors:
+- Why this escaped earlier detection:
+
+## 8) Fix Plan (map to issues)
+- Immediate mitigation:
+- Permanent fix:
+- Related issue IDs:
+  - `#199` submit lock
+  - `#200` async side effects
+  - `#201` index hardening
+  - `#202` request correlation
+  - `#203` global instrumentation
+  - `#204` stage timing
+  - `#205` DB observability
+  - `#206` recoverability ledger
+  - `#207` idempotency
+  - `#208` revalidation optimization
+  - `#209` network/region diagnostics
+  - `#210` growth regression guardrails
+
+## 9) Verification
+- Commands/tests run:
+- Before vs after timings:
+- Confirmed resolved for reporter: `yes/no`
+
+## 10) Follow-ups
+- Add/update alerts:
+- Add/update dashboards:
+- Update docs (`AGENTS.md`, runbooks):
+- Owner:
+- Target date:

--- a/supabase/seeds/app-data/sign-up-forms.sql
+++ b/supabase/seeds/app-data/sign-up-forms.sql
@@ -173,7 +173,7 @@ select 'guardian_consent_privacy', 'I understand that summerlunch+ is dedicated 
 union all
 select 'guardian_consent_presence', 'I understand that a guardian/caregiver or elder sibling must be present during live cooking classes to ensure the safety of the summerlunch+ participant.', 'checkbox'::form_question_type, '[]'::jsonb
 union all
-select 'guardian_consent_camera', 'I understand that cameras must remain ON during live cooking classes for engagement and safety purposes. If cameras are not on, you must provide a photo of one of the recipes that you prepared.', 'checkbox'::form_question_type, '[]'::jsonb
+select 'guardian_consent_camera', 'I understand that **cameras must remain ON** during live cooking classes for engagement and safety purposes. If cameras are not on, you must provide a photo of one of the recipes that you prepared.', 'checkbox'::form_question_type, '[]'::jsonb
 union all
 select 'guardian_consent_attendance', 'I understand that if my child(ren) do(es) not participate in two weeks of programming without notice, they will forfeit their spot in the program. Please let the summerlunch+ team know in advance if you need to miss a week.', 'checkbox'::form_question_type, '[]'::jsonb
 union all

--- a/web/app/components/forms/form-question.tsx
+++ b/web/app/components/forms/form-question.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import type { Database, Json } from '@/lib/database.types'
@@ -37,9 +39,48 @@ type FormQuestionProps = {
   required?: boolean
 }
 
+const parseInlineMarkdown = (text: string): ReactNode[] => {
+  const tokenRegex = /(\*\*[^*]+\*\*|__[^_]+__|\*[^*]+\*|_[^_]+_|`[^`]+`)/g
+  const parts = text.split(tokenRegex)
+
+  return parts.map((part, index) => {
+    if (part.startsWith('**') && part.endsWith('**')) {
+      return <strong key={`md-${index}`}>{part.slice(2, -2)}</strong>
+    }
+    if (part.startsWith('__') && part.endsWith('__')) {
+      return <strong key={`md-${index}`}>{part.slice(2, -2)}</strong>
+    }
+    if (part.startsWith('*') && part.endsWith('*')) {
+      return <em key={`md-${index}`}>{part.slice(1, -1)}</em>
+    }
+    if (part.startsWith('_') && part.endsWith('_')) {
+      return <em key={`md-${index}`}>{part.slice(1, -1)}</em>
+    }
+    if (part.startsWith('`') && part.endsWith('`')) {
+      return (
+        <code key={`md-${index}`} className="rounded bg-muted px-1 py-0.5 text-[0.92em]">
+          {part.slice(1, -1)}
+        </code>
+      )
+    }
+
+    return <span key={`md-${index}`}>{part}</span>
+  })
+}
+
+const renderPromptMarkdown = (text: string) => {
+  const lines = text.split('\n')
+  return lines.map((line, index) => (
+    <span key={`line-${index}`}>
+      {parseInlineMarkdown(line)}
+      {index < lines.length - 1 ? <br /> : null}
+    </span>
+  ))
+}
+
 const LabelWithRequired = ({ text, required }: { text: string; required?: boolean }) => (
   <>
-    {text}
+    {renderPromptMarkdown(text)}
     {required ? <span className="ml-1 text-destructive">*</span> : null}
   </>
 )
@@ -100,7 +141,7 @@ export function FormQuestion({ question, value, required }: FormQuestionProps) {
   if (question.type === 'no-input-text') {
     return (
       <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-        {question.prompt}
+        {renderPromptMarkdown(question.prompt)}
       </div>
     )
   }

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -582,6 +582,9 @@ export default function EnrollPage() {
             </div>
           ) : (
             <div className="rounded-lg border bg-card p-4 shadow-sm space-y-3">
+              <p className="text-sm text-muted-foreground">
+                Here are the cooking classes we are offering this summer. Please take a moment to sign up for one class that works best for your schedule, choosing a date and time that you can attend each week. Please note some classes are running in different time zones.
+              </p>
               <p className="text-sm text-muted-foreground">You can enroll in one workshop for this semester.</p>
               {(() => {
                 const sortedWorkshops = selectedSemester.workshops

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -1,4 +1,5 @@
-import { Link, redirect, useLoaderData, useNavigation } from 'react-router'
+import { Form, Link, redirect, useActionData, useLoaderData, useNavigation } from 'react-router'
+import { useEffect, useState } from 'react'
 
 import type { Route } from './+types/enroll'
 import { Button } from '@/components/ui/button'
@@ -49,6 +50,10 @@ type LoaderData = {
   nextClassByWorkshopId: Record<string, string | null>
   preSurveyBySemester: Record<string, { required: boolean; completed: boolean; preSurveyPath: string | null }>
   selectedSemesterId: string | null
+}
+
+type ActionData = {
+  error?: string
 }
 
 const ENROLLMENT_SUCCESS_MESSAGE =
@@ -280,7 +285,7 @@ export async function action({ request }: Route.ActionArgs) {
     family = await resolveFamilyGraph(supabase, auth.user.id)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Profile not found'
-    return redirectWithEnrollmentMessage('error', message)
+    return { error: message } satisfies ActionData
   }
 
   const { data: workshopRow, error: workshopError } = await supabase
@@ -290,7 +295,7 @@ export async function action({ request }: Route.ActionArgs) {
     .single()
 
   if (workshopError || !workshopRow?.semester_id) {
-    return redirectWithEnrollmentMessage('error', 'Workshop not found')
+    return { error: 'Workshop not found' } satisfies ActionData
   }
 
   const nowIso = new Date().toISOString()
@@ -298,7 +303,7 @@ export async function action({ request }: Route.ActionArgs) {
   const enrollmentCloseAt = workshopRow.enrollment_close_at
   const isOpen = (!enrollmentOpenAt || nowIso >= enrollmentOpenAt) && (!enrollmentCloseAt || nowIso <= enrollmentCloseAt)
   if (!isOpen) {
-    return redirectWithEnrollmentMessage('error', 'Enrollment is closed for this workshop')
+    return { error: 'Enrollment is closed for this workshop' } satisfies ActionData
   }
 
   const { data: existingEnrollment } = await supabase
@@ -310,18 +315,18 @@ export async function action({ request }: Route.ActionArgs) {
     .maybeSingle()
 
   if (existingEnrollment?.id) {
-    return redirectWithEnrollmentMessage('error', 'Your family is already enrolled in one workshop for this semester.')
+    return { error: 'Your family is already enrolled in one workshop for this semester.' } satisfies ActionData
   }
 
   const targetProfileId = getFamilyEnrollmentProfileId(family)
   if (!targetProfileId) {
-    return redirectWithEnrollmentMessage('error', 'Family enrollment profile not found.')
+    return { error: 'Family enrollment profile not found.' } satisfies ActionData
   }
 
   const preSurveyForm = await resolveSemesterSurveyForm(workshopRow.semester_id, 'pre_program_survey')
 
   if (!preSurveyForm.formId) {
-    return redirectWithEnrollmentMessage('error', 'Pre-program survey is not configured for this semester.')
+    return { error: 'Pre-program survey is not configured for this semester.' } satisfies ActionData
   }
 
   const { data: preSurveySubmission } = preSurveyForm.required
@@ -336,7 +341,7 @@ export async function action({ request }: Route.ActionArgs) {
     : { data: { id: 'not-required' } }
 
   if (preSurveyForm.required && !preSurveySubmission?.id) {
-    return redirectWithEnrollmentMessage('error', 'Please complete the pre-program survey before enrolling.')
+    return { error: 'Please complete the pre-program survey before enrolling.' } satisfies ActionData
   }
 
   const { data: workshopEnrollments } = await supabase
@@ -356,12 +361,12 @@ export async function action({ request }: Route.ActionArgs) {
   ).get(workshop_id)
 
   if (!capacitySnapshot) {
-    return redirectWithEnrollmentMessage('error', 'Unable to evaluate workshop capacity')
+    return { error: 'Unable to evaluate workshop capacity' } satisfies ActionData
   }
 
   const enrollmentAction = getWorkshopEnrollmentAction(capacitySnapshot)
   if (enrollmentAction === 'full') {
-    return redirectWithEnrollmentMessage('error', 'This workshop and its waitlist are full')
+    return { error: 'This workshop and its waitlist are full' } satisfies ActionData
   }
 
   const status = enrollmentAction === 'waitlist' ? 'waitlisted' : 'pending'
@@ -377,7 +382,7 @@ export async function action({ request }: Route.ActionArgs) {
     .single()
 
   if (enrollmentError || !enrollmentRow?.id) {
-    return redirectWithEnrollmentMessage('error', enrollmentError?.message ?? 'Unable to create enrollment')
+    return { error: enrollmentError?.message ?? 'Unable to create enrollment' } satisfies ActionData
   }
 
   const { data: familyProfilesData } = await adminClient
@@ -458,8 +463,18 @@ export async function action({ request }: Route.ActionArgs) {
 
 export default function EnrollPage() {
   const { semesters, enrollments, workshopCapacityById, nextClassByWorkshopId, preSurveyBySemester, selectedSemesterId } = useLoaderData<LoaderData>()
+  const actionData = useActionData<ActionData>()
   const navigation = useNavigation()
+  const [submitLocked, setSubmitLocked] = useState(false)
+
+  useEffect(() => {
+    if (navigation.state === 'idle' && actionData?.error) {
+      setSubmitLocked(false)
+    }
+  }, [actionData?.error, navigation.state])
+
   const mutationLocked =
+    submitLocked ||
     navigation.state !== 'idle' &&
     typeof navigation.formMethod === 'string' &&
     navigation.formMethod.toLowerCase() === 'post'
@@ -485,6 +500,7 @@ export default function EnrollPage() {
       <div className="flex flex-col gap-2">
         <h1 className="text-2xl font-semibold">Manage Enrollments</h1>
         <p className="text-sm text-muted-foreground">Step 1: select a semester. Step 2: complete pre-program survey. Step 3: choose one workshop.</p>
+        {actionData?.error ? <p className="text-sm text-destructive">{actionData.error}</p> : null}
       </div>
 
       {!selectedSemester ? (
@@ -628,12 +644,12 @@ export default function EnrollPage() {
                           {(workshop.enrollment_close_at ? formatDate(workshop.enrollment_close_at) : 'Close')}
                         </TableCell>
                         <TableCell className="text-right">
-                          <form method="post" className="inline-flex justify-end">
+                          <Form method="post" className="inline-flex justify-end" onSubmit={() => setSubmitLocked(true)}>
                             <input type="hidden" name="workshop_id" value={workshop.id} />
                             <Button type="submit" disabled={isFull || mutationLocked} size="sm">
-                              {isFull ? 'Full' : actionLabel}
+                              {isFull ? 'Full' : mutationLocked ? 'Submitting...' : actionLabel}
                             </Button>
-                          </form>
+                          </Form>
                         </TableCell>
                       </TableRow>
                     )

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -34,13 +34,31 @@ type ForeignKeyOption = {
   label: string
 }
 
+type HoverCardField = {
+  label: string
+  field: string
+  fallback?: string
+}
+
+type HoverCardConfig = {
+  titleField?: string
+  titleFallback?: string
+  fields: HoverCardField[]
+}
+
 type LoaderData = {
   columns: string[]
   rows: Record<string, unknown>[]
   label: string
   tableName: string
   tableVariant?: 'default' | 'pivot'
-  columnMeta?: Record<string, { label?: string; truncate?: boolean; filterable?: boolean; numeric?: boolean }>
+  columnMeta?: Record<string, {
+    label?: string
+    truncate?: boolean
+    filterable?: boolean
+    numeric?: boolean
+    hoverCard?: HoverCardConfig
+  }>
   canEditStatus?: boolean
   editorConfig?: EditorConfig
   foreignKeyOptions?: Record<string, ForeignKeyOption[]>
@@ -107,6 +125,30 @@ const getCellValue = (column: string, row: Record<string, unknown>, tableName?: 
     return formatTimestamp(value)
   }
   return (value ?? '').toString()
+}
+
+const normalizeHoverCardValue = (value: unknown) => {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return ''
+}
+
+const hoverCardDataForCell = (row: Record<string, unknown>, config?: HoverCardConfig) => {
+  if (!config?.fields.length) return null
+
+  const titleRaw = config.titleField ? normalizeHoverCardValue(row[config.titleField]) : ''
+  const title = titleRaw || config.titleFallback || ''
+  const fields = config.fields.map(field => {
+    const rawValue = normalizeHoverCardValue(row[field.field])
+    return {
+      label: field.label,
+      value: rawValue || field.fallback || '',
+    }
+  })
+
+  const hasValue = Boolean(title) || fields.some(field => Boolean(field.value))
+  return hasValue ? { title, fields } : null
 }
 
 const getDirectionIndicator = (stage: 0 | 1 | 2) => {
@@ -958,6 +1000,53 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                       const shouldTruncate = columnMeta[column]?.truncate ?? tableVariant !== 'pivot'
                       const filterable = columnMeta[column]?.filterable ?? true
                       const cellValue = getCellValue(column, row, tableName)
+                      const hoverCardData = hoverCardDataForCell(row, columnMeta[column]?.hoverCard)
+
+                      const content = isFormNameLink ? (
+                        <Link
+                          to={{
+                            pathname: `/manage/form/${row.id}`,
+                            search: new URLSearchParams({
+                              returnTo: `${location.pathname}${location.search}`,
+                            }).toString(),
+                          }}
+                          onClick={event => event.stopPropagation()}
+                          className="underline decoration-dotted underline-offset-2 hover:text-primary"
+                        >
+                          <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
+                            {cellValue}
+                          </span>
+                        </Link>
+                      ) : isFormAnswersLink ? (
+                        <Link
+                          to={{
+                            pathname: `/manage/form/${row.id}/answers`,
+                            search: new URLSearchParams({
+                              returnTo: `${location.pathname}${location.search}`,
+                            }).toString(),
+                          }}
+                          onClick={event => event.stopPropagation()}
+                          className="underline decoration-dotted underline-offset-2 hover:text-primary"
+                        >
+                          <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
+                            {cellValue}
+                          </span>
+                        </Link>
+                      ) : personLink ? (
+                        <Link
+                          to={personLink}
+                          onClick={event => event.stopPropagation()}
+                          className="underline decoration-dotted underline-offset-2 hover:text-primary"
+                        >
+                          <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
+                            {cellValue}
+                          </span>
+                        </Link>
+                      ) : (
+                        <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
+                          {cellValue}
+                        </span>
+                      )
 
                       return (
                         <td
@@ -973,50 +1062,25 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                             appendFilter(column, cellValue)
                           }}
                         >
-                          {isFormNameLink ? (
-                            <Link
-                              to={{
-                                pathname: `/manage/form/${row.id}`,
-                                search: new URLSearchParams({
-                                  returnTo: `${location.pathname}${location.search}`,
-                                }).toString(),
-                              }}
-                              onClick={event => event.stopPropagation()}
-                              className="underline decoration-dotted underline-offset-2 hover:text-primary"
-                            >
-                              <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                                {cellValue}
-                              </span>
-                            </Link>
-                          ) : isFormAnswersLink ? (
-                            <Link
-                              to={{
-                                pathname: `/manage/form/${row.id}/answers`,
-                                search: new URLSearchParams({
-                                  returnTo: `${location.pathname}${location.search}`,
-                                }).toString(),
-                              }}
-                              onClick={event => event.stopPropagation()}
-                              className="underline decoration-dotted underline-offset-2 hover:text-primary"
-                            >
-                              <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                                {cellValue}
-                              </span>
-                            </Link>
-                          ) : personLink ? (
-                            <Link
-                              to={personLink}
-                              onClick={event => event.stopPropagation()}
-                              className="underline decoration-dotted underline-offset-2 hover:text-primary"
-                            >
-                              <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                                {cellValue}
-                              </span>
-                            </Link>
+                          {hoverCardData ? (
+                            <div className="group/hovercard relative inline-block max-w-full">
+                              {content}
+                              <div className="pointer-events-none invisible absolute left-0 top-full z-40 mt-1 w-72 rounded-md border bg-popover p-2 text-left text-xs normal-case text-popover-foreground opacity-0 shadow-lg transition-opacity group-hover/hovercard:visible group-hover/hovercard:opacity-100">
+                                {hoverCardData.title ? (
+                                  <p className="mb-1 truncate font-semibold text-foreground">{hoverCardData.title}</p>
+                                ) : null}
+                                <div className="space-y-1">
+                                  {hoverCardData.fields.map(field => (
+                                    <p key={`${column}-${field.label}`} className="break-words">
+                                      <span className="font-medium text-foreground">{field.label}: </span>
+                                      <span>{field.value || 'N/A'}</span>
+                                    </p>
+                                  ))}
+                                </div>
+                              </div>
+                            </div>
                           ) : (
-                            <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                              {cellValue}
-                            </span>
+                            content
                           )}
                         </td>
                       )

--- a/web/app/routes/manage/table-loader.ts
+++ b/web/app/routes/manage/table-loader.ts
@@ -24,8 +24,9 @@ const profileDisplay = (profileRow: Record<string, unknown> | null, fallbackId: 
   const firstname = typeof profileRow?.firstname === 'string' ? profileRow.firstname.trim() : ''
   const surname = typeof profileRow?.surname === 'string' ? profileRow.surname.trim() : ''
   const email = typeof profileRow?.email === 'string' ? profileRow.email.trim() : ''
+  const fullName = [firstname, surname].filter(Boolean).join(' ').trim()
+  if (fullName) return fullName
   if (email) return email
-  if (firstname && surname) return `${firstname} ${surname}`
   return `ID ${fallbackId}`
 }
 
@@ -34,7 +35,8 @@ const submissionDisplay = (formRow: Record<string, unknown> | null, profileRow: 
   const firstname = typeof profileRow?.firstname === 'string' ? profileRow.firstname.trim() : ''
   const surname = typeof profileRow?.surname === 'string' ? profileRow.surname.trim() : ''
   const email = typeof profileRow?.email === 'string' ? profileRow.email.trim() : ''
-  const profileLabel = email || (firstname && surname ? `${firstname} ${surname}` : `ID ${fallbackId}`)
+  const fullName = [firstname, surname].filter(Boolean).join(' ').trim()
+  const profileLabel = fullName || email || `ID ${fallbackId}`
 
   let submittedDate = ''
   if (typeof submittedAt === 'string') {
@@ -85,8 +87,9 @@ const userProfileDisplay = (profileRow: Record<string, unknown> | null, fallback
   const email = typeof profileRow?.email === 'string' ? profileRow.email.trim() : ''
   const firstname = typeof profileRow?.firstname === 'string' ? profileRow.firstname.trim() : ''
   const surname = typeof profileRow?.surname === 'string' ? profileRow.surname.trim() : ''
+  const fullName = [firstname, surname].filter(Boolean).join(' ').trim()
+  if (fullName) return fullName
   if (email) return email
-  if (firstname && surname) return `${firstname} ${surname}`
   return `ID ${fallbackId}`
 }
 

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -22,6 +22,8 @@ const ENROLLMENT_STATUS_ORDER: Record<Database['public']['Enums']['workshop_enro
   rejected: 4,
 }
 
+const GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE = 'gift_card_store_preference'
+
 const toTime = (value: unknown) => {
   if (typeof value !== 'string' || !value) return Number.POSITIVE_INFINITY
   const parsed = Date.parse(value)
@@ -65,6 +67,17 @@ type GuardianChildEdge = {
   guardian_profile_id: string
   child_profile_id: string
   primary_child: boolean
+}
+
+type FormSubmissionRow = {
+  id: string
+  profile_id: string | null
+  submitted_at: string | null
+}
+
+type FormAnswerRow = {
+  submission_id: string
+  value: unknown
 }
 
 const normalizeRiding = (value: unknown) =>
@@ -157,32 +170,67 @@ export async function loader(args: Route.LoaderArgs) {
   let profileById = new Map<string, RidingProfileRow>()
   let guardiansByChildId = new Map<string, Array<{ profileId: string; primary: boolean }>>()
   let childrenByGuardianId = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  let familyProfileIdsByProfileId = new Map<string, string[]>()
+  let mealKitByProfileId = new Map<string, boolean>()
+  let giftCardPreferenceByProfileId = new Map<string, string>()
 
   if (profileIds.length) {
-    const { data: familyEdges, error: familyEdgesError } = await adminClient
-      .from('person_guardian_child')
-      .select('guardian_profile_id, child_profile_id, primary_child')
-      .or(`guardian_profile_id.in.(${profileIds.join(',')}),child_profile_id.in.(${profileIds.join(',')})`)
+    const seen = new Set<string>(profileIds)
+    const queue = [...profileIds]
+    const familyEdges: GuardianChildEdge[] = []
 
-    if (!familyEdgesError) {
-      for (const edge of (familyEdges ?? []) as GuardianChildEdge[]) {
-        pushEdge(guardiansByChildId, edge.child_profile_id, edge.guardian_profile_id, edge.primary_child)
-        pushEdge(childrenByGuardianId, edge.guardian_profile_id, edge.child_profile_id, edge.primary_child)
+    while (queue.length) {
+      const batch = queue.splice(0, queue.length)
+      const { data: batchEdges, error: familyEdgesError } = await adminClient
+        .from('person_guardian_child')
+        .select('guardian_profile_id, child_profile_id, primary_child')
+        .or(`guardian_profile_id.in.(${batch.join(',')}),child_profile_id.in.(${batch.join(',')})`)
+
+      if (familyEdgesError) {
+        break
+      }
+
+      for (const edge of (batchEdges ?? []) as GuardianChildEdge[]) {
+        familyEdges.push(edge)
+        if (!seen.has(edge.guardian_profile_id)) {
+          seen.add(edge.guardian_profile_id)
+          queue.push(edge.guardian_profile_id)
+        }
+        if (!seen.has(edge.child_profile_id)) {
+          seen.add(edge.child_profile_id)
+          queue.push(edge.child_profile_id)
+        }
       }
     }
 
-    const profileScope = new Set<string>(profileIds)
-    for (const edgeList of guardiansByChildId.values()) {
-      for (const edge of edgeList) profileScope.add(edge.profileId)
+    for (const edge of familyEdges) {
+      pushEdge(guardiansByChildId, edge.child_profile_id, edge.guardian_profile_id, edge.primary_child)
+      pushEdge(childrenByGuardianId, edge.guardian_profile_id, edge.child_profile_id, edge.primary_child)
     }
-    for (const edgeList of childrenByGuardianId.values()) {
-      for (const edge of edgeList) profileScope.add(edge.profileId)
+
+    const profileScope = Array.from(seen)
+    const familyAdjacency = new Map<string, Set<string>>()
+    for (const profileId of profileScope) {
+      if (!familyAdjacency.has(profileId)) {
+        familyAdjacency.set(profileId, new Set())
+      }
+    }
+
+    for (const edge of familyEdges) {
+      if (!familyAdjacency.has(edge.guardian_profile_id)) {
+        familyAdjacency.set(edge.guardian_profile_id, new Set())
+      }
+      if (!familyAdjacency.has(edge.child_profile_id)) {
+        familyAdjacency.set(edge.child_profile_id, new Set())
+      }
+      familyAdjacency.get(edge.guardian_profile_id)?.add(edge.child_profile_id)
+      familyAdjacency.get(edge.child_profile_id)?.add(edge.guardian_profile_id)
     }
 
     const { data: profileRows, error: profileRowsError } = await adminClient
       .from('profile')
       .select('id, role, federal_electoral_district_name')
-      .in('id', Array.from(profileScope))
+      .in('id', profileScope)
 
     if (!profileRowsError) {
       profileById = new Map(
@@ -190,6 +238,115 @@ export async function loader(args: Route.LoaderArgs) {
           .filter(profile => typeof profile.id === 'string' && profile.id)
           .map(profile => [profile.id, profile])
       )
+
+      const visited = new Set<string>()
+      for (const rootProfileId of profileScope) {
+        if (visited.has(rootProfileId)) continue
+
+        const familyIds: string[] = []
+        const bfsQueue = [rootProfileId]
+        visited.add(rootProfileId)
+
+        while (bfsQueue.length) {
+          const currentProfileId = bfsQueue.shift()
+          if (!currentProfileId) continue
+          familyIds.push(currentProfileId)
+
+          for (const neighbor of familyAdjacency.get(currentProfileId) ?? []) {
+            if (visited.has(neighbor)) continue
+            visited.add(neighbor)
+            bfsQueue.push(neighbor)
+          }
+        }
+
+        familyIds.sort((left, right) => left.localeCompare(right))
+        for (const familyProfileId of familyIds) {
+          familyProfileIdsByProfileId.set(familyProfileId, familyIds)
+        }
+      }
+
+      const ridingNames = Array.from(
+        new Set(
+          (profileRows ?? [])
+            .map(profile => normalizeRiding(profile.federal_electoral_district_name))
+            .filter((riding): riding is string => Boolean(riding))
+        )
+      )
+
+      const mealKitByRidingName = new Map<string, boolean>()
+      if (ridingNames.length) {
+        const { data: ridingRows, error: ridingRowsError } = await adminClient
+          .from('federal_electoral_district')
+          .select('name, meal_kit')
+          .in('name', ridingNames)
+
+        if (!ridingRowsError) {
+          for (const riding of ridingRows ?? []) {
+            if (typeof riding.name !== 'string') continue
+            mealKitByRidingName.set(riding.name, riding.meal_kit === true)
+          }
+        }
+      }
+
+      for (const profile of profileById.values()) {
+        const ridingName = normalizeRiding(profile.federal_electoral_district_name)
+        if (!ridingName) {
+          mealKitByProfileId.set(profile.id, false)
+          continue
+        }
+
+        mealKitByProfileId.set(profile.id, mealKitByRidingName.get(ridingName) === true)
+      }
+
+      const { data: submissionRows, error: submissionRowsError } = await adminClient
+        .from('form_submission')
+        .select('id, profile_id, submitted_at')
+        .in('profile_id', profileScope)
+        .order('submitted_at', { ascending: false })
+
+      if (!submissionRowsError) {
+        const submissions = (submissionRows ?? []) as FormSubmissionRow[]
+        const submissionIds = submissions
+          .map(submission => submission.id)
+          .filter((submissionId): submissionId is string => Boolean(submissionId))
+
+        if (submissionIds.length) {
+          const { data: answerRows, error: answerRowsError } = await adminClient
+            .from('form_answer')
+            .select('submission_id, value')
+            .eq('question_code', GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
+            .in('submission_id', submissionIds)
+
+          if (!answerRowsError) {
+            const submissionById = new Map(submissions.map(submission => [submission.id, submission]))
+            const latestGiftCardByProfileId = new Map<string, { value: string; submittedAt: number }>()
+
+            for (const answer of (answerRows ?? []) as FormAnswerRow[]) {
+              const submission = submissionById.get(answer.submission_id)
+              const profileId = submission?.profile_id
+              if (!profileId) continue
+
+              const value = typeof answer.value === 'string' ? answer.value.trim() : ''
+              if (!value) continue
+
+              const submittedAt = Date.parse(submission?.submitted_at ?? '')
+              const submittedAtTime = Number.isNaN(submittedAt) ? 0 : submittedAt
+              const existing = latestGiftCardByProfileId.get(profileId)
+
+              if (!existing || submittedAtTime > existing.submittedAt) {
+                latestGiftCardByProfileId.set(profileId, {
+                  value,
+                  submittedAt: submittedAtTime,
+                })
+              }
+            }
+
+            giftCardPreferenceByProfileId = new Map(
+              Array.from(latestGiftCardByProfileId.entries()).map(([profileId, entry]) => [profileId, entry.value])
+            )
+          }
+        }
+      }
     }
   }
 
@@ -234,10 +391,41 @@ export async function loader(args: Route.LoaderArgs) {
 
     const ridingDisplay = studentRiding ?? parentRiding ?? normalizeRiding(enrollmentProfile?.federal_electoral_district_name) ?? ''
 
+    const candidateProfileIds: string[] = []
+    const addCandidate = (candidateId: string | null) => {
+      if (!candidateId || candidateProfileIds.includes(candidateId)) return
+      candidateProfileIds.push(candidateId)
+    }
+
+    addCandidate(inferredStudentProfileId)
+    addCandidate(inferredParentProfileId)
+
+    for (const familyProfileId of familyProfileIdsByProfileId.get(profileId) ?? []) {
+      addCandidate(familyProfileId)
+    }
+
+    addCandidate(profileId || null)
+
+    const giftcardDisplay = (() => {
+      for (const candidateProfileId of candidateProfileIds) {
+        if (mealKitByProfileId.get(candidateProfileId) === true) {
+          return 'Meal Kit'
+        }
+
+        const giftCardChoice = giftCardPreferenceByProfileId.get(candidateProfileId)
+        if (giftCardChoice) {
+          return giftCardChoice
+        }
+      }
+
+      return 'N/A'
+    })()
+
     const baseRow = {
       ...row,
       enrolled_capacity: capacity === null ? `${approved}/-` : `${approved}/${capacity}`,
       riding_display: ridingDisplay,
+      giftcard_display: giftcardDisplay,
     }
 
     if (!profileSignals.length) {
@@ -293,6 +481,20 @@ export async function loader(args: Route.LoaderArgs) {
     }
   }
 
+  if (!columns.includes('giftcard_display')) {
+    const ridingIndex = columns.indexOf('riding_display')
+    if (ridingIndex >= 0) {
+      columns = [...columns.slice(0, ridingIndex + 1), 'giftcard_display', ...columns.slice(ridingIndex + 1)]
+    } else {
+      const profileIndex = columns.indexOf('profile_display')
+      if (profileIndex >= 0) {
+        columns = [...columns.slice(0, profileIndex + 1), 'giftcard_display', ...columns.slice(profileIndex + 1)]
+      } else {
+        columns = [...columns, 'giftcard_display']
+      }
+    }
+  }
+
   if (columns.includes('semester_range')) {
     columns = [...columns.filter(column => column !== 'semester_range'), 'semester_range']
   }
@@ -308,6 +510,9 @@ export async function loader(args: Route.LoaderArgs) {
       },
       riding_display: {
         label: 'riding',
+      },
+      giftcard_display: {
+        label: 'giftcard',
       },
     },
     canEditStatus: isRoleAtLeast(auth.claims.role, 'staff'),

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -60,6 +60,9 @@ const parseEnrollmentField = (
 type RidingProfileRow = {
   id: string
   role: string | null
+  firstname: string | null
+  surname: string | null
+  email: string | null
   federal_electoral_district_name: string | null
 }
 
@@ -82,6 +85,16 @@ type FormAnswerRow = {
 
 const normalizeRiding = (value: unknown) =>
   typeof value === 'string' && value.trim() ? value.trim() : null
+
+const normalizeText = (value: unknown) =>
+  typeof value === 'string' && value.trim() ? value.trim() : null
+
+const fullNameFromProfile = (profile: RidingProfileRow | null | undefined) => {
+  const firstname = normalizeText(profile?.firstname)
+  const surname = normalizeText(profile?.surname)
+  const fullName = [firstname, surname].filter(Boolean).join(' ').trim()
+  return fullName || null
+}
 
 const pushEdge = (
   map: Map<string, Array<{ profileId: string; primary: boolean }>>,
@@ -229,7 +242,7 @@ export async function loader(args: Route.LoaderArgs) {
 
     const { data: profileRows, error: profileRowsError } = await adminClient
       .from('profile')
-      .select('id, role, federal_electoral_district_name')
+      .select('id, role, firstname, surname, email, federal_electoral_district_name')
       .in('id', profileScope)
 
     if (!profileRowsError) {
@@ -390,6 +403,11 @@ export async function loader(args: Route.LoaderArgs) {
       : null
 
     const ridingDisplay = studentRiding ?? parentRiding ?? normalizeRiding(enrollmentProfile?.federal_electoral_district_name) ?? ''
+    const profileHoverName = fullNameFromProfile(enrollmentProfile) ?? 'N/A'
+    const profileHoverEmail = normalizeText(enrollmentProfile?.email) ?? 'N/A'
+    const profileHoverParentEmail = inferredParentProfileId
+      ? normalizeText(profileById.get(inferredParentProfileId)?.email) ?? 'N/A'
+      : 'N/A'
 
     const candidateProfileIds: string[] = []
     const addCandidate = (candidateId: string | null) => {
@@ -426,6 +444,9 @@ export async function loader(args: Route.LoaderArgs) {
       enrolled_capacity: capacity === null ? `${approved}/-` : `${approved}/${capacity}`,
       riding_display: ridingDisplay,
       giftcard_display: giftcardDisplay,
+      profile_hover_name: profileHoverName,
+      profile_hover_email: profileHoverEmail,
+      profile_hover_parent_email: profileHoverParentEmail,
     }
 
     if (!profileSignals.length) {
@@ -499,12 +520,28 @@ export async function loader(args: Route.LoaderArgs) {
     columns = [...columns.filter(column => column !== 'semester_range'), 'semester_range']
   }
 
+  const baseColumnMeta = (base.columnMeta ?? {}) as Record<
+    string,
+    { label?: string; truncate?: boolean; filterable?: boolean; numeric?: boolean }
+  >
+
   return {
     ...base,
     columns,
     rows: enrichedRows,
     columnMeta: {
-      ...(base.columnMeta ?? {}),
+      ...baseColumnMeta,
+      profile_display: {
+        ...(baseColumnMeta.profile_display ?? {}),
+        hoverCard: {
+          titleField: 'profile_hover_name',
+          titleFallback: 'N/A',
+          fields: [
+            { label: 'Email', field: 'profile_hover_email', fallback: 'N/A' },
+            { label: 'Parent Email', field: 'profile_hover_parent_email', fallback: 'N/A' },
+          ],
+        },
+      },
       enrolled_capacity: {
         label: 'enrolled/capacity',
       },

--- a/web/app/routes/semester-surveys.pre.tsx
+++ b/web/app/routes/semester-surveys.pre.tsx
@@ -1,5 +1,6 @@
 import { Form, Link, redirect, useActionData, useLoaderData, useNavigation } from 'react-router'
 
+import AuthStickerBackground from '@/components/auth/sticker-background'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -294,46 +295,48 @@ export default function SemesterPreSurveyPage() {
   const isSubmitting = navigation.state !== 'idle'
 
   return (
-    <main className="mx-auto w-full max-w-3xl px-6 py-10">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-2xl">{formName}</CardTitle>
-          <CardDescription>
-            Complete this pre-program survey before enrolling in workshops for this semester.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Form method="post" className="space-y-6">
-            <input type="hidden" name="return_to" value={returnTo} />
-            <p className="text-sm text-slate-500">Semester: {semesterId}</p>
+    <AuthStickerBackground maxWidthClassName="max-w-3xl" dense scrollContent>
+      <div className="w-full py-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-2xl">{formName}</CardTitle>
+            <CardDescription>
+              Complete this pre-program survey before enrolling in workshops for this semester.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Form method="post" className="space-y-6">
+              <input type="hidden" name="return_to" value={returnTo} />
+              <p className="text-sm text-slate-500">Semester: {semesterId}</p>
 
-            {questions.map(question => {
-              const metadata = (question.metadata ?? {}) as Record<string, Json>
-              const isOptional = metadata.optional === true
-              return (
-                <FormQuestion
-                  key={question.question_code}
-                  question={question}
-                  value={answers[question.question_code]}
-                  required={!isOptional && question.type !== 'no-input-text'}
-                />
-              )
-            })}
+              {questions.map(question => {
+                const metadata = (question.metadata ?? {}) as Record<string, Json>
+                const isOptional = metadata.optional === true
+                return (
+                  <FormQuestion
+                    key={question.question_code}
+                    question={question}
+                    value={answers[question.question_code]}
+                    required={!isOptional && question.type !== 'no-input-text'}
+                  />
+                )
+              })}
 
-            {actionData?.error ? <p className="text-sm text-red-500">{actionData.error}</p> : null}
+              {actionData?.error ? <p className="text-sm text-red-500">{actionData.error}</p> : null}
 
-            <div className="flex items-center justify-end gap-3">
-              <Button variant="ghost" asChild>
-                <Link to="/home">Cancel</Link>
-              </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? 'Loading next step...' : 'Save and continue'}
-              </Button>
-            </div>
-          </Form>
-        </CardContent>
-      </Card>
-      <p className="mt-3 text-xs text-slate-500">Form ID: {formId}</p>
-    </main>
+              <div className="flex items-center justify-end gap-3">
+                <Button variant="ghost" asChild>
+                  <Link to="/home">Cancel</Link>
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? 'Loading next step...' : 'Save and continue'}
+                </Button>
+              </div>
+            </Form>
+          </CardContent>
+        </Card>
+        <p className="mt-3 text-xs text-slate-500">Form ID: {formId}</p>
+      </div>
+    </AuthStickerBackground>
   )
 }


### PR DESCRIPTION
## What changed
- adds a giftcard display column to workshop enrollments
- resolves giftcard value by scanning child, then parent, then rest of family tree
- shows Meal Kit for meal-kit ridings, otherwise latest gift_card_store_preference, else N/A
- updates manage table profile labels to prefer full name over email
- adds a configurable columnMeta.<column>.hoverCard API in TableDisplay
- implements a profile hover card on workshop enrollment profile_display with name, email, and parent email

## Verification
- npm run typecheck (from web/)