### PR TITLE
Async-load workshop enrollment enrichment data

### DIFF
--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -50,6 +50,7 @@ export default [
     route("class", "routes/manage/class.tsx"),
     route("class-attendance", "routes/manage/class-attendance.tsx"),
     route("workshop-enrollment", "routes/manage/workshop-enrollment.tsx"),
+    route("workshop-enrollment/enrichment", "routes/manage/workshop-enrollment.enrichment.ts"),
     route("form", "routes/manage/form.tsx"),
     route("form/:formID/answers", "routes/manage/form.$id.answers.tsx"),
     route("form/:formID", "routes/manage/form.$id.tsx"),

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -46,6 +46,18 @@ type HoverCardConfig = {
   fields: HoverCardField[]
 }
 
+type WorkshopEnrollmentEnrichment = {
+  riding_display: string
+  giftcard_display: string
+  profile_hover_name: string
+  profile_hover_email: string
+  profile_hover_parent_email: string
+}
+
+type WorkshopEnrollmentEnrichmentResponse = {
+  byProfileId: Record<string, WorkshopEnrollmentEnrichment>
+}
+
 type LoaderData = {
   columns: string[]
   rows: Record<string, unknown>[]
@@ -57,6 +69,7 @@ type LoaderData = {
     truncate?: boolean
     filterable?: boolean
     numeric?: boolean
+    maxChars?: number
     hoverCard?: HoverCardConfig
   }>
   canEditStatus?: boolean
@@ -261,8 +274,11 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
   const [createValues, setCreateValues] = useState<Record<string, string>>({})
   const [editingRowKey, setEditingRowKey] = useState<string | null>(null)
   const [editValues, setEditValues] = useState<Record<string, string>>({})
+  const [enrichmentByProfileId, setEnrichmentByProfileId] = useState<Record<string, WorkshopEnrollmentEnrichment>>({})
+  const loadingEnrichmentProfileIdsRef = useRef<Set<string>>(new Set())
   const filterButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const filterPopoverRef = useRef<HTMLDivElement | null>(null)
+  const isWorkshopEnrollmentTable = tableName === 'class-enrollment'
 
   useEffect(() => {
     const nextSort = searchParams.get('sort')
@@ -349,8 +365,20 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
       return selectedValues.includes(cellValue)
     })
 
+  const rowsWithEnrichment = useMemo(() => {
+    if (!isWorkshopEnrollmentTable) return rows
+
+    return rows.map(row => {
+      const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+      if (!profileId) return row
+      const enrichment = enrichmentByProfileId[profileId]
+      if (!enrichment) return row
+      return { ...row, ...enrichment }
+    })
+  }, [enrichmentByProfileId, isWorkshopEnrollmentTable, rows])
+
   const derivedRows = useMemo(() => {
-    let adjustedRows = rows.filter(row => rowMatchesFilters(row, filters))
+    let adjustedRows = rowsWithEnrichment.filter(row => rowMatchesFilters(row, filters))
     if (sortColumn && sortStage > 0) {
       adjustedRows.sort((a, b) => {
         const aValue = getCellValue(sortColumn, a)
@@ -361,19 +389,19 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
       })
     }
     return adjustedRows
-  }, [rows, columns, filters, sortColumn, sortStage, tableName])
+  }, [rowsWithEnrichment, columns, filters, sortColumn, sortStage, tableName])
 
   const filterOptionsByColumn = useMemo(() => {
     return columns.reduce<Record<string, string[]>>((acc, column) => {
       const nextOptions = new Set<string>()
-      for (const row of rows) {
+      for (const row of rowsWithEnrichment) {
         if (!rowMatchesFilters(row, filters, column)) continue
         nextOptions.add(getCellValue(column, row, tableName))
       }
       acc[column] = Array.from(nextOptions).sort((a, b) => a.localeCompare(b))
       return acc
     }, {})
-  }, [columns, rows, filters, tableName])
+  }, [columns, rowsWithEnrichment, filters, tableName])
 
   const totalRows = derivedRows.length
   const totalPages = Math.max(1, Math.ceil(totalRows / pageSize))
@@ -389,6 +417,71 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
     const start = (effectivePage - 1) * pageSize
     return derivedRows.slice(start, start + pageSize)
   }, [derivedRows, effectivePage, pageSize])
