### PR TITLE
Add markdown email draft builder foundation

### DIFF
--- a/supabase/migrations/20260603120000_email-draft-builder.sql
+++ b/supabase/migrations/20260603120000_email-draft-builder.sql
@@ -1,0 +1,109 @@
+create type public.email_draft_channel as enum ('transactional', 'auth');
+
+create type public.email_draft_status as enum ('draft', 'published', 'archived');
+
+create table public.email_draft (
+  id uuid primary key default gen_random_uuid(),
+  draft_key text not null unique,
+  title text not null,
+  description text,
+  channel public.email_draft_channel not null,
+  status public.email_draft_status not null default 'draft',
+  is_system boolean not null default false,
+  variables_schema jsonb not null default '{}'::jsonb,
+  current_subject_markdown text not null default '',
+  current_body_markdown text not null default '',
+  published_version_id uuid,
+  created_by_user_id uuid references auth.users (id) on delete set null,
+  updated_by_user_id uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.email_draft_version (
+  id uuid primary key default gen_random_uuid(),
+  email_draft_id uuid not null references public.email_draft (id) on delete cascade,
+  version_number integer not null check (version_number > 0),
+  subject_markdown text not null,
+  body_markdown text not null,
+  subject_rendered text not null,
+  html_rendered text not null,
+  text_rendered text not null,
+  variables_schema jsonb not null default '{}'::jsonb,
+  change_note text,
+  created_by_user_id uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  published_at timestamptz,
+  published_by_user_id uuid references auth.users (id) on delete set null,
+  unique (email_draft_id, version_number)
+);
+
+alter table public.email_draft
+  add constraint email_draft_published_version_id_fkey
+  foreign key (published_version_id) references public.email_draft_version (id) on delete set null;
+
+create index email_draft_channel_status_idx on public.email_draft (channel, status);
+create index email_draft_updated_at_idx on public.email_draft (updated_at desc);
+create index email_draft_version_draft_created_idx on public.email_draft_version (email_draft_id, created_at desc);
+
+create or replace function public.touch_email_draft_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists on_email_draft_updated_set_timestamp on public.email_draft;
+create trigger on_email_draft_updated_set_timestamp
+before update on public.email_draft
+for each row execute function public.touch_email_draft_updated_at();
+
+alter table public.email_draft enable row level security;
+alter table public.email_draft_version enable row level security;
+
+create policy email_draft_read
+  on public.email_draft
+  for select
+  using (public.authorize('form.read'));
+
+create policy email_draft_insert
+  on public.email_draft
+  for insert
+  with check (public.authorize('form.update'));
+
+create policy email_draft_update
+  on public.email_draft
+  for update
+  using (public.authorize('form.update'))
+  with check (public.authorize('form.update'));
+
+create policy email_draft_delete
+  on public.email_draft
+  for delete
+  using (public.authorize('form.update') and not is_system);
+
+create policy email_draft_version_read
+  on public.email_draft_version
+  for select
+  using (public.authorize('form.read'));
+
+create policy email_draft_version_insert
+  on public.email_draft_version
+  for insert
+  with check (public.authorize('form.update'));
+
+grant usage on type public.email_draft_channel to authenticated, supabase_auth_admin;
+grant usage on type public.email_draft_status to authenticated, supabase_auth_admin;
+
+grant all on table public.email_draft to supabase_auth_admin;
+revoke all on table public.email_draft from anon, public;
+grant select, insert, update, delete on table public.email_draft to authenticated;
+
+grant all on table public.email_draft_version to supabase_auth_admin;
+revoke all on table public.email_draft_version from anon, public;
+grant select, insert on table public.email_draft_version to authenticated;

--- a/supabase/schemas/12_email_drafts.sql
+++ b/supabase/schemas/12_email_drafts.sql
@@ -1,0 +1,109 @@
+create type public.email_draft_channel as enum ('transactional', 'auth');
+
+create type public.email_draft_status as enum ('draft', 'published', 'archived');
+
+create table public.email_draft (
+  id uuid primary key default gen_random_uuid(),
+  draft_key text not null unique,
+  title text not null,
+  description text,
+  channel public.email_draft_channel not null,
+  status public.email_draft_status not null default 'draft',
+  is_system boolean not null default false,
+  variables_schema jsonb not null default '{}'::jsonb,
+  current_subject_markdown text not null default '',
+  current_body_markdown text not null default '',
+  published_version_id uuid,
+  created_by_user_id uuid references auth.users (id) on delete set null,
+  updated_by_user_id uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.email_draft_version (
+  id uuid primary key default gen_random_uuid(),
+  email_draft_id uuid not null references public.email_draft (id) on delete cascade,
+  version_number integer not null check (version_number > 0),
+  subject_markdown text not null,
+  body_markdown text not null,
+  subject_rendered text not null,
+  html_rendered text not null,
+  text_rendered text not null,
+  variables_schema jsonb not null default '{}'::jsonb,
+  change_note text,
+  created_by_user_id uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  published_at timestamptz,
+  published_by_user_id uuid references auth.users (id) on delete set null,
+  unique (email_draft_id, version_number)
+);
+
+alter table public.email_draft
+  add constraint email_draft_published_version_id_fkey
+  foreign key (published_version_id) references public.email_draft_version (id) on delete set null;
+
+create index email_draft_channel_status_idx on public.email_draft (channel, status);
+create index email_draft_updated_at_idx on public.email_draft (updated_at desc);
+create index email_draft_version_draft_created_idx on public.email_draft_version (email_draft_id, created_at desc);
+
+create or replace function public.touch_email_draft_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists on_email_draft_updated_set_timestamp on public.email_draft;
+create trigger on_email_draft_updated_set_timestamp
+before update on public.email_draft
+for each row execute function public.touch_email_draft_updated_at();
+
+alter table public.email_draft enable row level security;
+alter table public.email_draft_version enable row level security;
+
+create policy email_draft_read
+  on public.email_draft
+  for select
+  using (public.authorize('form.read'));
+
+create policy email_draft_insert
+  on public.email_draft
+  for insert
+  with check (public.authorize('form.update'));
+
+create policy email_draft_update
+  on public.email_draft
+  for update
+  using (public.authorize('form.update'))
+  with check (public.authorize('form.update'));
+
+create policy email_draft_delete
+  on public.email_draft
+  for delete
+  using (public.authorize('form.update') and not is_system);
+
+create policy email_draft_version_read
+  on public.email_draft_version
+  for select
+  using (public.authorize('form.read'));
+
+create policy email_draft_version_insert
+  on public.email_draft_version
+  for insert
+  with check (public.authorize('form.update'));
+
+grant usage on type public.email_draft_channel to authenticated, supabase_auth_admin;
+grant usage on type public.email_draft_status to authenticated, supabase_auth_admin;
+
+grant all on table public.email_draft to supabase_auth_admin;
+revoke all on table public.email_draft from anon, public;
+grant select, insert, update, delete on table public.email_draft to authenticated;
+
+grant all on table public.email_draft_version to supabase_auth_admin;
+revoke all on table public.email_draft_version from anon, public;
+grant select, insert on table public.email_draft_version to authenticated;

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -120,6 +120,127 @@ export type Database = {
           },
         ]
       }
