### PR TITLE
Use TableDisplay for person submissions answers navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,38 @@
 # AGENTS.md
 
-High-signal guidance for OpenCode sessions in this repo.
+## Repo shape
+- Runtime app lives in `web/` (React Router v7 SSR + Vite + TypeScript + Supabase).
+- Use `web/package.json` scripts for app work; root `package.json` has no scripts.
+- Routing is explicitly declared in `web/app/routes.ts` (not filesystem auto-routing).
+- App shell and auth/onboarding guard wiring start in `web/app/root.tsx`.
+- Path aliases `~/` and `@/` both map to `web/app/*` (`web/tsconfig.json`).
 
-## Repo shape and entrypoints
-- Runtime app is `web/` (React Router v7 SSR + Vite + TS strict + Supabase).
-- Root `package.json` is not the app command source of truth; use `web/package.json` scripts.
-- App shell starts in `web/app/root.tsx`; route table is manually maintained in `web/app/routes.ts`.
-- Path aliases `~/` and `@/` both resolve to `web/app` (`web/tsconfig.json`).
+## Setup and env
+- First-time local setup: `cp web/.env.template web/.env.local` from repo root.
+- Start Supabase from repo root: `supabase start --debug`, then pull keys with `supabase status -o json` into `web/.env.local`.
+- Local app/test URL is `http://localhost:5173`.
+- `ONBOARDING_MODE` resolves to `role` unless explicitly set to `permission` (`web/app/lib/auth.server.ts`).
+- `SUPABASE_SECRET_KEY` is service-role only; never expose it to client code or loader-returned data.
 
-## Setup and environment
-- First-time local setup: copy `web/.env.template` to `web/.env.local`, then run Supabase locally and fill keys from `supabase status -o json`.
-- Local app/test base URL is `http://localhost:5173`.
-- `ONBOARDING_MODE` defaults to role-based behavior (`role` unless explicitly set to `permission` in server env).
-- Keep `SUPABASE_SECRET_KEY` server-only; never expose it in client code or loader data.
+## Commands
+- Install deps: `npm ci` in `web/` (CI uses `npm ci`; `npm install` is fine for local updates).
+- Dev server: `npm run dev` (from `web/`).
+- Typecheck gate: `npm run typecheck` (also regenerates React Router types).
+- Build/start: `npm run build` then `npm run start` (from `web/`).
+- Tests: `npm run test` (Playwright).
+- Focused tests: `npm run test:e2e -- tests/e2e/guardian-signup-enroll.spec.ts --grep "..."`.
+- `npm run test:unit` currently points to `tests/unit` with `--pass-with-no-tests`; this repo currently only has `tests/e2e/`.
 