+
+  useEffect(() => {
+    if (!isWorkshopEnrollmentTable) return
+
+    const missingProfileIds = Array.from(
+      new Set(
+        paginatedRows
+          .map(row => (typeof row.profile_id === 'string' ? row.profile_id : ''))
+          .filter(profileId =>
+            Boolean(profileId) &&
+            !enrichmentByProfileId[profileId] &&
+            !loadingEnrichmentProfileIdsRef.current.has(profileId)
+          )
+      )
+    )
+
+    if (!missingProfileIds.length) return
+
+    const requestProfileIds = missingProfileIds.slice(0, 40)
+    requestProfileIds.forEach(profileId => loadingEnrichmentProfileIdsRef.current.add(profileId))
+
+    const abortController = new AbortController()
+    void (async () => {
+      try {
+        const searchParams = new URLSearchParams()
+        requestProfileIds.forEach(profileId => searchParams.append('profileId', profileId))
+        const response = await fetch(`/manage/workshop-enrollment/enrichment?${searchParams.toString()}`, {
+          signal: abortController.signal,
+        })
+
+        if (!response.ok) return
+        const payload = (await response.json()) as WorkshopEnrollmentEnrichmentResponse
+        const fallbackEnrichment: WorkshopEnrollmentEnrichment = {
+          riding_display: '',
+          giftcard_display: 'N/A',
+          profile_hover_name: 'N/A',
+          profile_hover_email: 'N/A',
+          profile_hover_parent_email: 'N/A',
+        }
+
+        const resolvedByProfileId = requestProfileIds.reduce<Record<string, WorkshopEnrollmentEnrichment>>(
+          (acc, profileId) => {
+            acc[profileId] = payload?.byProfileId?.[profileId] ?? fallbackEnrichment
+            return acc
+          },
+          {}
+        )
+
+        setEnrichmentByProfileId(prev => ({
+          ...prev,
+          ...resolvedByProfileId,
+        }))
+      } catch (error) {
+        if ((error as Error).name !== 'AbortError') {
+          console.error('[table display] enrichment fetch failed', error)
+        }
+      } finally {
+        requestProfileIds.forEach(profileId => loadingEnrichmentProfileIdsRef.current.delete(profileId))
+      }
+    })()
+
+    return () => {
+      abortController.abort()
+    }
+  }, [enrichmentByProfileId, isWorkshopEnrollmentTable, paginatedRows])
 
   const updateSort = (column: string) => {
     if (sortColumn !== column) {
@@ -529,7 +622,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
   }, [openFilterColumn])
 
   const isClassAttendance = tableName === 'class-attendance'
-  const isWorkshopEnrollment = tableName === 'class-enrollment'
+  const isWorkshopEnrollment = isWorkshopEnrollmentTable
   const canInlineInsert = Boolean(editorConfig?.allowInsert)
   const canInlineUpdate = Boolean(editorConfig?.allowUpdate)
 
@@ -1000,6 +1093,11 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                       const shouldTruncate = columnMeta[column]?.truncate ?? tableVariant !== 'pivot'
                       const filterable = columnMeta[column]?.filterable ?? true
                       const cellValue = getCellValue(column, row, tableName)
+                      const maxChars = columnMeta[column]?.maxChars
+                      const displayValue =
+                        typeof maxChars === 'number' && maxChars > 0 && cellValue.length > maxChars
+                          ? `${cellValue.slice(0, maxChars)}...`
+                          : cellValue
                       const hoverCardData = hoverCardDataForCell(row, columnMeta[column]?.hoverCard)
 
                       const content = isFormNameLink ? (
@@ -1014,7 +1112,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                           className="underline decoration-dotted underline-offset-2 hover:text-primary"
                         >
                           <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                            {cellValue}
+                            {displayValue}
                           </span>
                         </Link>
                       ) : isFormAnswersLink ? (
@@ -1029,7 +1127,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                           className="underline decoration-dotted underline-offset-2 hover:text-primary"
                         >
                           <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                            {cellValue}
+                            {displayValue}
                           </span>
                         </Link>
                       ) : personLink ? (
@@ -1039,12 +1137,12 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                           className="underline decoration-dotted underline-offset-2 hover:text-primary"
                         >
                           <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                            {cellValue}
+                            {displayValue}
                           </span>
                         </Link>
                       ) : (
                         <span className={shouldTruncate ? 'block max-w-full truncate' : 'whitespace-normal break-words'}>
-                          {cellValue}
+                          {displayValue}
                         </span>
                       )
 