+      email_draft: {
+        Row: {
+          channel: Database["public"]["Enums"]["email_draft_channel"]
+          created_at: string
+          created_by_user_id: string | null
+          current_body_markdown: string
+          current_subject_markdown: string
+          description: string | null
+          draft_key: string
+          id: string
+          is_system: boolean
+          published_version_id: string | null
+          status: Database["public"]["Enums"]["email_draft_status"]
+          title: string
+          updated_at: string
+          updated_by_user_id: string | null
+          variables_schema: Json
+        }
+        Insert: {
+          channel: Database["public"]["Enums"]["email_draft_channel"]
+          created_at?: string
+          created_by_user_id?: string | null
+          current_body_markdown?: string
+          current_subject_markdown?: string
+          description?: string | null
+          draft_key: string
+          id?: string
+          is_system?: boolean
+          published_version_id?: string | null
+          status?: Database["public"]["Enums"]["email_draft_status"]
+          title: string
+          updated_at?: string
+          updated_by_user_id?: string | null
+          variables_schema?: Json
+        }
+        Update: {
+          channel?: Database["public"]["Enums"]["email_draft_channel"]
+          created_at?: string
+          created_by_user_id?: string | null
+          current_body_markdown?: string
+          current_subject_markdown?: string
+          description?: string | null
+          draft_key?: string
+          id?: string
+          is_system?: boolean
+          published_version_id?: string | null
+          status?: Database["public"]["Enums"]["email_draft_status"]
+          title?: string
+          updated_at?: string
+          updated_by_user_id?: string | null
+          variables_schema?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "email_draft_published_version_id_fkey"
+            columns: ["published_version_id"]
+            isOneToOne: false
+            referencedRelation: "email_draft_version"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      email_draft_version: {
+        Row: {
+          body_markdown: string
+          change_note: string | null
+          created_at: string
+          created_by_user_id: string | null
+          email_draft_id: string
+          html_rendered: string
+          id: string
+          published_at: string | null
+          published_by_user_id: string | null
+          subject_markdown: string
+          subject_rendered: string
+          text_rendered: string
+          variables_schema: Json
+          version_number: number
+        }
+        Insert: {
+          body_markdown: string
+          change_note?: string | null
+          created_at?: string
+          created_by_user_id?: string | null
+          email_draft_id: string
+          html_rendered: string
+          id?: string
+          published_at?: string | null
+          published_by_user_id?: string | null
+          subject_markdown: string
+          subject_rendered: string
+          text_rendered: string
+          variables_schema?: Json
+          version_number: number
+        }
+        Update: {
+          body_markdown?: string
+          change_note?: string | null
+          created_at?: string
+          created_by_user_id?: string | null
+          email_draft_id?: string
+          html_rendered?: string
+          id?: string
+          published_at?: string | null
+          published_by_user_id?: string | null
+          subject_markdown?: string
+          subject_rendered?: string
+          text_rendered?: string
+          variables_schema?: Json
+          version_number?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "email_draft_version_email_draft_id_fkey"
+            columns: ["email_draft_id"]
+            isOneToOne: false
+            referencedRelation: "email_draft"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       email_message: {
         Row: {
           created_at: string
@@ -207,6 +328,33 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      federal_electoral_district: {
+        Row: {
+          code: number
+          created_at: string
+          meal_kit: boolean
+          name: string
+          updated_at: string
+          whitelist: boolean
+        }
+        Insert: {
+          code: number
+          created_at?: string
+          meal_kit?: boolean
+          name: string
+          updated_at?: string
+          whitelist?: boolean
+        }
+        Update: {
+          code?: number
+          created_at?: string
+          meal_kit?: boolean
+          name?: string
+          updated_at?: string
+          whitelist?: boolean
+        }
+        Relationships: []
       }
       form: {
         Row: {
@@ -675,6 +823,7 @@ export type Database = {
           created_at: string
           date_of_birth: string | null
           email: string | null
+          federal_electoral_district_name: string | null
           firstname: string | null
           household_children_count: number | null
           household_size: number | null
@@ -684,6 +833,9 @@ export type Database = {
           phone: string | null
           postcode: string | null
           province: string | null
+          riding_lookup_error: string | null
+          riding_lookup_last_attempt_at: string | null
+          riding_lookup_status: string | null
           role: Database["public"]["Enums"]["app_role"]
           street_address: string | null
           surname: string | null
@@ -695,6 +847,7 @@ export type Database = {
           created_at?: string
           date_of_birth?: string | null
           email?: string | null
+          federal_electoral_district_name?: string | null
           firstname?: string | null
           household_children_count?: number | null
           household_size?: number | null
@@ -704,6 +857,9 @@ export type Database = {
           phone?: string | null
           postcode?: string | null
           province?: string | null
+          riding_lookup_error?: string | null
+          riding_lookup_last_attempt_at?: string | null
+          riding_lookup_status?: string | null
           role: Database["public"]["Enums"]["app_role"]
           street_address?: string | null
           surname?: string | null
@@ -715,6 +871,7 @@ export type Database = {
           created_at?: string
           date_of_birth?: string | null
           email?: string | null
+          federal_electoral_district_name?: string | null
           firstname?: string | null
           household_children_count?: number | null
           household_size?: number | null
@@ -724,13 +881,24 @@ export type Database = {
           phone?: string | null
           postcode?: string | null
           province?: string | null
+          riding_lookup_error?: string | null
+          riding_lookup_last_attempt_at?: string | null
+          riding_lookup_status?: string | null
           role?: Database["public"]["Enums"]["app_role"]
           street_address?: string | null
           surname?: string | null
           updated_at?: string
           user_id?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "profile_federal_electoral_district_name_fkey"
+            columns: ["federal_electoral_district_name"]
+            isOneToOne: false
+            referencedRelation: "federal_electoral_district"
+            referencedColumns: ["name"]
+          },
+        ]
       }
       role_permission: {
         Row: {
@@ -1234,6 +1402,8 @@ export type Database = {
         | "student"
         | "guardian"
       class_attendance_status: "unknown" | "present" | "absent"
+      email_draft_channel: "transactional" | "auth"
+      email_draft_status: "draft" | "published" | "archived"
       email_message_status: "queued" | "sent" | "failed" | "skipped"
       form_assignment_status: "pending" | "submitted"
       form_question_type:
@@ -1448,6 +1618,8 @@ export const Constants = {
         "guardian",
       ],
       class_attendance_status: ["unknown", "present", "absent"],
+      email_draft_channel: ["transactional", "auth"],
+      email_draft_status: ["draft", "published", "archived"],
       email_message_status: ["queued", "sent", "failed", "skipped"],
       form_assignment_status: ["pending", "submitted"],
       form_question_type: [

--- a/web/app/lib/email/drafts/renderer.server.ts
+++ b/web/app/lib/email/drafts/renderer.server.ts
@@ -1,0 +1,128 @@
+import type { RenderDraftInput, RenderDraftOutput } from '@/lib/email/drafts/types'
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+const PLACEHOLDER_RE = /\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g
+
+const readVariable = (key: string, variables: Record<string, unknown>) => {
+  const parts = key.split('.')
+  let current: unknown = variables
+
+  for (const part of parts) {
+    if (!current || typeof current !== 'object') return undefined
+    current = (current as Record<string, unknown>)[part]
+  }
+
+  return current
+}
+
+const interpolate = (input: string, variables: Record<string, unknown>) => {
+  const missing = new Set<string>()
+
+  const output = input.replaceAll(PLACEHOLDER_RE, (_match, key: string) => {
+    const resolved = readVariable(key, variables)
+    if (resolved === null || resolved === undefined || resolved === '') {
+      missing.add(key)
+      return `{{${key}}}`
+    }
+    return String(resolved)
+  })
+
+  return { output, missingVariables: Array.from(missing).sort() }
+}
+
+const renderInlineMarkdown = (line: string) => {
+  const escaped = escapeHtml(line)
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/__(.+?)__/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/_(.+?)_/g, '<em>$1</em>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+}
+
+const markdownToHtml = (markdown: string) => {
+  const normalized = markdown.replace(/\r\n/g, '\n').trim()
+  if (!normalized) return '<p></p>'
+
+  const lines = normalized.split('\n')
+  const html: string[] = []
+  let inList = false
+
+  const closeList = () => {
+    if (inList) {
+      html.push('</ul>')
+      inList = false
+    }
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd()
+    if (!line.trim()) {
+      closeList()
+      continue
+    }
+
+    const heading = line.match(/^(#{1,3})\s+(.*)$/)
+    if (heading) {
+      closeList()
+      const level = heading[1].length
+      html.push(`<h${level}>${renderInlineMarkdown(heading[2])}</h${level}>`)
+      continue
+    }
+
+    const listItem = line.match(/^[-*]\s+(.*)$/)
+    if (listItem) {
+      if (!inList) {
+        html.push('<ul>')
+        inList = true
+      }
+      html.push(`<li>${renderInlineMarkdown(listItem[1])}</li>`)
+      continue
+    }
+
+    closeList()
+    html.push(`<p>${renderInlineMarkdown(line)}</p>`)
+  }
+
+  closeList()
+  return html.join('\n')
+}
+
+const markdownToText = (markdown: string) => markdown.replace(/\r\n/g, '\n').trim()
+
+export const renderEmailDraft = ({
+  subjectMarkdown,
+  bodyMarkdown,
+  variables = {},
+}: RenderDraftInput): RenderDraftOutput => {
+  const subjectInterpolation = interpolate(subjectMarkdown, variables)
+  const bodyInterpolation = interpolate(bodyMarkdown, variables)
+  const missingVariables = Array.from(
+    new Set([...subjectInterpolation.missingVariables, ...bodyInterpolation.missingVariables])
+  ).sort()
+
+  return {
+    subject: subjectInterpolation.output,
+    html: markdownToHtml(bodyInterpolation.output),
+    text: markdownToText(bodyInterpolation.output),
+    missingVariables,
+  }
+}
+
+export const collectPlaceholders = (value: string) => {
+  const keys = new Set<string>()
+  let next = PLACEHOLDER_RE.exec(value)
+  while (next) {
+    keys.add(next[1])
+    next = PLACEHOLDER_RE.exec(value)
+  }
+  PLACEHOLDER_RE.lastIndex = 0
+  return Array.from(keys).sort()
+}

--- a/web/app/lib/email/drafts/repository.server.ts
+++ b/web/app/lib/email/drafts/repository.server.ts
@@ -1,0 +1,245 @@
+import { adminClient } from '@/lib/supabase/adminClient'
+import type {
+  EmailDraftChannel,
+  EmailDraftRecord,
+  EmailDraftSchema,
+  EmailDraftStatus,
+  EmailDraftVersionRecord,
+} from '@/lib/email/drafts/types'
+
+type DraftListFilters = {
+  channel?: EmailDraftChannel | 'all'
+  status?: EmailDraftStatus | 'all'
+}
+
+export const listEmailDrafts = async (filters: DraftListFilters = {}) => {
+  let query = adminClient
+    .from('email_draft')
+    .select(
+      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
+    )
+    .order('updated_at', { ascending: false })
+
+  if (filters.channel && filters.channel !== 'all') {
+    query = query.eq('channel', filters.channel)
+  }
+
+  if (filters.status && filters.status !== 'all') {
+    query = query.eq('status', filters.status)
+  }
+
+  const { data, error } = await query
+  if (error) throw new Error(error.message)
+  return (data ?? []) as EmailDraftRecord[]
+}
+
+export const createEmailDraft = async ({
+  draftKey,
+  title,
+  channel,
+  actorUserId,
+}: {
+  draftKey: string
+  title: string
+  channel: EmailDraftChannel
+  actorUserId: string
+}) => {
+  const { data, error } = await adminClient
+    .from('email_draft')
+    .insert({
+      draft_key: draftKey,
+      title,
+      channel,
+      created_by_user_id: actorUserId,
+      updated_by_user_id: actorUserId,
+    })
+    .select(
+      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
+    )
+    .single()
+
+  if (error) throw new Error(error.message)
+  return data as EmailDraftRecord
+}
+
+export const getEmailDraftById = async (draftId: string) => {
+  const { data, error } = await adminClient
+    .from('email_draft')
+    .select(
+      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
+    )
+    .eq('id', draftId)
+    .single()
+
+  if (error) throw new Error(error.message)
+  return data as EmailDraftRecord
+}
+
+export const getEmailDraftByKey = async (draftKey: string) => {
+  const { data, error } = await adminClient
+    .from('email_draft')
+    .select(
+      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
+    )
+    .eq('draft_key', draftKey)
+    .single()
+
+  if (error) throw new Error(error.message)
+  return data as EmailDraftRecord
+}
+
+export const getEmailDraftVersions = async (draftId: string) => {
+  const { data, error } = await adminClient
+    .from('email_draft_version')
+    .select(
+      'id, email_draft_id, version_number, subject_markdown, body_markdown, subject_rendered, html_rendered, text_rendered, variables_schema, change_note, created_by_user_id, created_at, published_at, published_by_user_id'
+    )
+    .eq('email_draft_id', draftId)
+    .order('version_number', { ascending: false })
+
+  if (error) throw new Error(error.message)
+  return (data ?? []) as EmailDraftVersionRecord[]
+}
+
+export const updateEmailDraft = async ({
+  draftId,
+  actorUserId,
+  payload,
+}: {
+  draftId: string
+  actorUserId: string
+  payload: {
+    title?: string
+    description?: string | null
+    status?: EmailDraftStatus
+    subjectMarkdown?: string
+    bodyMarkdown?: string
+    variablesSchema?: EmailDraftSchema
+  }
+}) => {
+  const updatePayload: Record<string, unknown> = {
+    updated_by_user_id: actorUserId,
+  }
+
+  if (typeof payload.title === 'string') updatePayload.title = payload.title
+  if (payload.description !== undefined) updatePayload.description = payload.description
+  if (payload.status) updatePayload.status = payload.status
+  if (typeof payload.subjectMarkdown === 'string') {
+    updatePayload.current_subject_markdown = payload.subjectMarkdown
+  }
+  if (typeof payload.bodyMarkdown === 'string') {
+    updatePayload.current_body_markdown = payload.bodyMarkdown
+  }
+  if (payload.variablesSchema !== undefined) {
+    updatePayload.variables_schema = payload.variablesSchema
+  }
+
+  const { data, error } = await adminClient
+    .from('email_draft')
+    .update(updatePayload)
+    .eq('id', draftId)
+    .select(
+      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
+    )
+    .single()
+
+  if (error) throw new Error(error.message)
+  return data as EmailDraftRecord
+}
+
+export const createEmailDraftVersion = async ({
+  draftId,
+  subjectMarkdown,
+  bodyMarkdown,
+  subjectRendered,
+  htmlRendered,
+  textRendered,
+  variablesSchema,
+  changeNote,
+  actorUserId,
+}: {
+  draftId: string
+  subjectMarkdown: string
+  bodyMarkdown: string
+  subjectRendered: string
+  htmlRendered: string
+  textRendered: string
+  variablesSchema: EmailDraftSchema
+  changeNote: string | null
+  actorUserId: string
+}) => {
+  const { data: versionRow, error: versionError } = await adminClient
+    .from('email_draft_version')
+    .select('version_number')
+    .eq('email_draft_id', draftId)
+    .order('version_number', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (versionError) throw new Error(versionError.message)
+
+  const nextVersion = (versionRow?.version_number ?? 0) + 1
+
+  const { data, error } = await adminClient
+    .from('email_draft_version')
+    .insert({
+      email_draft_id: draftId,
+      version_number: nextVersion,
+      subject_markdown: subjectMarkdown,
+      body_markdown: bodyMarkdown,
+      subject_rendered: subjectRendered,
+      html_rendered: htmlRendered,
+      text_rendered: textRendered,
+      variables_schema: variablesSchema,
+      change_note: changeNote,
+      created_by_user_id: actorUserId,
+      published_at: new Date().toISOString(),
+      published_by_user_id: actorUserId,
+    })
+    .select(
+      'id, email_draft_id, version_number, subject_markdown, body_markdown, subject_rendered, html_rendered, text_rendered, variables_schema, change_note, created_by_user_id, created_at, published_at, published_by_user_id'
+    )
+    .single()
+
+  if (error) throw new Error(error.message)
+  return data as EmailDraftVersionRecord
+}
+
+export const setPublishedVersion = async ({
+  draftId,
+  versionId,
+  actorUserId,
+}: {
+  draftId: string
+  versionId: string
+  actorUserId: string
+}) => {
+  const { data, error } = await adminClient
+    .from('email_draft')
+    .update({
+      status: 'published',
+      published_version_id: versionId,
+      updated_by_user_id: actorUserId,
+    })
+    .eq('id', draftId)
+    .select(
+      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
+    )
+    .single()
+
+  if (error) throw new Error(error.message)
+  return data as EmailDraftRecord
+}
+
+export const getEmailDraftVersionById = async (versionId: string) => {
+  const { data, error } = await adminClient
+    .from('email_draft_version')
+    .select(
+      'id, email_draft_id, version_number, subject_markdown, body_markdown, subject_rendered, html_rendered, text_rendered, variables_schema, change_note, created_by_user_id, created_at, published_at, published_by_user_id'
+    )
+    .eq('id', versionId)
+    .single()
+
+  if (error) throw new Error(error.message)
+  return data as EmailDraftVersionRecord
+}

--- a/web/app/lib/email/drafts/service.server.ts
+++ b/web/app/lib/email/drafts/service.server.ts
@@ -1,0 +1,184 @@
+import {
+  createEmailDraft,
+  createEmailDraftVersion,
+  getEmailDraftById,
+  getEmailDraftByKey,
+  getEmailDraftVersionById,
+  getEmailDraftVersions,
+  listEmailDrafts,
+  setPublishedVersion,
+  updateEmailDraft,
+} from '@/lib/email/drafts/repository.server'
+import { renderEmailDraft } from '@/lib/email/drafts/renderer.server'
+import type {
+  EmailDraftChannel,
+  EmailDraftSchema,
+  EmailDraftStatus,
+} from '@/lib/email/drafts/types'
+import { validateDraftForPublish } from '@/lib/email/drafts/validators'
+
+export const listDrafts = listEmailDrafts
+
+export const createDraft = async ({
+  draftKey,
+  title,
+  channel,
+  actorUserId,
+}: {
+  draftKey: string
+  title: string
+  channel: EmailDraftChannel
+  actorUserId: string
+}) => {
+  return createEmailDraft({ draftKey, title, channel, actorUserId })
+}
+
+export const getDraftForEditor = async (draftId: string) => {
+  const [draft, versions] = await Promise.all([
+    getEmailDraftById(draftId),
+    getEmailDraftVersions(draftId),
+  ])
+
+  return { draft, versions }
+}
+
+export const saveDraft = async ({
+  draftId,
+  actorUserId,
+  title,
+  description,
+  status,
+  subjectMarkdown,
+  bodyMarkdown,
+  variablesSchema,
+}: {
+  draftId: string
+  actorUserId: string
+  title: string
+  description: string | null
+  status: EmailDraftStatus
+  subjectMarkdown: string
+  bodyMarkdown: string
+  variablesSchema: EmailDraftSchema
+}) => {
+  return updateEmailDraft({
+    draftId,
+    actorUserId,
+    payload: {
+      title,
+      description,
+      status,
+      subjectMarkdown,
+      bodyMarkdown,
+      variablesSchema,
+    },
+  })
+}
+
+export const publishDraft = async ({
+  draftId,
+  actorUserId,
+  changeNote,
+}: {
+  draftId: string
+  actorUserId: string
+  changeNote: string | null
+}) => {
+  const draft = await getEmailDraftById(draftId)
+  const schema = (draft.variables_schema ?? {}) as EmailDraftSchema
+  const validation = validateDraftForPublish({
+    subjectMarkdown: draft.current_subject_markdown,
+    bodyMarkdown: draft.current_body_markdown,
+    variablesSchema: schema,
+  })
+
+  if (!validation.ok) {
+    return { ok: false as const, errors: validation.errors }
+  }
+
+  const rendered = renderEmailDraft({
+    subjectMarkdown: draft.current_subject_markdown,
+    bodyMarkdown: draft.current_body_markdown,
+  })
+
+  const version = await createEmailDraftVersion({
+    draftId,
+    subjectMarkdown: draft.current_subject_markdown,
+    bodyMarkdown: draft.current_body_markdown,
+    subjectRendered: rendered.subject,
+    htmlRendered: rendered.html,
+    textRendered: rendered.text,
+    variablesSchema: schema,
+    changeNote,
+    actorUserId,
+  })
+
+  await setPublishedVersion({
+    draftId,
+    versionId: version.id,
+    actorUserId,
+  })
+
+  return { ok: true as const, version }
+}
+
+export const previewDraft = ({
+  subjectMarkdown,
+  bodyMarkdown,
+  variables,
+}: {
+  subjectMarkdown: string
+  bodyMarkdown: string
+  variables?: Record<string, unknown>
+}) => {
+  return renderEmailDraft({ subjectMarkdown, bodyMarkdown, variables })
+}
+
+export const rollbackDraftToVersion = async ({
+  draftId,
+  versionId,
+  actorUserId,
+}: {
+  draftId: string
+  versionId: string
+  actorUserId: string
+}) => {
+  const version = await getEmailDraftVersionById(versionId)
+  if (version.email_draft_id !== draftId) {
+    return { ok: false as const, error: 'Version does not belong to this draft.' }
+  }
+
+  await updateEmailDraft({
+    draftId,
+    actorUserId,
+    payload: {
+      status: 'draft',
+      subjectMarkdown: version.subject_markdown,
+      bodyMarkdown: version.body_markdown,
+      variablesSchema: (version.variables_schema ?? {}) as EmailDraftSchema,
+    },
+  })
+
+  return { ok: true as const }
+}
+
+export const resolvePublishedDraftByKey = async ({
+  draftKey,
+  variables,
+}: {
+  draftKey: string
+  variables?: Record<string, unknown>
+}) => {
+  const draft = await getEmailDraftByKey(draftKey)
+
+  if (!draft.published_version_id) {
+    return null
+  }
+
+  const version = await getEmailDraftVersionById(draft.published_version_id)
+  return previewDraft({
+    subjectMarkdown: version.subject_markdown,
+    bodyMarkdown: version.body_markdown,
+    variables,
+  })
+}

--- a/web/app/lib/email/drafts/types.ts
+++ b/web/app/lib/email/drafts/types.ts
@@ -1,0 +1,63 @@
+import type { Json } from '@/lib/database.types'
+
+export type EmailDraftChannel = 'transactional' | 'auth'
+
+export type EmailDraftStatus = 'draft' | 'published' | 'archived'
+
+export type EmailDraftSchema = {
+  required?: string[]
+  properties?: Record<string, { description?: string; example?: string }>
+}
+
+export type EmailDraftRecord = {
+  id: string
+  draft_key: string
+  title: string
+  description: string | null
+  channel: EmailDraftChannel
+  status: EmailDraftStatus
+  is_system: boolean
+  variables_schema: Json
+  current_subject_markdown: string
+  current_body_markdown: string
+  published_version_id: string | null
+  created_by_user_id: string | null
+  updated_by_user_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type EmailDraftVersionRecord = {
+  id: string
+  email_draft_id: string
+  version_number: number
+  subject_markdown: string
+  body_markdown: string
+  subject_rendered: string
+  html_rendered: string
+  text_rendered: string
+  variables_schema: Json
+  change_note: string | null
+  created_by_user_id: string | null
+  created_at: string
+  published_at: string | null
+  published_by_user_id: string | null
+}
+
+export type RenderDraftInput = {
+  subjectMarkdown: string
+  bodyMarkdown: string
+  variables?: Record<string, unknown>
+}
+
+export type RenderDraftOutput = {
+  subject: string
+  html: string
+  text: string
+  missingVariables: string[]
+}
+
+export type ValidateDraftResult = {
+  ok: boolean
+  errors: string[]
+}

--- a/web/app/lib/email/drafts/validators.ts
+++ b/web/app/lib/email/drafts/validators.ts
@@ -1,0 +1,91 @@
+import { collectPlaceholders } from '@/lib/email/drafts/renderer.server'
+import type { EmailDraftSchema, ValidateDraftResult } from '@/lib/email/drafts/types'
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const normalizeSchema = (value: unknown): EmailDraftSchema => {
+  if (!isObject(value)) return {}
+
+  const required = Array.isArray(value.required)
+    ? value.required.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    : undefined
+
+  const properties = isObject(value.properties)
+    ? Object.fromEntries(
+        Object.entries(value.properties).map(([key, entry]) => [
+          key,
+          isObject(entry)
+            ? {
+                description:
+                  typeof entry.description === 'string' ? entry.description : undefined,
+                example: typeof entry.example === 'string' ? entry.example : undefined,
+              }
+            : {},
+        ])
+      )
+    : undefined
+
+  return {
+    ...(required ? { required } : {}),
+    ...(properties ? { properties } : {}),
+  }
+}
+
+export const parseSchemaInput = (schemaText: string) => {
+  const trimmed = schemaText.trim()
+  if (!trimmed) return { schema: {}, error: null as string | null }
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (!isObject(parsed)) {
+      return { schema: {}, error: 'Variables schema must be a JSON object.' }
+    }
+    return { schema: normalizeSchema(parsed), error: null as string | null }
+  } catch (error) {
+    return {
+      schema: {},
+      error: error instanceof Error ? error.message : 'Variables schema must be valid JSON.',
+    }
+  }
+}
+
+export const validateDraftForPublish = ({
+  subjectMarkdown,
+  bodyMarkdown,
+  variablesSchema,
+}: {
+  subjectMarkdown: string
+  bodyMarkdown: string
+  variablesSchema: EmailDraftSchema
+}): ValidateDraftResult => {
+  const errors: string[] = []
+
+  if (!subjectMarkdown.trim()) {
+    errors.push('Subject markdown is required.')
+  }
+
+  if (!bodyMarkdown.trim()) {
+    errors.push('Body markdown is required.')
+  }
+
+  const required = Array.isArray(variablesSchema.required)
+    ? variablesSchema.required.filter(key => key.trim().length > 0)
+    : []
+
+  const placeholders = new Set([
+    ...collectPlaceholders(subjectMarkdown),
+    ...collectPlaceholders(bodyMarkdown),
+  ])
+
+  for (const key of required) {
+    if (!placeholders.has(key)) {
+      errors.push(`Required variable {{${key}}} is missing from subject/body markdown.`)
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+  }
+}

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -63,6 +63,8 @@ export default [
     route("form-submission", "routes/manage/form-submission.tsx"),
     route("login-event", "routes/manage/login-event.tsx"),
     route("email-message", "routes/manage/email-message.tsx"),
+    route("email-drafts", "routes/manage/email-drafts.tsx"),
+    route("email-drafts/:draftId", "routes/manage/email-drafts.$draftId.tsx"),
     route("form-answer", "routes/manage/form-answer.tsx"),
     route("gift-cards", "routes/manage/gift-cards.tsx"),
     route("role-permission", "routes/manage/role-permission.tsx"),

--- a/web/app/routes/manage/email-drafts.$draftId.tsx
+++ b/web/app/routes/manage/email-drafts.$draftId.tsx
@@ -1,0 +1,483 @@
+import { Link, redirect, useFetcher, useLoaderData } from 'react-router'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { requireAuth } from '@/lib/auth.server'
+import type { Json } from '@/lib/database.types'
+import {
+  getDraftForEditor,
+  previewDraft,
+  publishDraft,
+  rollbackDraftToVersion,
+  saveDraft,
+} from '@/lib/email/drafts/service.server'
+import type { EmailDraftSchema, EmailDraftStatus } from '@/lib/email/drafts/types'
+import { sendTransactionalEmail } from '@/lib/email/send-email.server'
+import { isRoleAtLeast } from '@/lib/roles'
+import { parseSchemaInput, validateDraftForPublish } from '@/lib/email/drafts/validators'
+
+import type { Route } from './+types/email-drafts.$draftId'
+
+type ActionData = {
+  ok?: boolean
+  message?: string
+  error?: string
+  errors?: string[]
+  preview?: {
+    subject: string
+    html: string
+    text: string
+    missingVariables: string[]
+  }
+}
+
+const normalizeStatus = (value: string): EmailDraftStatus => {
+  if (value === 'draft' || value === 'published' || value === 'archived') return value
+  return 'draft'
+}
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'manager')) {
+    throw redirect('/manage', { headers: auth.headers })
+  }
+
+  const draftId = params.draftId
+  if (!draftId) {
+    throw redirect('/manage/email-drafts', { headers: auth.headers })
+  }
+
+  const { draft, versions } = await getDraftForEditor(draftId)
+  const schema = (draft.variables_schema ?? {}) as EmailDraftSchema
+  const validation = validateDraftForPublish({
+    subjectMarkdown: draft.current_subject_markdown,
+    bodyMarkdown: draft.current_body_markdown,
+    variablesSchema: schema,
+  })
+  const initialPreview = previewDraft({
+    subjectMarkdown: draft.current_subject_markdown,
+    bodyMarkdown: draft.current_body_markdown,
+  })
+
+  return {
+    draft,
+    versions,
+    schemaText: JSON.stringify(schema, null, 2),
+    validation,
+    initialPreview,
+  }
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'manager')) {
+    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const draftId = params.draftId
+  if (!draftId) {
+    return { error: 'Missing draft id' } satisfies ActionData
+  }
+
+  const formData = await request.formData()
+  const intent = String(formData.get('intent') ?? '')
+
+  if (intent === 'preview-draft') {
+    const subjectMarkdown = String(formData.get('subject_markdown') ?? '')
+    const bodyMarkdown = String(formData.get('body_markdown') ?? '')
+    const sampleVariablesText = String(formData.get('sample_variables') ?? '').trim()
+    let sampleVariables: Record<string, unknown> = {}
+
+    if (sampleVariablesText) {
+      try {
+        const parsed = JSON.parse(sampleVariablesText)
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          return { error: 'Sample variables must be a JSON object.' } satisfies ActionData
+        }
+        sampleVariables = parsed as Record<string, unknown>
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : 'Sample variables must be valid JSON.',
+        } satisfies ActionData
+      }
+    }
+
+    const preview = previewDraft({
+      subjectMarkdown,
+      bodyMarkdown,
+      variables: sampleVariables,
+    })
+
+    return { ok: true, preview } satisfies ActionData
+  }
+
+  if (intent === 'send-test-email') {
+    const toEmail = String(formData.get('to_email') ?? '').trim().toLowerCase()
+    const sampleVariablesText = String(formData.get('sample_variables') ?? '').trim()
+    let sampleVariables: Record<string, unknown> = {}
+
+    if (!toEmail) {
+      return { error: 'Test recipient email is required.' } satisfies ActionData
+    }
+
+    if (sampleVariablesText) {
+      try {
+        const parsed = JSON.parse(sampleVariablesText)
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          return { error: 'Sample variables must be a JSON object.' } satisfies ActionData
+        }
+        sampleVariables = parsed as Record<string, unknown>
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : 'Sample variables must be valid JSON.',
+        } satisfies ActionData
+      }
+    }
+
+    const { draft } = await getDraftForEditor(draftId)
+    const rendered = previewDraft({
+      subjectMarkdown: draft.current_subject_markdown,
+      bodyMarkdown: draft.current_body_markdown,
+      variables: sampleVariables,
+    })
+
+    const sendResult = await sendTransactionalEmail({
+      toEmail,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+      templateKey: `email_draft_test:${draft.draft_key}`,
+      templateData: sampleVariables as Json,
+      eventKey: null,
+      triggeredByUserId: auth.user.id,
+    })
+
+    if (sendResult.status === 'failed') {
+      return { error: sendResult.error ?? 'Unable to send test email.' } satisfies ActionData
+    }
+
+    if (sendResult.status === 'skipped') {
+      return { error: 'Test email was skipped unexpectedly.' } satisfies ActionData
+    }
+
+    return { ok: true, message: `Test email sent to ${toEmail}.` } satisfies ActionData
+  }
+
+  if (intent === 'save-draft') {
+    const title = String(formData.get('title') ?? '').trim()
+    const description = String(formData.get('description') ?? '').trim()
+    const status = normalizeStatus(String(formData.get('status') ?? 'draft'))
+    const subjectMarkdown = String(formData.get('subject_markdown') ?? '')
+    const bodyMarkdown = String(formData.get('body_markdown') ?? '')
+    const schemaText = String(formData.get('variables_schema') ?? '')
+
+    if (!title) {
+      return { error: 'Title is required.' } satisfies ActionData
+    }
+
+    const parsedSchema = parseSchemaInput(schemaText)
+    if (parsedSchema.error) {
+      return { error: `Variables schema error: ${parsedSchema.error}` } satisfies ActionData
+    }
+
+    await saveDraft({
+      draftId,
+      actorUserId: auth.user.id,
+      title,
+      description: description || null,
+      status,
+      subjectMarkdown,
+      bodyMarkdown,
+      variablesSchema: parsedSchema.schema,
+    })
+
+    return { ok: true } satisfies ActionData
+  }
+
+  if (intent === 'publish-draft') {
+    const result = await publishDraft({
+      draftId,
+      actorUserId: auth.user.id,
+      changeNote: String(formData.get('change_note') ?? '').trim() || null,
+    })
+
+    if (!result.ok) {
+      return {
+        error: 'Draft did not pass publish validation.',
+        errors: result.errors,
+      } satisfies ActionData
+    }
+
+    return { ok: true } satisfies ActionData
+  }
+
+  if (intent === 'rollback-draft') {
+    const versionId = String(formData.get('version_id') ?? '')
+    if (!versionId) {
+      return { error: 'Missing version id.' } satisfies ActionData
+    }
+
+    const result = await rollbackDraftToVersion({
+      draftId,
+      versionId,
+      actorUserId: auth.user.id,
+    })
+
+    if (!result.ok) {
+      return { error: result.error } satisfies ActionData
+    }
+
+    return { ok: true } satisfies ActionData
+  }
+
+  return { error: 'Unsupported action.' } satisfies ActionData
+}
+
+export default function EmailDraftEditorPage() {
+  const { draft, versions, schemaText, validation, initialPreview } = useLoaderData<typeof loader>()
+  const fetcher = useFetcher<ActionData>()
+  const isSubmitting = fetcher.state === 'submitting'
+
+  const preview = fetcher.data?.preview ?? initialPreview
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{draft.title}</h1>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-mono text-xs">{draft.draft_key}</span> - {draft.channel} - {draft.status}
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link to="/manage/email-drafts">Back to drafts</Link>
+        </Button>
+      </div>
+
+      {fetcher.data?.error ? <p className="text-sm text-red-500">{fetcher.data.error}</p> : null}
+      {fetcher.data?.message ? <p className="text-sm text-emerald-600">{fetcher.data.message}</p> : null}
+      {fetcher.data?.errors?.length ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {fetcher.data.errors.map(error => (
+            <p key={error}>{error}</p>
+          ))}
+        </div>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Draft editor</CardTitle>
+          <CardDescription>
+            Edit markdown content, schema, and status. Save before publishing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <fetcher.Form method="post" className="space-y-4">
+            <input type="hidden" name="intent" value="save-draft" />
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="title">Title</Label>
+                <Input id="title" name="title" defaultValue={draft.title} required />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="status">Status</Label>
+                <select
+                  id="status"
+                  name="status"
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                  defaultValue={draft.status}
+                >
+                  <option value="draft">draft</option>
+                  <option value="published">published</option>
+                  <option value="archived">archived</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="description">Description</Label>
+              <Input id="description" name="description" defaultValue={draft.description ?? ''} />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="subject-markdown">Subject markdown</Label>
+              <Input
+                id="subject-markdown"
+                name="subject_markdown"
+                defaultValue={draft.current_subject_markdown}
+                required
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="body-markdown">Body markdown</Label>
+              <textarea
+                id="body-markdown"
+                name="body_markdown"
+                defaultValue={draft.current_body_markdown}
+                rows={12}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                required
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="variables-schema">Variables schema (JSON)</Label>
+              <textarea
+                id="variables-schema"
+                name="variables_schema"
+                defaultValue={schemaText}
+                rows={8}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+              />
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Saving...' : 'Save draft'}
+              </Button>
+              {!validation.ok ? (
+                <span className="text-xs text-amber-600">Current draft has publish validation issues.</span>
+              ) : (
+                <span className="text-xs text-emerald-600">Current draft passes publish validation.</span>
+              )}
+            </div>
+          </fetcher.Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Preview + publish</CardTitle>
+          <CardDescription>Preview uses the latest saved markdown content for this draft.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <fetcher.Form method="post" className="space-y-3">
+            <input type="hidden" name="intent" value="preview-draft" />
+            <input type="hidden" name="subject_markdown" value={draft.current_subject_markdown} />
+            <input type="hidden" name="body_markdown" value={draft.current_body_markdown} />
+            <div className="grid gap-2">
+              <Label htmlFor="sample-variables">Sample variables JSON</Label>
+              <textarea
+                id="sample-variables"
+                name="sample_variables"
+                rows={5}
+                placeholder='{"actorName":"Alex","workshopName":"Beginner Kitchen"}'
+                className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+              />
+            </div>
+            <Button type="submit" variant="outline" disabled={isSubmitting}>
+              {isSubmitting ? 'Rendering...' : 'Preview with variables'}
+            </Button>
+          </fetcher.Form>
+
+          <fetcher.Form method="post" className="space-y-3 rounded-md border p-3">
+            <input type="hidden" name="intent" value="send-test-email" />
+            <div className="grid gap-2 md:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="to-email">Test recipient</Label>
+                <Input id="to-email" name="to_email" type="email" placeholder="team@example.com" required />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="test-sample-variables">Sample variables JSON</Label>
+                <Input
+                  id="test-sample-variables"
+                  name="sample_variables"
+                  placeholder='{"actorName":"Alex"}'
+                />
+              </div>
+            </div>
+            <Button type="submit" variant="outline" disabled={isSubmitting}>
+              {isSubmitting ? 'Sending...' : 'Send test email'}
+            </Button>
+          </fetcher.Form>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="rounded-md border p-3">
+              <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">Rendered subject</p>
+              <p className="text-sm font-medium">{preview.subject || '(empty subject)'}</p>
+              {preview.missingVariables.length ? (
+                <p className="mt-2 text-xs text-amber-600">
+                  Missing variables: {preview.missingVariables.join(', ')}
+                </p>
+              ) : null}
+            </div>
+            <div className="rounded-md border p-3">
+              <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">Rendered text</p>
+              <pre className="whitespace-pre-wrap text-xs">{preview.text || '(empty text body)'}</pre>
+            </div>
+          </div>
+
+          <div className="rounded-md border p-3">
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">Rendered HTML</p>
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-all text-xs">{preview.html}</pre>
+          </div>
+
+          <fetcher.Form method="post" className="space-y-2">
+            <input type="hidden" name="intent" value="publish-draft" />
+            <div className="grid gap-2">
+              <Label htmlFor="change-note">Change note (optional)</Label>
+              <Input id="change-note" name="change_note" placeholder="Updated signup CTA copy" />
+            </div>
+            <Button type="submit" disabled={isSubmitting || !validation.ok}>
+              {isSubmitting ? 'Publishing...' : 'Publish new version'}
+            </Button>
+          </fetcher.Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Version history</CardTitle>
+          <CardDescription>Published snapshots are immutable and can be rolled back into draft mode.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {versions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No versions published yet.</p>
+          ) : (
+            <div className="overflow-x-auto rounded-md border">
+              <table className="min-w-full text-sm">
+                <thead className="bg-muted/50 text-left">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Version</th>
+                    <th className="px-3 py-2 font-medium">Published</th>
+                    <th className="px-3 py-2 font-medium">Change note</th>
+                    <th className="px-3 py-2 font-medium">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {versions.map(version => (
+                    <tr key={version.id} className="border-t">
+                      <td className="px-3 py-2 font-medium">v{version.version_number}</td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {version.published_at
+                          ? new Intl.DateTimeFormat(undefined, {
+                              dateStyle: 'medium',
+                              timeStyle: 'short',
+                            }).format(new Date(version.published_at))
+                          : '-'}
+                      </td>
+                      <td className="px-3 py-2">{version.change_note ?? '-'}</td>
+                      <td className="px-3 py-2">
+                        <fetcher.Form method="post">
+                          <input type="hidden" name="intent" value="rollback-draft" />
+                          <input type="hidden" name="version_id" value={version.id} />
+                          <Button type="submit" variant="outline" size="sm" disabled={isSubmitting}>
+                            Roll back
+                          </Button>
+                        </fetcher.Form>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/web/app/routes/manage/email-drafts.tsx
+++ b/web/app/routes/manage/email-drafts.tsx
@@ -1,0 +1,190 @@
+import { Link, redirect, useFetcher, useLoaderData } from 'react-router'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { requireAuth } from '@/lib/auth.server'
+import { createDraft, listDrafts } from '@/lib/email/drafts/service.server'
+import { isRoleAtLeast } from '@/lib/roles'
+
+import type { Route } from './+types/email-drafts'
+
+type ActionData = {
+  error?: string
+}
+
+const normalizeDraftKey = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/\s+/g, '_')
+    .replaceAll(/[^a-z0-9_.-]/g, '_')
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'manager')) {
+    throw redirect('/manage', { headers: auth.headers })
+  }
+
+  const url = new URL(request.url)
+  const channelFilter = url.searchParams.get('channel')
+  const statusFilter = url.searchParams.get('status')
+
+  const drafts = await listDrafts({
+    channel: channelFilter === 'auth' || channelFilter === 'transactional' ? channelFilter : 'all',
+    status:
+      statusFilter === 'draft' || statusFilter === 'published' || statusFilter === 'archived'
+        ? statusFilter
+        : 'all',
+  })
+
+  return {
+    drafts,
+    channelFilter: channelFilter ?? 'all',
+    statusFilter: statusFilter ?? 'all',
+  }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'manager')) {
+    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const formData = await request.formData()
+  const intent = String(formData.get('intent') ?? '')
+  if (intent !== 'create-draft') {
+    return { error: 'Unsupported action' } satisfies ActionData
+  }
+
+  const title = String(formData.get('title') ?? '').trim()
+  const draftKey = normalizeDraftKey(String(formData.get('draft_key') ?? ''))
+  const channel = String(formData.get('channel') ?? '')
+
+  if (!title) {
+    return { error: 'Title is required.' } satisfies ActionData
+  }
+
+  if (!draftKey) {
+    return { error: 'Draft key is required.' } satisfies ActionData
+  }
+
+  if (channel !== 'auth' && channel !== 'transactional') {
+    return { error: 'Select a valid channel.' } satisfies ActionData
+  }
+
+  try {
+    const created = await createDraft({
+      draftKey,
+      title,
+      channel,
+      actorUserId: auth.user.id,
+    })
+
+    return redirect(`/manage/email-drafts/${created.id}`, { headers: auth.headers })
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : 'Unable to create draft.',
+    } satisfies ActionData
+  }
+}
+
+export default function EmailDraftsPage() {
+  const { drafts, channelFilter, statusFilter } = useLoaderData<typeof loader>()
+  const fetcher = useFetcher<ActionData>()
+  const creating = fetcher.state === 'submitting'
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Create email draft</CardTitle>
+          <CardDescription>
+            Draft keys are stable identifiers used by server send logic. Use lowercase and underscores.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <fetcher.Form method="post" className="grid gap-4 md:grid-cols-[1fr_1fr_180px_auto]">
+            <input type="hidden" name="intent" value="create-draft" />
+            <div className="grid gap-2">
+              <Label htmlFor="title">Title</Label>
+              <Input id="title" name="title" placeholder="Family enrollment accepted" required />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="draft-key">Draft key</Label>
+              <Input id="draft-key" name="draft_key" placeholder="family_enrollment_accepted_v1" required />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="channel">Channel</Label>
+              <select
+                id="channel"
+                name="channel"
+                className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                defaultValue="transactional"
+                required
+              >
+                <option value="transactional">transactional</option>
+                <option value="auth">auth</option>
+              </select>
+            </div>
+            <div className="flex items-end">
+              <Button type="submit" disabled={creating}>
+                {creating ? 'Creating...' : 'Create draft'}
+              </Button>
+            </div>
+          </fetcher.Form>
+          {fetcher.data?.error ? <p className="mt-3 text-sm text-red-500">{fetcher.data.error}</p> : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Email drafts</CardTitle>
+          <CardDescription>
+            Filtered view. Active filters: channel={channelFilter}, status={statusFilter}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {drafts.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No drafts found for selected filters.</p>
+          ) : (
+            <div className="overflow-x-auto rounded-md border">
+              <table className="min-w-full text-sm">
+                <thead className="bg-muted/50 text-left">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Title</th>
+                    <th className="px-3 py-2 font-medium">Key</th>
+                    <th className="px-3 py-2 font-medium">Channel</th>
+                    <th className="px-3 py-2 font-medium">Status</th>
+                    <th className="px-3 py-2 font-medium">Updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {drafts.map(draft => (
+                    <tr key={draft.id} className="border-t">
+                      <td className="px-3 py-2">
+                        <Link to={`/manage/email-drafts/${draft.id}`} className="font-medium text-primary hover:underline">
+                          {draft.title}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 font-mono text-xs">{draft.draft_key}</td>
+                      <td className="px-3 py-2">{draft.channel}</td>
+                      <td className="px-3 py-2">{draft.status}</td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {new Intl.DateTimeFormat(undefined, {
+                          dateStyle: 'medium',
+                          timeStyle: 'short',
+                        }).format(new Date(draft.updated_at))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/web/app/routes/manage/nav.ts
+++ b/web/app/routes/manage/nav.ts
@@ -67,6 +67,7 @@ export const manageSections: ManageNavSection[] = [
     items: [
       { to: '/manage/login-event', label: 'Login events', description: 'Successful sign-in metadata and source context.' },
       { to: '/manage/email-message', label: 'Email messages', description: 'Outbound transactional email log with delivery status and template data.' },
+      { to: '/manage/email-drafts', label: 'Email drafts', description: 'Markdown drafts with versioning, preview, and publish flow.' },
       { to: '/manage/semester-form-requirement', label: 'Semester surveys', description: 'Map one pre/post survey form per semester.' },
       { to: '/manage/role-permission', label: 'Role permissions', description: 'Permissions assigned to each role.' },
       { to: '/manage/request-metadata', label: 'Request metadata', description: 'Validate proxy headers and extracted request metadata.' },


### PR DESCRIPTION
## What
- add `email_draft` + `email_draft_version` schema, migration, and generated DB types
- add draft domain services/repository/renderer/validators under `web/app/lib/email/drafts/`
- add manage UI routes for draft list/editor, preview, publish, rollback, and test-send
- wire routes/nav entries for `/manage/email-drafts`

## Verification
- `supabase migration up`
- `supabase gen types typescript --local > web/app/lib/database.types.ts`
- `npm run typecheck` (from `web/`)