-## Commands (run from `web/`)
-- Install deps: `npm install`
-- Dev server: `npm run dev`
-- Type gate (required before handoff): `npm run typecheck` (`react-router typegen && tsc`)
-- Build/serve: `npm run build` then `npm run start`
-- Tests: `npm run test` (Playwright over `tests/`)
-- Scoped tests: `npm run test:e2e`, `npm run test:unit`
+## Database and schema workflow
+- Source of truth is declarative SQL in `supabase/schemas/` (see `CODE_STANDARDS.md`).
+- Do not manually edit existing files in `supabase/migrations/`; generate forward migrations instead.
+- Typical flow from repo root: edit schema SQL -> `supabase db diff -f <name>` -> `supabase migration up`.
+- Regenerate DB types after schema changes: `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
+- New tables/features need matching `app_permissions` + `role_permission` seeds and RLS policies in the same change (`CODE_STANDARDS.md`).
 
-## Playwright quirks and focused runs
-- If `PLAYWRIGHT_BASE_URL` is unset, Playwright auto-starts `npm run dev -- --port 5173`.
-- Single e2e file: `npm run test:e2e -- tests/e2e/guardian-signup-enroll.spec.ts`
-- File + title filter: `npm run test:e2e -- tests/e2e/guardian-signup-enroll.spec.ts --grep "guardian signs up"`
-- Title-only filter: `npm run test:e2e -- --grep "guardian signs up, completes pre-program survey, and enrolls"`
-
-## Supabase workflow
-- Start local services from repo root: `supabase start --debug`; inspect keys/status with `supabase status -o json`.
-- Create migrations with CLI (`supabase migration new <name>`); do not hand-create or rename versions in `supabase/migrations/`.
-- Do not edit already-committed migrations; add a new forward-fix migration instead.
-- Typical schema flow: edit `supabase/schemas/*.sql` -> `supabase db diff -f <name>` -> `supabase migration up`.
-- After schema changes, regenerate DB types: `supabase gen types typescript --local > web/app/lib/database.types.ts`.
-
-## Generated files and auth/session gotchas
-- Never manually edit generated router types in `web/.react-router/types/`.
-- Route modules commonly import generated `./+types/*`; rerun `npm run typecheck` after route changes.
-- Server auth helpers (`web/app/lib/supabase/server.ts`) return `headers`; preserve/pass these headers on auth redirects/responses or sessions can break.
-- Email templates under `supabase/templates/` are inline-styled HTML; keep styles inline (no `<style>` blocks).
-
-## Performance diagnostics conventions
-- Keep submit buttons disabled for the full mutation transition (`submitting` + `loading`) on signup, enrollment, family-management, and survey forms to prevent duplicate writes.
-- Client router timing logs are emitted from `web/app/lib/router-instrumentation.ts`; enable in production with `VITE_ENABLE_ROUTER_INSTRUMENTATION=true`.
-- Treat suspicious-signal refresh and enrollment notification dispatch as async side effects; do not block user-visible responses on them.
+## Gotchas that break flows
+- Never edit generated router types in `web/.react-router/types/`.
+- If you add/move a route file, also update `web/app/routes.ts` or it will 404.
+- `createClient()` in `web/app/lib/supabase/server.ts` returns response `headers`; preserve/pass them on redirects and responses to avoid auth session bugs.
+- Playwright auto-starts `npm run dev -- --port 5173` when `PLAYWRIGHT_BASE_URL` is unset (`web/playwright.config.ts`).
+- Email templates configured in `supabase/config.toml` live under `supabase/templates/` and are inline-HTML templates.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "supperlunchplus"
+project_id = "summerlunchplus"
 
 [api]
 enabled = true

--- a/web/app/routes/manage/form.$id.answers.tsx
+++ b/web/app/routes/manage/form.$id.answers.tsx
@@ -44,6 +44,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const { supabase, headers } = createClient(request)
   const url = new URL(request.url)
+  const submissionId = url.searchParams.get('submissionId')
   const { data: formRow, error: formError } = await supabase
     .from('form')
     .select('id, name')
@@ -66,10 +67,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const answerColumns = (questionRows ?? []).map(row => String(row.question_code ?? ''))
 
-  const { data: submissionRows, error: submissionError } = await supabase
+  let submissionQuery = supabase
     .from('form_submission')
     .select('id, profile_id, submitted_at, profile:profile_id ( id, firstname, surname, email )')
     .eq('form_id', formId)
+
+  if (submissionId) {
+    submissionQuery = submissionQuery.eq('id', submissionId)
+  }
+
+  const { data: submissionRows, error: submissionError } = await submissionQuery
     .order('submitted_at', { ascending: false })
 
   if (submissionError) {
@@ -133,6 +140,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function ManageFormAnswersPage() {
   const { form, returnTo } = useLoaderData() as LoaderData
+  const backLabel = returnTo.startsWith('/manage/person') ? 'Back to person' : 'Back to forms'
 
   return (
     <TableDisplay
@@ -149,7 +157,7 @@ export default function ManageFormAnswersPage() {
             </Link>
           </Button>
           <Button asChild variant="outline" size="sm">
-            <Link to={returnTo}>Back to forms</Link>
+            <Link to={returnTo}>{backLabel}</Link>
           </Button>
         </div>
       }

--- a/web/app/routes/manage/person.form-submissions.tsx
+++ b/web/app/routes/manage/person.form-submissions.tsx
@@ -1,14 +1,7 @@
 import { useMemo } from 'react'
 import { useOutletContext } from 'react-router'
 
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
+import TableDisplay from './table-display'
 
 import type { PersonLoaderData } from './person.shared'
 import { formatDateTime, profileLabel } from './person.shared'
@@ -27,41 +20,43 @@ export default function ManagePersonFormSubmissionsPage() {
     [familyProfiles]
   )
 
+  const rows = formSubmissions.map(submission => {
+    const submittedBy =
+      (submission.profile_id ? profileById.get(submission.profile_id) : null) ||
+      (submission.user_id ? profileByUserId.get(submission.user_id) : null)
+
+    const submittedByFallback = submission.profile_id ?? submission.user_id
+
+    return {
+      id: submission.id,
+      form_id: submission.form_id,
+      submitted_by: submittedBy
+        ? profileLabel(submittedBy)
+        : submittedByFallback
+          ? submittedByFallback.slice(0, 8)
+          : '-',
+      form_name: formNameById[submission.form_id] ?? submission.form_id.slice(0, 8),
+      submitted_at: formatDateTime(submission.submitted_at),
+      submission_id: submission.id,
+      view_answers: 'View answers',
+    }
+  })
+
   return (
-    <section className="space-y-3 rounded-lg border bg-card p-4">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Form submissions</h2>
-      {formSubmissions.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No form submissions found for this family.</p>
-      ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Submitted by</TableHead>
-              <TableHead>Form</TableHead>
-              <TableHead>Submitted at</TableHead>
-              <TableHead>Submission ID</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {formSubmissions.map(submission => {
-              const submittedBy =
-                (submission.profile_id ? profileById.get(submission.profile_id) : null) ||
-                (submission.user_id ? profileByUserId.get(submission.user_id) : null)
-
-              const submittedByFallback = submission.profile_id ?? submission.user_id
-
-              return (
-                <TableRow key={submission.id}>
-                  <TableCell>{submittedBy ? profileLabel(submittedBy) : submittedByFallback ? submittedByFallback.slice(0, 8) : '-'}</TableCell>
-                  <TableCell>{formNameById[submission.form_id] ?? submission.form_id.slice(0, 8)}</TableCell>
-                  <TableCell>{formatDateTime(submission.submitted_at)}</TableCell>
-                  <TableCell className="font-mono text-xs">{submission.id}</TableCell>
-                </TableRow>
-              )
-            })}
-          </TableBody>
-        </Table>
-      )}
-    </section>
+    <TableDisplay
+      data={{
+        columns: ['submitted_by', 'form_name', 'submitted_at', 'submission_id', 'view_answers'],
+        rows,
+        label: 'Form submissions',
+        tableName: 'person-form-submissions',
+        columnMeta: {
+          submitted_by: { label: 'Submitted by' },
+          form_name: { label: 'Form' },
+          submitted_at: { label: 'Submitted at' },
+          submission_id: { label: 'Submission ID', truncate: true },
+          view_answers: { label: 'Answers', filterable: false },
+        },
+      }}
+    />
   )
 }

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -847,8 +847,8 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
     : []
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className="-mx-6 flex min-w-0 flex-col gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-3 px-6">
         <div>
           <h1 className="text-2xl font-semibold">{label}</h1>
           <p className="text-sm text-muted-foreground">
@@ -860,7 +860,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
       </div>
 
       {canInlineInsert ? (
-        <section className="relative z-30 overflow-visible rounded-lg border bg-card p-4">
+        <section className="relative z-30 mx-6 overflow-visible rounded-lg border bg-card p-4">
           <div className="flex items-center justify-between">
             <h2 className="text-sm font-semibold">Add row</h2>
             <button
@@ -895,9 +895,9 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
         </section>
       ) : null}
 
-      {editorFetcher.data?.error ? <p className="text-sm text-destructive">{editorFetcher.data.error}</p> : null}
+      {editorFetcher.data?.error ? <p className="px-6 text-sm text-destructive">{editorFetcher.data.error}</p> : null}
 
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 px-6">
         <p className="text-xs text-muted-foreground">
           Page {effectivePage} of {totalPages}
         </p>
@@ -940,7 +940,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-lg border">
+      <div className="min-w-0 overflow-x-auto border-y">
         <table className="w-full table-auto text-sm">
           <thead className="bg-muted/40 text-[11px] uppercase tracking-widest text-muted-foreground">
             <tr>

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -847,7 +847,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
     : []
 
   return (
-    <div className="-mx-6 flex w-[calc(100%+3rem)] min-w-0 flex-col gap-4">
+    <div className="-mx-6 flex min-w-0 flex-col gap-4">
       <div className="flex flex-wrap items-start justify-between gap-3 px-6">
         <div>
           <h1 className="text-2xl font-semibold">{label}</h1>
@@ -940,7 +940,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
         </div>
       </div>
 
-      <div className="min-w-0 overflow-x-auto border-y">
+      <div className="min-w-0 overflow-x-auto overflow-y-hidden border-y">
         <table className="w-full table-auto text-sm">
           <thead className="bg-muted/40 text-[11px] uppercase tracking-widest text-muted-foreground">
             <tr>

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import { Link, useFetcher, useLoaderData, useLocation, useSearchParams } from 'react-router'
 import { Filter } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import { Combobox } from '@/components/ui/combobox'
 import { Constants, type Database } from '@/lib/database.types'
 import { getOffsetMinutesForLocalDateTime, toLocalDateTimeInputValue } from '@/lib/datetime'
@@ -243,9 +244,12 @@ const personLinkForCell = (
 
 type TableDisplayProps = {
   headerActions?: ReactNode
+  data?: LoaderData
 }
 
-export default function TableDisplay({ headerActions }: TableDisplayProps = {}) {
+export default function TableDisplay({ headerActions, data }: TableDisplayProps = {}) {
+  const routeData = useLoaderData() as LoaderData | undefined
+  const source = data ?? routeData
   const {
     columns = [],
     rows = [],
@@ -256,7 +260,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
     canEditStatus,
     editorConfig,
     foreignKeyOptions = {},
-  } = useLoaderData() as LoaderData
+  } = source ?? ({} as LoaderData)
   const location = useLocation()
 
   const statusFetcher = useFetcher()
@@ -1083,6 +1087,31 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
                             >
                               Resend
                             </button>
+                          </td>
+                        )
+                      }
+
+                      if (tableName === 'person-form-submissions' && column === 'view_answers') {
+                        const formId = typeof row.form_id === 'string' ? row.form_id : ''
+                        const submissionId = typeof row.id === 'string' ? row.id : ''
+                        const returnTo = `${location.pathname}${location.search}`
+
+                        return (
+                          <td key={`cell-${absoluteRowIndex}-${column}`} className="px-4 py-2" title="View form answers">
+                            <Button asChild variant="outline" size="xs">
+                              <Link
+                                to={{
+                                  pathname: `/manage/form/${formId}/answers`,
+                                  search: new URLSearchParams({
+                                    returnTo,
+                                    submissionId,
+                                  }).toString(),
+                                }}
+                                onClick={event => event.stopPropagation()}
+                              >
+                                View answers
+                              </Link>
+                            </Button>
                           </td>
                         )
                       }

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -940,8 +940,8 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
         </div>
       </div>
 
-      <div className="min-w-0 overflow-x-auto overflow-y-hidden border-y">
-        <table className="w-full table-auto text-sm">
+      <div className="min-w-0 border-y">
+        <table className="min-w-full w-max table-auto text-sm">
           <thead className="bg-muted/40 text-[11px] uppercase tracking-widest text-muted-foreground">
             <tr>
               {columns.map(column => {

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -847,7 +847,7 @@ export default function TableDisplay({ headerActions }: TableDisplayProps = {}) 
     : []
 
   return (
-    <div className="-mx-6 flex min-w-0 flex-col gap-4">
+    <div className="-mx-6 flex w-[calc(100%+3rem)] min-w-0 flex-col gap-4">
       <div className="flex flex-wrap items-start justify-between gap-3 px-6">
         <div>
           <h1 className="text-2xl font-semibold">{label}</h1>

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -183,7 +183,7 @@ export default function TeamLayout() {
         </div>
       </aside>
 
-      <section className="relative z-0 min-w-0 flex-1 space-y-6 overflow-y-auto p-6">
+      <section className="relative z-0 min-w-0 flex-1 space-y-6 overflow-x-hidden overflow-y-auto p-6">
         <Outlet />
       </section>
     </main>

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -56,16 +56,16 @@ export default function TeamLayout() {
   }
 
   return (
-    <main className="flex min-h-[calc(100svh-4rem)] w-full">
+    <main className="flex w-full items-start">
       <aside
         className={cn(
-          'relative z-50 shrink-0 overflow-visible border-r bg-card transition-[width] duration-200',
+          'sticky top-16 z-50 h-[calc(100svh-4rem)] shrink-0 overflow-y-auto overflow-x-visible border-r bg-card transition-[width] duration-200',
           sidebarCollapsed ? 'w-16' : 'w-64'
         )}
       >
         <div
           className={cn(
-            'flex h-full flex-col p-2',
+            'flex flex-col p-2',
             sidebarCollapsed ? 'overflow-visible' : 'overflow-visible'
           )}
         >
@@ -183,7 +183,7 @@ export default function TeamLayout() {
         </div>
       </aside>
 
-      <section className="relative z-0 min-w-0 flex-1 space-y-6 p-6">
+      <section className="relative z-0 min-w-0 flex-1 space-y-6 px-6 pt-6 pb-0">
         <Outlet />
       </section>
     </main>

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -56,7 +56,7 @@ export default function TeamLayout() {
   }
 
   return (
-    <main className="flex min-h-[calc(100svh-4rem)] w-full overflow-x-hidden">
+    <main className="flex min-h-[calc(100svh-4rem)] w-full">
       <aside
         className={cn(
           'relative z-50 shrink-0 overflow-visible border-r bg-card transition-[width] duration-200',
@@ -183,7 +183,7 @@ export default function TeamLayout() {
         </div>
       </aside>
 
-      <section className="relative z-0 min-w-0 flex-1 space-y-6 overflow-x-hidden p-6">
+      <section className="relative z-0 min-w-0 flex-1 space-y-6 p-6">
         <Outlet />
       </section>
     </main>

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -56,7 +56,7 @@ export default function TeamLayout() {
   }
 
   return (
-    <main className="flex h-[calc(100svh-4rem)] w-full overflow-hidden">
+    <main className="flex min-h-[calc(100svh-4rem)] w-full overflow-x-hidden">
       <aside
         className={cn(
           'relative z-50 shrink-0 overflow-visible border-r bg-card transition-[width] duration-200',
@@ -183,7 +183,7 @@ export default function TeamLayout() {
         </div>
       </aside>
 
-      <section className="relative z-0 min-w-0 flex-1 space-y-6 overflow-x-hidden overflow-y-auto p-6">
+      <section className="relative z-0 min-w-0 flex-1 space-y-6 overflow-x-hidden p-6">
         <Outlet />
       </section>
     </main>

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -66,7 +66,7 @@ export default function TeamLayout() {
         <div
           className={cn(
             'flex h-full flex-col p-2',
-            sidebarCollapsed ? 'overflow-visible' : 'overflow-y-auto overflow-x-hidden'
+            sidebarCollapsed ? 'overflow-visible' : 'overflow-visible'
           )}
         >
           <div className={cn('flex items-center', sidebarCollapsed ? 'justify-center' : 'justify-between')}>


### PR DESCRIPTION
## What changed
- switches person form submissions tab to use regular TableDisplay
- adds a per-row View answers action button that links to form answers
- passes returnTo so users can navigate back to the person page
- allows form answers page to filter by submissionId and labels back action contextually

## Verification
- npm run typecheck (from web/)