--- a/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
+++ b/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
@@ -1,0 +1,405 @@
+import { adminClient } from '@/lib/supabase/adminClient'
+
+const GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE = 'gift_card_store_preference'
+const RELATIONSHIP_BATCH_SIZE = 100
+const IN_CLAUSE_BATCH_SIZE = 250
+
+type RidingProfileRow = {
+  id: string
+  role: string | null
+  firstname: string | null
+  surname: string | null
+  email: string | null
+  federal_electoral_district_name: string | null
+}
+
+type GuardianChildEdge = {
+  guardian_profile_id: string
+  child_profile_id: string
+  primary_child: boolean
+}
+
+type FormSubmissionRow = {
+  id: string
+  profile_id: string | null
+  submitted_at: string | null
+}
+
+type FormAnswerRow = {
+  submission_id: string
+  value: unknown
+}
+
+export type WorkshopEnrollmentEnrichment = {
+  riding_display: string
+  giftcard_display: string
+  profile_hover_name: string
+  profile_hover_email: string
+  profile_hover_parent_email: string
+}
+
+const normalizeRiding = (value: unknown) =>
+  typeof value === 'string' && value.trim() ? value.trim() : null
+
+const normalizeText = (value: unknown) =>
+  typeof value === 'string' && value.trim() ? value.trim() : null
+
+const fullNameFromProfile = (profile: RidingProfileRow | null | undefined) => {
+  const firstname = normalizeText(profile?.firstname)
+  const surname = normalizeText(profile?.surname)
+  const fullName = [firstname, surname].filter(Boolean).join(' ').trim()
+  return fullName || null
+}
+
+const chunkArray = <T,>(items: T[], size: number): T[][] => {
+  if (size <= 0 || !items.length) return []
+
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+const pushEdge = (
+  map: Map<string, Array<{ profileId: string; primary: boolean }>>,
+  key: string,
+  profileId: string,
+  primary: boolean
+) => {
+  const current = map.get(key) ?? []
+  if (!current.some(item => item.profileId === profileId)) {
+    current.push({ profileId, primary })
+    current.sort((left, right) => Number(right.primary) - Number(left.primary))
+    map.set(key, current)
+  }
+}
+
+const preferredRelatedProfileId = (
+  map: Map<string, Array<{ profileId: string; primary: boolean }>>,
+  key: string
+) => map.get(key)?.[0]?.profileId ?? null
+
+export async function loadWorkshopEnrollmentEnrichment(profileIds: string[]) {
+  const normalizedProfileIds = Array.from(new Set(profileIds.filter(Boolean)))
+  const byProfileId: Record<string, WorkshopEnrollmentEnrichment> = {}
+
+  if (!normalizedProfileIds.length) {
+    return byProfileId
+  }
+
+  let profileById = new Map<string, RidingProfileRow>()
+  const guardiansByChildId = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  const childrenByGuardianId = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  const familyProfileIdsByProfileId = new Map<string, string[]>()
+  const mealKitByProfileId = new Map<string, boolean>()
+  let giftCardPreferenceByProfileId = new Map<string, string>()
+
+  const seen = new Set<string>(normalizedProfileIds)
+  const queue = [...normalizedProfileIds]
+  const familyEdges: GuardianChildEdge[] = []
+
+  while (queue.length) {
+    const batch = queue.splice(0, Math.min(queue.length, RELATIONSHIP_BATCH_SIZE))
+    const { data: batchEdges, error: familyEdgesError } = await adminClient
+      .from('person_guardian_child')
+      .select('guardian_profile_id, child_profile_id, primary_child')
+      .or(`guardian_profile_id.in.(${batch.join(',')}),child_profile_id.in.(${batch.join(',')})`)
+
+    if (familyEdgesError) {
+      console.error('[workshop enrollment] enrichment failed to load family edges', {
+        batchSize: batch.length,
+        error: familyEdgesError.message,
+      })
+      break
+    }
+
+    for (const edge of (batchEdges ?? []) as GuardianChildEdge[]) {
+      familyEdges.push(edge)
+      if (!seen.has(edge.guardian_profile_id)) {
+        seen.add(edge.guardian_profile_id)
+        queue.push(edge.guardian_profile_id)
+      }
+      if (!seen.has(edge.child_profile_id)) {
+        seen.add(edge.child_profile_id)
+        queue.push(edge.child_profile_id)
+      }
+    }
+  }
+
+  for (const edge of familyEdges) {
+    pushEdge(guardiansByChildId, edge.child_profile_id, edge.guardian_profile_id, edge.primary_child)
+    pushEdge(childrenByGuardianId, edge.guardian_profile_id, edge.child_profile_id, edge.primary_child)
+  }
+
+  const profileScope = Array.from(seen)
+  const familyAdjacency = new Map<string, Set<string>>()
+  for (const profileId of profileScope) {
+    if (!familyAdjacency.has(profileId)) {
+      familyAdjacency.set(profileId, new Set())
+    }
+  }
+
+  for (const edge of familyEdges) {
+    if (!familyAdjacency.has(edge.guardian_profile_id)) {
+      familyAdjacency.set(edge.guardian_profile_id, new Set())
+    }
+    if (!familyAdjacency.has(edge.child_profile_id)) {
+      familyAdjacency.set(edge.child_profile_id, new Set())
+    }
+    familyAdjacency.get(edge.guardian_profile_id)?.add(edge.child_profile_id)
+    familyAdjacency.get(edge.child_profile_id)?.add(edge.guardian_profile_id)
+  }
+
+  const profileRows: RidingProfileRow[] = []
+  for (const profileChunk of chunkArray(profileScope, IN_CLAUSE_BATCH_SIZE)) {
+    const { data, error } = await adminClient
+      .from('profile')
+      .select('id, role, firstname, surname, email, federal_electoral_district_name')
+      .in('id', profileChunk)
+
+    if (error) {
+      console.error('[workshop enrollment] enrichment failed to load profile rows', {
+        chunkSize: profileChunk.length,
+        error: error.message,
+      })
+      continue
+    }
+
+    profileRows.push(...((data ?? []) as RidingProfileRow[]))
+  }
+
+  if (!profileRows.length) {
+    return byProfileId
+  }
+
+  profileById = new Map(
+    profileRows
+      .filter(profile => typeof profile.id === 'string' && profile.id)
+      .map(profile => [profile.id, profile])
+  )
+
+  const visited = new Set<string>()
+  for (const rootProfileId of profileScope) {
+    if (visited.has(rootProfileId)) continue
+
+    const familyIds: string[] = []
+    const bfsQueue = [rootProfileId]
+    visited.add(rootProfileId)
+
+    while (bfsQueue.length) {
+      const currentProfileId = bfsQueue.shift()
+      if (!currentProfileId) continue
+      familyIds.push(currentProfileId)
+
+      for (const neighbor of familyAdjacency.get(currentProfileId) ?? []) {
+        if (visited.has(neighbor)) continue
+        visited.add(neighbor)
+        bfsQueue.push(neighbor)
+      }
+    }
+
+    familyIds.sort((left, right) => left.localeCompare(right))
+    for (const familyProfileId of familyIds) {
+      familyProfileIdsByProfileId.set(familyProfileId, familyIds)
+    }
+  }
+
+  const ridingNames = Array.from(
+    new Set(
+      profileRows
+        .map(profile => normalizeRiding(profile.federal_electoral_district_name))
+        .filter((riding): riding is string => Boolean(riding))
+    )
+  )
+
+  const mealKitByRidingName = new Map<string, boolean>()
+  if (ridingNames.length) {
+    for (const ridingChunk of chunkArray(ridingNames, IN_CLAUSE_BATCH_SIZE)) {
+      const { data: ridingRows, error: ridingRowsError } = await adminClient
+        .from('federal_electoral_district')
+        .select('name, meal_kit')
+        .in('name', ridingChunk)
+
+      if (ridingRowsError) {
+        console.error('[workshop enrollment] enrichment failed to load riding meal-kit rows', {
+          chunkSize: ridingChunk.length,
+          error: ridingRowsError.message,
+        })
+        continue
+      }
+
+      for (const riding of ridingRows ?? []) {
+        if (typeof riding.name !== 'string') continue
+        mealKitByRidingName.set(riding.name, riding.meal_kit === true)
+      }
+    }
+  }
+
+  for (const profile of profileById.values()) {
+    const ridingName = normalizeRiding(profile.federal_electoral_district_name)
+    if (!ridingName) {
+      mealKitByProfileId.set(profile.id, false)
+      continue
+    }
+
+    mealKitByProfileId.set(profile.id, mealKitByRidingName.get(ridingName) === true)
+  }
+
+  const submissions: FormSubmissionRow[] = []
+  for (const profileChunk of chunkArray(profileScope, IN_CLAUSE_BATCH_SIZE)) {
+    const { data: submissionRows, error } = await adminClient
+      .from('form_submission')
+      .select('id, profile_id, submitted_at')
+      .in('profile_id', profileChunk)
+
+    if (error) {
+      console.error('[workshop enrollment] enrichment failed to load form submissions', {
+        chunkSize: profileChunk.length,
+        error: error.message,
+      })
+      continue
+    }
+
+    submissions.push(...((submissionRows ?? []) as FormSubmissionRow[]))
+  }
+
+  if (submissions.length) {
+    const submissionIds = submissions
+      .map(submission => submission.id)
+      .filter((submissionId): submissionId is string => Boolean(submissionId))
+
+    if (submissionIds.length) {
+      const answerRows: FormAnswerRow[] = []
+      for (const submissionChunk of chunkArray(submissionIds, IN_CLAUSE_BATCH_SIZE)) {
+        const { data, error } = await adminClient
+          .from('form_answer')
+          .select('submission_id, value')
+          .eq('question_code', GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
+          .in('submission_id', submissionChunk)
+
+        if (error) {
+          console.error('[workshop enrollment] enrichment failed to load gift card answers', {
+            chunkSize: submissionChunk.length,
+            error: error.message,
+          })
+          continue
+        }
+
+        answerRows.push(...((data ?? []) as FormAnswerRow[]))
+      }
+
+      if (answerRows.length) {
+        const submissionById = new Map(submissions.map(submission => [submission.id, submission]))
+        const latestGiftCardByProfileId = new Map<string, { value: string; submittedAt: number }>()
+
+        for (const answer of answerRows) {
+          const submission = submissionById.get(answer.submission_id)
+          const profileId = submission?.profile_id
+          if (!profileId) continue
+
+          const value = typeof answer.value === 'string' ? answer.value.trim() : ''
+          if (!value) continue
+
+          const submittedAt = Date.parse(submission?.submitted_at ?? '')
+          const submittedAtTime = Number.isNaN(submittedAt) ? 0 : submittedAt
+          const existing = latestGiftCardByProfileId.get(profileId)
+
+          if (!existing || submittedAtTime > existing.submittedAt) {
+            latestGiftCardByProfileId.set(profileId, {
+              value,
+              submittedAt: submittedAtTime,
+            })
+          }
+        }
+
+        giftCardPreferenceByProfileId = new Map(
+          Array.from(latestGiftCardByProfileId.entries()).map(([profileId, entry]) => [profileId, entry.value])
+        )
+      }
+    }
+  }
+
+  for (const profileId of normalizedProfileIds) {
+    const enrollmentProfile = profileById.get(profileId) ?? null
+
+    const inferredStudentProfileId = (() => {
+      if (!profileId) return null
+      if (enrollmentProfile?.role === 'student') return profileId
+      if (enrollmentProfile?.role === 'guardian') {
+        return preferredRelatedProfileId(childrenByGuardianId, profileId)
+      }
+
+      const directChild = preferredRelatedProfileId(childrenByGuardianId, profileId)
+      if (directChild) return directChild
+      return profileId
+    })()
+
+    const studentRiding = inferredStudentProfileId
+      ? normalizeRiding(profileById.get(inferredStudentProfileId)?.federal_electoral_district_name)
+      : null
+
+    const inferredParentProfileId = (() => {
+      if (!profileId) return null
+      if (inferredStudentProfileId) {
+        const guardianId = preferredRelatedProfileId(guardiansByChildId, inferredStudentProfileId)
+        if (guardianId) return guardianId
+      }
+      if (enrollmentProfile?.role === 'guardian') return profileId
+      return preferredRelatedProfileId(guardiansByChildId, profileId)
+    })()
+
+    const parentRiding = inferredParentProfileId
+      ? normalizeRiding(profileById.get(inferredParentProfileId)?.federal_electoral_district_name)
+      : null
+
+    const ridingDisplay =
+      studentRiding ?? parentRiding ?? normalizeRiding(enrollmentProfile?.federal_electoral_district_name) ?? ''
+
+    const profileHoverName = fullNameFromProfile(enrollmentProfile) ?? 'N/A'
+    const profileHoverEmail = normalizeText(enrollmentProfile?.email) ?? 'N/A'
+    const profileHoverParentEmail = inferredParentProfileId
+      ? normalizeText(profileById.get(inferredParentProfileId)?.email) ?? 'N/A'
+      : 'N/A'
+
+    const candidateProfileIds: string[] = []
+    const addCandidate = (candidateId: string | null) => {
+      if (!candidateId || candidateProfileIds.includes(candidateId)) return
+      candidateProfileIds.push(candidateId)
+    }
+
+    addCandidate(inferredStudentProfileId)
+    addCandidate(inferredParentProfileId)
+
+    for (const familyProfileId of familyProfileIdsByProfileId.get(profileId) ?? []) {
+      addCandidate(familyProfileId)
+    }
+
+    addCandidate(profileId || null)
+
+    const giftcardDisplay = (() => {
+      for (const candidateProfileId of candidateProfileIds) {
+        if (mealKitByProfileId.get(candidateProfileId) === true) {
+          return 'Meal Kit'
+        }
+
+        const giftCardChoice = giftCardPreferenceByProfileId.get(candidateProfileId)
+        if (giftCardChoice) {
+          return giftCardChoice
+        }
+      }
+
+      return 'N/A'
+    })()
+
+    byProfileId[profileId] = {
+      riding_display: ridingDisplay,
+      giftcard_display: giftcardDisplay,
+      profile_hover_name: profileHoverName,
+      profile_hover_email: profileHoverEmail,
+      profile_hover_parent_email: profileHoverParentEmail,
+    }
+  }
+
+  return byProfileId
+}

--- a/web/app/routes/manage/workshop-enrollment.enrichment.ts
+++ b/web/app/routes/manage/workshop-enrollment.enrichment.ts
@@ -1,0 +1,25 @@
+import { requireAuth } from '@/lib/auth.server'
+import { isRoleAtLeast } from '@/lib/roles'
+import { loadWorkshopEnrollmentEnrichment } from './workshop-enrollment-enrichment.server'
+
+import type { Route } from './+types/workshop-enrollment.enrichment'
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'staff')) {
+    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const url = new URL(request.url)
+  const profileIds = url.searchParams
+    .getAll('profileId')
+    .map(value => value.trim())
+    .filter(Boolean)
+
+  if (!profileIds.length) {
+    return Response.json({ byProfileId: {} }, { headers: auth.headers })
+  }
+
+  const byProfileId = await loadWorkshopEnrollmentEnrichment(profileIds)
+  return Response.json({ byProfileId }, { headers: auth.headers })
+}

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -22,10 +22,6 @@ const ENROLLMENT_STATUS_ORDER: Record<Database['public']['Enums']['workshop_enro
   rejected: 4,
 }
 
-const GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE = 'gift_card_store_preference'
-const RELATIONSHIP_BATCH_SIZE = 100
-const IN_CLAUSE_BATCH_SIZE = 250
-
 const toTime = (value: unknown) => {
   if (typeof value !== 'string' || !value) return Number.POSITIVE_INFINITY
   const parsed = Date.parse(value)
@@ -58,74 +54,6 @@ const parseEnrollmentField = (
 
   return { value, valid: true }
 }
-
-type RidingProfileRow = {
-  id: string
-  role: string | null
-  firstname: string | null
-  surname: string | null
-  email: string | null
-  federal_electoral_district_name: string | null
-}
-
-type GuardianChildEdge = {
-  guardian_profile_id: string
-  child_profile_id: string
-  primary_child: boolean
-}
-
-type FormSubmissionRow = {
-  id: string
-  profile_id: string | null
-  submitted_at: string | null
-}
-
-type FormAnswerRow = {
-  submission_id: string
-  value: unknown
-}
-
-const normalizeRiding = (value: unknown) =>
-  typeof value === 'string' && value.trim() ? value.trim() : null
-
-const normalizeText = (value: unknown) =>
-  typeof value === 'string' && value.trim() ? value.trim() : null
-
-const fullNameFromProfile = (profile: RidingProfileRow | null | undefined) => {
-  const firstname = normalizeText(profile?.firstname)
-  const surname = normalizeText(profile?.surname)
-  const fullName = [firstname, surname].filter(Boolean).join(' ').trim()
-  return fullName || null
-}
-
-const chunkArray = <T,>(items: T[], size: number): T[][] => {
-  if (size <= 0 || !items.length) return []
-
-  const chunks: T[][] = []
-  for (let index = 0; index < items.length; index += size) {
-    chunks.push(items.slice(index, index + size))
-  }
-  return chunks
-}
-
-const pushEdge = (
-  map: Map<string, Array<{ profileId: string; primary: boolean }>>,
-  key: string,
-  profileId: string,
-  primary: boolean
-) => {
-  const current = map.get(key) ?? []
-  if (!current.some(item => item.profileId === profileId)) {
-    current.push({ profileId, primary })
-    current.sort((left, right) => Number(right.primary) - Number(left.primary))
-    map.set(key, current)
-  }
-}
-
-const preferredRelatedProfileId = (
-  map: Map<string, Array<{ profileId: string; primary: boolean }>>,
-  key: string
-) => map.get(key)?.[0]?.profileId ?? null
 
 export async function loader(args: Route.LoaderArgs) {
   const auth = await requireAuth(args.request)
@@ -192,238 +120,6 @@ export async function loader(args: Route.LoaderArgs) {
     }
   }
 
-  let profileById = new Map<string, RidingProfileRow>()
-  let guardiansByChildId = new Map<string, Array<{ profileId: string; primary: boolean }>>()
-  let childrenByGuardianId = new Map<string, Array<{ profileId: string; primary: boolean }>>()
-  let familyProfileIdsByProfileId = new Map<string, string[]>()
-  let mealKitByProfileId = new Map<string, boolean>()
-  let giftCardPreferenceByProfileId = new Map<string, string>()
-
-  if (profileIds.length) {
-    const seen = new Set<string>(profileIds)
-    const queue = [...profileIds]
-    const familyEdges: GuardianChildEdge[] = []
-
-    while (queue.length) {
-      const batch = queue.splice(0, Math.min(queue.length, RELATIONSHIP_BATCH_SIZE))
-      const { data: batchEdges, error: familyEdgesError } = await adminClient
-        .from('person_guardian_child')
-        .select('guardian_profile_id, child_profile_id, primary_child')
-        .or(`guardian_profile_id.in.(${batch.join(',')}),child_profile_id.in.(${batch.join(',')})`)
-
-      if (familyEdgesError) {
-        console.error('[workshop enrollment] failed to load family edges', {
-          batchSize: batch.length,
-          error: familyEdgesError.message,
-        })
-        break
-      }
-
-      for (const edge of (batchEdges ?? []) as GuardianChildEdge[]) {
-        familyEdges.push(edge)
-        if (!seen.has(edge.guardian_profile_id)) {
-          seen.add(edge.guardian_profile_id)
-          queue.push(edge.guardian_profile_id)
-        }
-        if (!seen.has(edge.child_profile_id)) {
-          seen.add(edge.child_profile_id)
-          queue.push(edge.child_profile_id)
-        }
-      }
-    }
-
-    for (const edge of familyEdges) {
-      pushEdge(guardiansByChildId, edge.child_profile_id, edge.guardian_profile_id, edge.primary_child)
-      pushEdge(childrenByGuardianId, edge.guardian_profile_id, edge.child_profile_id, edge.primary_child)
-    }
-
-    const profileScope = Array.from(seen)
-    const familyAdjacency = new Map<string, Set<string>>()
-    for (const profileId of profileScope) {
-      if (!familyAdjacency.has(profileId)) {
-        familyAdjacency.set(profileId, new Set())
-      }
-    }
-
-    for (const edge of familyEdges) {
-      if (!familyAdjacency.has(edge.guardian_profile_id)) {
-        familyAdjacency.set(edge.guardian_profile_id, new Set())
-      }
-      if (!familyAdjacency.has(edge.child_profile_id)) {
-        familyAdjacency.set(edge.child_profile_id, new Set())
-      }
-      familyAdjacency.get(edge.guardian_profile_id)?.add(edge.child_profile_id)
-      familyAdjacency.get(edge.child_profile_id)?.add(edge.guardian_profile_id)
-    }
-
-    const profileRows: RidingProfileRow[] = []
-    for (const profileChunk of chunkArray(profileScope, IN_CLAUSE_BATCH_SIZE)) {
-      const { data, error } = await adminClient
-        .from('profile')
-        .select('id, role, firstname, surname, email, federal_electoral_district_name')
-        .in('id', profileChunk)
-
-      if (error) {
-        console.error('[workshop enrollment] failed to load profile rows', {
-          chunkSize: profileChunk.length,
-          error: error.message,
-        })
-        continue
-      }
-
-      profileRows.push(...((data ?? []) as RidingProfileRow[]))
-    }
-
-    if (profileRows.length) {
-      profileById = new Map(
-        profileRows
-          .filter(profile => typeof profile.id === 'string' && profile.id)
-          .map(profile => [profile.id, profile])
-      )
-
-      const visited = new Set<string>()
-      for (const rootProfileId of profileScope) {
-        if (visited.has(rootProfileId)) continue
-
-        const familyIds: string[] = []
-        const bfsQueue = [rootProfileId]
-        visited.add(rootProfileId)
-
-        while (bfsQueue.length) {
-          const currentProfileId = bfsQueue.shift()
-          if (!currentProfileId) continue
-          familyIds.push(currentProfileId)
-
-          for (const neighbor of familyAdjacency.get(currentProfileId) ?? []) {
-            if (visited.has(neighbor)) continue
-            visited.add(neighbor)
-            bfsQueue.push(neighbor)
-          }
-        }
-
-        familyIds.sort((left, right) => left.localeCompare(right))
-        for (const familyProfileId of familyIds) {
-          familyProfileIdsByProfileId.set(familyProfileId, familyIds)
-        }
-      }
-
-      const ridingNames = Array.from(
-        new Set(
-          profileRows
-            .map(profile => normalizeRiding(profile.federal_electoral_district_name))
-            .filter((riding): riding is string => Boolean(riding))
-        )
-      )
-
-      const mealKitByRidingName = new Map<string, boolean>()
-      if (ridingNames.length) {
-        for (const ridingChunk of chunkArray(ridingNames, IN_CLAUSE_BATCH_SIZE)) {
-          const { data: ridingRows, error: ridingRowsError } = await adminClient
-            .from('federal_electoral_district')
-            .select('name, meal_kit')
-            .in('name', ridingChunk)
-
-          if (ridingRowsError) {
-            console.error('[workshop enrollment] failed to load riding meal-kit rows', {
-              chunkSize: ridingChunk.length,
-              error: ridingRowsError.message,
-            })
-            continue
-          }
-
-          for (const riding of ridingRows ?? []) {
-            if (typeof riding.name !== 'string') continue
-            mealKitByRidingName.set(riding.name, riding.meal_kit === true)
-          }
-        }
-      }
-
-      for (const profile of profileById.values()) {
-        const ridingName = normalizeRiding(profile.federal_electoral_district_name)
-        if (!ridingName) {
-          mealKitByProfileId.set(profile.id, false)
-          continue
-        }
-
-        mealKitByProfileId.set(profile.id, mealKitByRidingName.get(ridingName) === true)
-      }
-
-      const submissions: FormSubmissionRow[] = []
-      for (const profileChunk of chunkArray(profileScope, IN_CLAUSE_BATCH_SIZE)) {
-        const { data: submissionRows, error } = await adminClient
-          .from('form_submission')
-          .select('id, profile_id, submitted_at')
-          .in('profile_id', profileChunk)
-
-        if (error) {
-          console.error('[workshop enrollment] failed to load form submissions', {
-            chunkSize: profileChunk.length,
-            error: error.message,
-          })
-          continue
-        }
-
-        submissions.push(...((submissionRows ?? []) as FormSubmissionRow[]))
-      }
-
-      if (submissions.length) {
-        const submissionIds = submissions
-          .map(submission => submission.id)
-          .filter((submissionId): submissionId is string => Boolean(submissionId))
-
-        if (submissionIds.length) {
-          const answerRows: FormAnswerRow[] = []
-          for (const submissionChunk of chunkArray(submissionIds, IN_CLAUSE_BATCH_SIZE)) {
-            const { data, error } = await adminClient
-              .from('form_answer')
-              .select('submission_id, value')
-              .eq('question_code', GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
-              .in('submission_id', submissionChunk)
-
-            if (error) {
-              console.error('[workshop enrollment] failed to load gift card answers', {
-                chunkSize: submissionChunk.length,
-                error: error.message,
-              })
-              continue
-            }
-
-            answerRows.push(...((data ?? []) as FormAnswerRow[]))
-          }
-
-          if (answerRows.length) {
-            const submissionById = new Map(submissions.map(submission => [submission.id, submission]))
-            const latestGiftCardByProfileId = new Map<string, { value: string; submittedAt: number }>()
-
-            for (const answer of answerRows) {
-              const submission = submissionById.get(answer.submission_id)
-              const profileId = submission?.profile_id
-              if (!profileId) continue
-
-              const value = typeof answer.value === 'string' ? answer.value.trim() : ''
-              if (!value) continue
-
-              const submittedAt = Date.parse(submission?.submitted_at ?? '')
-              const submittedAtTime = Number.isNaN(submittedAt) ? 0 : submittedAt
-              const existing = latestGiftCardByProfileId.get(profileId)
-
-              if (!existing || submittedAtTime > existing.submittedAt) {
-                latestGiftCardByProfileId.set(profileId, {
-                  value,
-                  submittedAt: submittedAtTime,
-                })
-              }
-            }
-
-            giftCardPreferenceByProfileId = new Map(
-              Array.from(latestGiftCardByProfileId.entries()).map(([profileId, entry]) => [profileId, entry.value])
-            )
-          }
-        }
-      }
-    }
-  }
-
   const enrichedRows: Array<Record<string, unknown>> = rows.map(row => {
     const workshopId = typeof row.workshop_id === 'string' ? row.workshop_id : ''
     const approved = workshopId ? approvedByWorkshopId.get(workshopId) ?? 0 : 0
@@ -431,83 +127,15 @@ export async function loader(args: Route.LoaderArgs) {
 
     const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
     const profileSignals = profileId ? openSignalsByProfileId.get(profileId) ?? [] : []
-    const enrollmentProfile = profileId ? profileById.get(profileId) ?? null : null
-
-    const inferredStudentProfileId = (() => {
-      if (!profileId) return null
-      if (enrollmentProfile?.role === 'student') return profileId
-      if (enrollmentProfile?.role === 'guardian') {
-        return preferredRelatedProfileId(childrenByGuardianId, profileId)
-      }
-
-      const directChild = preferredRelatedProfileId(childrenByGuardianId, profileId)
-      if (directChild) return directChild
-      return profileId
-    })()
-
-    const studentRiding = inferredStudentProfileId
-      ? normalizeRiding(profileById.get(inferredStudentProfileId)?.federal_electoral_district_name)
-      : null
-
-    const inferredParentProfileId = (() => {
-      if (!profileId) return null
-      if (inferredStudentProfileId) {
-        const guardianId = preferredRelatedProfileId(guardiansByChildId, inferredStudentProfileId)
-        if (guardianId) return guardianId
-      }
-      if (enrollmentProfile?.role === 'guardian') return profileId
-      return preferredRelatedProfileId(guardiansByChildId, profileId)
-    })()
-
-    const parentRiding = inferredParentProfileId
-      ? normalizeRiding(profileById.get(inferredParentProfileId)?.federal_electoral_district_name)
-      : null
-
-    const ridingDisplay = studentRiding ?? parentRiding ?? normalizeRiding(enrollmentProfile?.federal_electoral_district_name) ?? ''
-    const profileHoverName = fullNameFromProfile(enrollmentProfile) ?? 'N/A'
-    const profileHoverEmail = normalizeText(enrollmentProfile?.email) ?? 'N/A'
-    const profileHoverParentEmail = inferredParentProfileId
-      ? normalizeText(profileById.get(inferredParentProfileId)?.email) ?? 'N/A'
-      : 'N/A'
-
-    const candidateProfileIds: string[] = []
-    const addCandidate = (candidateId: string | null) => {
-      if (!candidateId || candidateProfileIds.includes(candidateId)) return
-      candidateProfileIds.push(candidateId)
-    }
-
-    addCandidate(inferredStudentProfileId)
-    addCandidate(inferredParentProfileId)
-
-    for (const familyProfileId of familyProfileIdsByProfileId.get(profileId) ?? []) {
-      addCandidate(familyProfileId)
-    }
-
-    addCandidate(profileId || null)
-
-    const giftcardDisplay = (() => {
-      for (const candidateProfileId of candidateProfileIds) {
-        if (mealKitByProfileId.get(candidateProfileId) === true) {
-          return 'Meal Kit'
-        }
-
-        const giftCardChoice = giftCardPreferenceByProfileId.get(candidateProfileId)
-        if (giftCardChoice) {
-          return giftCardChoice
-        }
-      }
-
-      return 'N/A'
-    })()
 
     const baseRow = {
       ...row,
       enrolled_capacity: capacity === null ? `${approved}/-` : `${approved}/${capacity}`,
-      riding_display: ridingDisplay,
-      giftcard_display: giftcardDisplay,
-      profile_hover_name: profileHoverName,
-      profile_hover_email: profileHoverEmail,
-      profile_hover_parent_email: profileHoverParentEmail,
+      riding_display: '...',
+      giftcard_display: '...',
+      profile_hover_name: '',
+      profile_hover_email: '',
+      profile_hover_parent_email: '',
     }
 
     if (!profileSignals.length) {
@@ -583,7 +211,14 @@ export async function loader(args: Route.LoaderArgs) {
 
   const baseColumnMeta = (base.columnMeta ?? {}) as Record<
     string,
-    { label?: string; truncate?: boolean; filterable?: boolean; numeric?: boolean }
+    {
+      label?: string
+      truncate?: boolean
+      filterable?: boolean
+      numeric?: boolean
+      maxChars?: number
+      hoverCard?: unknown
+    }
   >
 
   return {
@@ -611,6 +246,7 @@ export async function loader(args: Route.LoaderArgs) {
       },
       giftcard_display: {
         label: 'giftcard',
+        maxChars: 6,
       },
     },
     canEditStatus: isRoleAtLeast(auth.claims.role, 'staff'),


### PR DESCRIPTION
## What changed
- moves workshop-enrollment heavy profile/family/riding/giftcard derivation into a dedicated enrichment endpoint
- keeps main workshop-enrollment loader lightweight so table renders quickly with placeholders first
- async-loads enrichment for visible class-enrollment rows in TableDisplay
- adds a new manage route: workshop-enrollment/enrichment
- truncates displayed giftcard values to 6 characters via column metadata

## Verification
- npm run typecheck (from web/)