### PR TITLE
Promote email draft migration and admin enrollment tests

### DIFF
--- a/supabase/migrations/20260604110000_email-draft-trigger-metadata-and-seed.sql
+++ b/supabase/migrations/20260604110000_email-draft-trigger-metadata-and-seed.sql
@@ -1,0 +1,181 @@
+alter table public.email_draft
+  add column if not exists trigger_summary text not null default '',
+  add column if not exists trigger_event_key text,
+  add column if not exists trigger_owner text;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'email_draft_trigger_summary_length_check'
+      and conrelid = 'public.email_draft'::regclass
+  ) then
+    alter table public.email_draft
+      add constraint email_draft_trigger_summary_length_check
+      check (char_length(trigger_summary) <= 200);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'email_draft_trigger_summary_required_for_transactional'
+      and conrelid = 'public.email_draft'::regclass
+  ) then
+    alter table public.email_draft
+      add constraint email_draft_trigger_summary_required_for_transactional
+      check (channel <> 'transactional' or char_length(btrim(trigger_summary)) > 0);
+  end if;
+end;
+$$;
+
+with upsert_requested as (
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    'family_enrollment_requested_v1',
+    'Family enrollment requested',
+    'Family enrollment request notification.',
+    'Sent to each family email immediately after enrollment is requested.',
+    'workshop_enrollment.family_requested',
+    'web/app/routes/enroll.tsx',
+    'transactional',
+    'draft',
+    true,
+    '{"required": ["actorName", "actorEmail", "workshopName"]}'::jsonb,
+    'We''ve received your summerlunch+ registration!',
+    E'Hi,\n\nThank you for registering for summerlunch+! We''re excited to welcome your family this summer.\n\nYour registration has been received and is currently pending approval. Our team will review your information and send you a confirmation email shortly with your program details, class schedule, and next steps.\n\nWhile you wait, we encourage you to invite additional family members to join your profile.\n\nAs a reminder, to help maintain a safe and engaging class environment, all participants must be supervised by a parent or guardian during classes and are expected to keep their cameras on throughout the session.\n\nRegistration details:\n- Registered by: {{actorName}} ({{actorEmail}})\n- Workshop: {{workshopName}}\n\nIf you have any questions in the meantime, feel free to email us at hello@summerlunchplus.com.\n\nWe''re looking forward to cooking with you soon!\n\n- The summerlunch+ Team'
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      is_system = true,
+      variables_schema = case
+        when public.email_draft.variables_schema = '{}'::jsonb then excluded.variables_schema
+        else public.email_draft.variables_schema
+      end,
+      current_subject_markdown = case
+        when char_length(btrim(public.email_draft.current_subject_markdown)) = 0 then excluded.current_subject_markdown
+        else public.email_draft.current_subject_markdown
+      end,
+      current_body_markdown = case
+        when char_length(btrim(public.email_draft.current_body_markdown)) = 0 then excluded.current_body_markdown
+        else public.email_draft.current_body_markdown
+      end
+  returning id
+),
+upsert_accepted as (
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    'family_enrollment_accepted_v1',
+    'Family enrollment accepted',
+    'Family enrollment approved notification.',
+    'Sent to family emails when staff changes enrollment status to approved.',
+    'workshop_enrollment.family_accepted',
+    'web/app/routes/manage/workshop-enrollment.tsx',
+    'transactional',
+    'draft',
+    true,
+    '{"required": ["workshopName"]}'::jsonb,
+    'Family enrollment accepted',
+    E'Great news! Your family enrollment for {{workshopName}} has been accepted.\n\nWe look forward to seeing your family in the program.'
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      is_system = true,
+      variables_schema = case
+        when public.email_draft.variables_schema = '{}'::jsonb then excluded.variables_schema
+        else public.email_draft.variables_schema
+      end,
+      current_subject_markdown = case
+        when char_length(btrim(public.email_draft.current_subject_markdown)) = 0 then excluded.current_subject_markdown
+        else public.email_draft.current_subject_markdown
+      end,
+      current_body_markdown = case
+        when char_length(btrim(public.email_draft.current_body_markdown)) = 0 then excluded.current_body_markdown
+        else public.email_draft.current_body_markdown
+      end
+  returning id
+)
+select 1
+from upsert_requested
+cross join upsert_accepted;
+
+insert into public.email_draft_version (
+  email_draft_id,
+  version_number,
+  subject_markdown,
+  body_markdown,
+  subject_rendered,
+  html_rendered,
+  text_rendered,
+  variables_schema,
+  change_note,
+  published_at
+)
+select
+  draft.id,
+  1,
+  draft.current_subject_markdown,
+  draft.current_body_markdown,
+  draft.current_subject_markdown,
+  '<p>' || replace(replace(replace(draft.current_body_markdown, '&', '&amp;'), '<', '&lt;'), E'\n', '<br />') || '</p>',
+  draft.current_body_markdown,
+  draft.variables_schema,
+  'Seeded transactional draft content for migration.',
+  now()
+from public.email_draft as draft
+where draft.draft_key in ('family_enrollment_requested_v1', 'family_enrollment_accepted_v1')
+  and draft.published_version_id is null
+on conflict (email_draft_id, version_number) do nothing;
+
+update public.email_draft as draft
+set
+  published_version_id = (
+    select version.id
+    from public.email_draft_version as version
+    where version.email_draft_id = draft.id
+    order by version.version_number desc
+    limit 1
+  ),
+  status = 'published'
+where draft.draft_key in ('family_enrollment_requested_v1', 'family_enrollment_accepted_v1')
+  and draft.published_version_id is null;

--- a/supabase/schemas/12_email_drafts.sql
+++ b/supabase/schemas/12_email_drafts.sql
@@ -7,6 +7,9 @@ create table public.email_draft (
   draft_key text not null unique,
   title text not null,
   description text,
+  trigger_summary text not null default '',
+  trigger_event_key text,
+  trigger_owner text,
   channel public.email_draft_channel not null,
   status public.email_draft_status not null default 'draft',
   is_system boolean not null default false,
@@ -17,7 +20,10 @@ create table public.email_draft (
   created_by_user_id uuid references auth.users (id) on delete set null,
   updated_by_user_id uuid references auth.users (id) on delete set null,
   created_at timestamptz not null default now(),
-  updated_at timestamptz not null default now()
+  updated_at timestamptz not null default now(),
+  constraint email_draft_trigger_summary_length_check check (char_length(trigger_summary) <= 200),
+  constraint email_draft_trigger_summary_required_for_transactional
+    check (channel <> 'transactional' or char_length(btrim(trigger_summary)) > 0)
 );
 
 create table public.email_draft_version (

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -134,6 +134,9 @@ export type Database = {
           published_version_id: string | null
           status: Database["public"]["Enums"]["email_draft_status"]
           title: string
+          trigger_event_key: string | null
+          trigger_owner: string | null
+          trigger_summary: string
           updated_at: string
           updated_by_user_id: string | null
           variables_schema: Json
@@ -151,6 +154,9 @@ export type Database = {
           published_version_id?: string | null
           status?: Database["public"]["Enums"]["email_draft_status"]
           title: string
+          trigger_event_key?: string | null
+          trigger_owner?: string | null
+          trigger_summary?: string
           updated_at?: string
           updated_by_user_id?: string | null
           variables_schema?: Json
@@ -168,6 +174,9 @@ export type Database = {
           published_version_id?: string | null
           status?: Database["public"]["Enums"]["email_draft_status"]
           title?: string
+          trigger_event_key?: string | null
+          trigger_owner?: string | null
+          trigger_summary?: string
           updated_at?: string
           updated_by_user_id?: string | null
           variables_schema?: Json

--- a/web/app/lib/email/drafts/repository.server.ts
+++ b/web/app/lib/email/drafts/repository.server.ts
@@ -12,12 +12,13 @@ type DraftListFilters = {
   status?: EmailDraftStatus | 'all'
 }
 
+const EMAIL_DRAFT_SELECT =
+  'id, draft_key, title, description, trigger_summary, trigger_event_key, trigger_owner, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
+
 export const listEmailDrafts = async (filters: DraftListFilters = {}) => {
   let query = adminClient
     .from('email_draft')
-    .select(
-      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
-    )
+    .select(EMAIL_DRAFT_SELECT)
     .order('updated_at', { ascending: false })
 
   if (filters.channel && filters.channel !== 'all') {
@@ -36,11 +37,17 @@ export const listEmailDrafts = async (filters: DraftListFilters = {}) => {
 export const createEmailDraft = async ({
   draftKey,
   title,
+  triggerSummary,
+  triggerEventKey,
+  triggerOwner,
   channel,
   actorUserId,
 }: {
   draftKey: string
   title: string
+  triggerSummary: string
+  triggerEventKey?: string | null
+  triggerOwner?: string | null
   channel: EmailDraftChannel
   actorUserId: string
 }) => {
@@ -49,13 +56,14 @@ export const createEmailDraft = async ({
     .insert({
       draft_key: draftKey,
       title,
+      trigger_summary: triggerSummary,
+      trigger_event_key: triggerEventKey ?? null,
+      trigger_owner: triggerOwner ?? null,
       channel,
       created_by_user_id: actorUserId,
       updated_by_user_id: actorUserId,
     })
-    .select(
-      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
-    )
+    .select(EMAIL_DRAFT_SELECT)
     .single()
 
   if (error) throw new Error(error.message)
@@ -65,9 +73,7 @@ export const createEmailDraft = async ({
 export const getEmailDraftById = async (draftId: string) => {
   const { data, error } = await adminClient
     .from('email_draft')
-    .select(
-      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
-    )
+    .select(EMAIL_DRAFT_SELECT)
     .eq('id', draftId)
     .single()
 
@@ -78,9 +84,7 @@ export const getEmailDraftById = async (draftId: string) => {
 export const getEmailDraftByKey = async (draftKey: string) => {
   const { data, error } = await adminClient
     .from('email_draft')
-    .select(
-      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
-    )
+    .select(EMAIL_DRAFT_SELECT)
     .eq('draft_key', draftKey)
     .single()
 
@@ -111,6 +115,9 @@ export const updateEmailDraft = async ({
   payload: {
     title?: string
     description?: string | null
+    triggerSummary?: string
+    triggerEventKey?: string | null
+    triggerOwner?: string | null
     status?: EmailDraftStatus
     subjectMarkdown?: string
     bodyMarkdown?: string
@@ -123,6 +130,9 @@ export const updateEmailDraft = async ({
 
   if (typeof payload.title === 'string') updatePayload.title = payload.title
   if (payload.description !== undefined) updatePayload.description = payload.description
+  if (typeof payload.triggerSummary === 'string') updatePayload.trigger_summary = payload.triggerSummary
+  if (payload.triggerEventKey !== undefined) updatePayload.trigger_event_key = payload.triggerEventKey
+  if (payload.triggerOwner !== undefined) updatePayload.trigger_owner = payload.triggerOwner
   if (payload.status) updatePayload.status = payload.status
   if (typeof payload.subjectMarkdown === 'string') {
     updatePayload.current_subject_markdown = payload.subjectMarkdown
@@ -138,9 +148,7 @@ export const updateEmailDraft = async ({
     .from('email_draft')
     .update(updatePayload)
     .eq('id', draftId)
-    .select(
-      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
-    )
+    .select(EMAIL_DRAFT_SELECT)
     .single()
 
   if (error) throw new Error(error.message)
@@ -222,9 +230,7 @@ export const setPublishedVersion = async ({
       updated_by_user_id: actorUserId,
     })
     .eq('id', draftId)
-    .select(
-      'id, draft_key, title, description, channel, status, is_system, variables_schema, current_subject_markdown, current_body_markdown, published_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at'
-    )
+    .select(EMAIL_DRAFT_SELECT)
     .single()
 
   if (error) throw new Error(error.message)

--- a/web/app/lib/email/drafts/service.server.ts
+++ b/web/app/lib/email/drafts/service.server.ts
@@ -22,15 +22,29 @@ export const listDrafts = listEmailDrafts
 export const createDraft = async ({
   draftKey,
   title,
+  triggerSummary,
+  triggerEventKey,
+  triggerOwner,
   channel,
   actorUserId,
 }: {
   draftKey: string
   title: string
+  triggerSummary: string
+  triggerEventKey?: string | null
+  triggerOwner?: string | null
   channel: EmailDraftChannel
   actorUserId: string
 }) => {
-  return createEmailDraft({ draftKey, title, channel, actorUserId })
+  return createEmailDraft({
+    draftKey,
+    title,
+    triggerSummary,
+    triggerEventKey,
+    triggerOwner,
+    channel,
+    actorUserId,
+  })
 }
 
 export const getDraftForEditor = async (draftId: string) => {
@@ -47,6 +61,9 @@ export const saveDraft = async ({
   actorUserId,
   title,
   description,
+  triggerSummary,
+  triggerEventKey,
+  triggerOwner,
   status,
   subjectMarkdown,
   bodyMarkdown,
@@ -56,6 +73,9 @@ export const saveDraft = async ({
   actorUserId: string
   title: string
   description: string | null
+  triggerSummary: string
+  triggerEventKey: string | null
+  triggerOwner: string | null
   status: EmailDraftStatus
   subjectMarkdown: string
   bodyMarkdown: string
@@ -67,6 +87,9 @@ export const saveDraft = async ({
     payload: {
       title,
       description,
+      triggerSummary,
+      triggerEventKey,
+      triggerOwner,
       status,
       subjectMarkdown,
       bodyMarkdown,
@@ -87,6 +110,8 @@ export const publishDraft = async ({
   const draft = await getEmailDraftById(draftId)
   const schema = (draft.variables_schema ?? {}) as EmailDraftSchema
   const validation = validateDraftForPublish({
+    channel: draft.channel,
+    triggerSummary: draft.trigger_summary,
     subjectMarkdown: draft.current_subject_markdown,
     bodyMarkdown: draft.current_body_markdown,
     variablesSchema: schema,
@@ -169,7 +194,13 @@ export const resolvePublishedDraftByKey = async ({
   draftKey: string
   variables?: Record<string, unknown>
 }) => {
-  const draft = await getEmailDraftByKey(draftKey)
+  let draft
+
+  try {
+    draft = await getEmailDraftByKey(draftKey)
+  } catch {
+    return null
+  }
 
   if (!draft.published_version_id) {
     return null

--- a/web/app/lib/email/drafts/types.ts
+++ b/web/app/lib/email/drafts/types.ts
@@ -14,6 +14,9 @@ export type EmailDraftRecord = {
   draft_key: string
   title: string
   description: string | null
+  trigger_summary: string
+  trigger_event_key: string | null
+  trigger_owner: string | null
   channel: EmailDraftChannel
   status: EmailDraftStatus
   is_system: boolean

--- a/web/app/lib/email/drafts/validators.ts
+++ b/web/app/lib/email/drafts/validators.ts
@@ -1,5 +1,9 @@
 import { collectPlaceholders } from '@/lib/email/drafts/renderer.server'
-import type { EmailDraftSchema, ValidateDraftResult } from '@/lib/email/drafts/types'
+import type {
+  EmailDraftChannel,
+  EmailDraftSchema,
+  ValidateDraftResult,
+} from '@/lib/email/drafts/types'
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -51,10 +55,14 @@ export const parseSchemaInput = (schemaText: string) => {
 }
 
 export const validateDraftForPublish = ({
+  channel,
+  triggerSummary,
   subjectMarkdown,
   bodyMarkdown,
   variablesSchema,
 }: {
+  channel: EmailDraftChannel
+  triggerSummary: string
   subjectMarkdown: string
   bodyMarkdown: string
   variablesSchema: EmailDraftSchema
@@ -67,6 +75,15 @@ export const validateDraftForPublish = ({
 
   if (!bodyMarkdown.trim()) {
     errors.push('Body markdown is required.')
+  }
+
+  if (channel === 'transactional') {
+    const normalized = triggerSummary.trim()
+    if (!normalized) {
+      errors.push('A short trigger summary is required for transactional drafts.')
+    } else if (normalized.length > 200) {
+      errors.push('Trigger summary must be 200 characters or fewer.')
+    }
   }
 
   const required = Array.isArray(variablesSchema.required)

--- a/web/app/lib/email/send-email.server.ts
+++ b/web/app/lib/email/send-email.server.ts
@@ -1,4 +1,5 @@
 import type { Json } from '@/lib/database.types'
+import { resolvePublishedDraftByKey } from '@/lib/email/drafts/service.server'
 import {
   emailTemplates,
   type EmailTemplateKey,
@@ -37,6 +38,19 @@ type SendTransactionalEmailResult = {
   status: 'sent' | 'failed' | 'skipped'
   id: string | null
   error: string | null
+}
+
+const parseBooleanFlag = (value: string | undefined) =>
+  value === '1' || value === 'true' || value === 'yes' || value === 'on'
+
+const migrationFlagForTemplate = (templateKey: string) =>
+  `EMAIL_DRAFT_USE_${templateKey.toUpperCase().replaceAll(/[^A-Z0-9]/g, '_')}`
+
+const normalizeTemplateVariables = (value: Json): Record<string, unknown> => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return {}
 }
 
 export const sendTransactionalEmail = async ({
@@ -164,7 +178,33 @@ export const sendTemplateEmail = async <K extends EmailTemplateKey>({
   familyProfileId,
   workshopEnrollmentId,
 }: SendTemplateEmailArgs<K>) => {
-  const template = emailTemplates[templateKey].render(templateData)
+  const migrationFlag = migrationFlagForTemplate(templateKey)
+  const shouldUseDraft = parseBooleanFlag(process.env[migrationFlag])
+  let resolved = null as { subject: string; html: string; text: string } | null
+
+  if (shouldUseDraft) {
+    try {
+      resolved = await resolvePublishedDraftByKey({
+        draftKey: templateKey,
+        variables: templateData as Record<string, unknown>,
+      })
+
+      if (!resolved) {
+        console.warn('[email] draft resolver returned null, using legacy template', {
+          templateKey,
+          migrationFlag,
+        })
+      }
+    } catch (error) {
+      console.error('[email] draft resolver failed, using legacy template', {
+        templateKey,
+        migrationFlag,
+        error,
+      })
+    }
+  }
+
+  const template = resolved ?? emailTemplates[templateKey].render(templateData)
 
   return sendTransactionalEmail({
     toEmail,
@@ -199,6 +239,34 @@ export const resendEmailMessageById = async ({
 
   if (error || !message) {
     return { ok: false, error: error?.message ?? 'Email message not found' }
+  }
+
+  const draftRendered = await resolvePublishedDraftByKey({
+    draftKey: message.template_key,
+    variables: normalizeTemplateVariables(message.template_data),
+  })
+
+  if (draftRendered) {
+    const resendResult = await sendTransactionalEmail({
+      toEmail: message.to_email,
+      subject: draftRendered.subject,
+      html: draftRendered.html,
+      text: draftRendered.text,
+      templateKey: message.template_key,
+      templateData: message.template_data,
+      eventKey: null,
+      triggeredByUserId,
+      recipientUserId: message.recipient_user_id,
+      profileId: message.profile_id,
+      familyProfileId: message.family_profile_id,
+      workshopEnrollmentId: message.workshop_enrollment_id,
+    })
+
+    if (resendResult.status === 'failed') {
+      return { ok: false, error: resendResult.error ?? 'Resend failed' }
+    }
+
+    return { ok: true }
   }
 
   const templateEntry = (emailTemplates as Record<string, { render: (data: unknown) => { subject: string; html: string; text: string } }>)[message.template_key]

--- a/web/app/routes/manage/email-drafts.$draftId.tsx
+++ b/web/app/routes/manage/email-drafts.$draftId.tsx
@@ -264,7 +264,7 @@ export default function EmailDraftEditorPage() {
         <div>
           <h1 className="text-2xl font-semibold">{draft.title}</h1>
           <p className="text-sm text-muted-foreground">
-            <span className="font-mono text-xs">{draft.draft_key}</span> - {draft.channel} - {draft.status}
+            {draft.channel} - {draft.status}
           </p>
         </div>
         <Button asChild variant="outline">
@@ -329,25 +329,6 @@ export default function EmailDraftEditorPage() {
               />
             </div>
 
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="grid gap-2">
-                <Label htmlFor="trigger-event-key">Trigger event key (optional)</Label>
-                <Input
-                  id="trigger-event-key"
-                  name="trigger_event_key"
-                  defaultValue={draft.trigger_event_key ?? ''}
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="trigger-owner">Trigger owner file (optional)</Label>
-                <Input
-                  id="trigger-owner"
-                  name="trigger_owner"
-                  defaultValue={draft.trigger_owner ?? ''}
-                />
-              </div>
-            </div>
-
             <div className="grid gap-2">
               <Label htmlFor="subject-markdown">Subject markdown</Label>
               <Input
@@ -370,16 +351,45 @@ export default function EmailDraftEditorPage() {
               />
             </div>
 
-            <div className="grid gap-2">
-              <Label htmlFor="variables-schema">Variables schema (JSON)</Label>
-              <textarea
-                id="variables-schema"
-                name="variables_schema"
-                defaultValue={schemaText}
-                rows={8}
-                className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
-              />
-            </div>
+            <details className="rounded-md border bg-muted/10">
+              <summary className="cursor-pointer px-3 py-2 text-sm font-medium">Advanced</summary>
+              <div className="space-y-4 border-t px-3 py-3">
+                <div className="grid gap-2">
+                  <Label htmlFor="draft-key">Draft key</Label>
+                  <Input id="draft-key" value={draft.draft_key} readOnly className="font-mono text-xs" />
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="grid gap-2">
+                    <Label htmlFor="trigger-event-key">Trigger event key (optional)</Label>
+                    <Input
+                      id="trigger-event-key"
+                      name="trigger_event_key"
+                      defaultValue={draft.trigger_event_key ?? ''}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="trigger-owner">Trigger owner file (optional)</Label>
+                    <Input
+                      id="trigger-owner"
+                      name="trigger_owner"
+                      defaultValue={draft.trigger_owner ?? ''}
+                    />
+                  </div>
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="variables-schema">Variables schema (JSON)</Label>
+                  <textarea
+                    id="variables-schema"
+                    name="variables_schema"
+                    defaultValue={schemaText}
+                    rows={8}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+                  />
+                </div>
+              </div>
+            </details>
 
             <div className="flex items-center gap-3">
               <Button type="submit" disabled={isSubmitting}>

--- a/web/app/routes/manage/email-drafts.$draftId.tsx
+++ b/web/app/routes/manage/email-drafts.$draftId.tsx
@@ -286,7 +286,7 @@ export default function EmailDraftEditorPage() {
         <CardHeader>
           <CardTitle>Draft editor</CardTitle>
           <CardDescription>
-            Edit markdown content and define a short trigger summary. Save before publishing.
+            Edit markdown content. Use Advanced for trigger and metadata settings.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -311,22 +311,6 @@ export default function EmailDraftEditorPage() {
                   <option value="archived">archived</option>
                 </select>
               </div>
-            </div>
-
-            <div className="grid gap-2">
-              <Label htmlFor="description">Description</Label>
-              <Input id="description" name="description" defaultValue={draft.description ?? ''} />
-            </div>
-
-            <div className="grid gap-2">
-              <Label htmlFor="trigger-summary">When this email sends (plain language)</Label>
-              <Input
-                id="trigger-summary"
-                name="trigger_summary"
-                defaultValue={draft.trigger_summary}
-                maxLength={200}
-                required
-              />
             </div>
 
             <div className="grid gap-2">
@@ -357,6 +341,22 @@ export default function EmailDraftEditorPage() {
                 <div className="grid gap-2">
                   <Label htmlFor="draft-key">Draft key</Label>
                   <Input id="draft-key" value={draft.draft_key} readOnly className="font-mono text-xs" />
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Input id="description" name="description" defaultValue={draft.description ?? ''} />
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="trigger-summary">When this email sends (plain language)</Label>
+                  <Input
+                    id="trigger-summary"
+                    name="trigger_summary"
+                    defaultValue={draft.trigger_summary}
+                    maxLength={200}
+                    required
+                  />
                 </div>
 
                 <div className="grid gap-4 md:grid-cols-2">

--- a/web/app/routes/manage/email-drafts.$draftId.tsx
+++ b/web/app/routes/manage/email-drafts.$draftId.tsx
@@ -52,6 +52,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const { draft, versions } = await getDraftForEditor(draftId)
   const schema = (draft.variables_schema ?? {}) as EmailDraftSchema
   const validation = validateDraftForPublish({
+    channel: draft.channel,
+    triggerSummary: draft.trigger_summary,
     subjectMarkdown: draft.current_subject_markdown,
     bodyMarkdown: draft.current_body_markdown,
     variablesSchema: schema,
@@ -168,6 +170,9 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (intent === 'save-draft') {
     const title = String(formData.get('title') ?? '').trim()
     const description = String(formData.get('description') ?? '').trim()
+    const triggerSummary = String(formData.get('trigger_summary') ?? '').trim()
+    const triggerEventKey = String(formData.get('trigger_event_key') ?? '').trim()
+    const triggerOwner = String(formData.get('trigger_owner') ?? '').trim()
     const status = normalizeStatus(String(formData.get('status') ?? 'draft'))
     const subjectMarkdown = String(formData.get('subject_markdown') ?? '')
     const bodyMarkdown = String(formData.get('body_markdown') ?? '')
@@ -175,6 +180,14 @@ export async function action({ request, params }: Route.ActionArgs) {
 
     if (!title) {
       return { error: 'Title is required.' } satisfies ActionData
+    }
+
+    if (!triggerSummary) {
+      return { error: 'When this email sends is required.' } satisfies ActionData
+    }
+
+    if (triggerSummary.length > 200) {
+      return { error: 'When this email sends must be 200 characters or fewer.' } satisfies ActionData
     }
 
     const parsedSchema = parseSchemaInput(schemaText)
@@ -187,6 +200,9 @@ export async function action({ request, params }: Route.ActionArgs) {
       actorUserId: auth.user.id,
       title,
       description: description || null,
+      triggerSummary,
+      triggerEventKey: triggerEventKey || null,
+      triggerOwner: triggerOwner || null,
       status,
       subjectMarkdown,
       bodyMarkdown,
@@ -270,7 +286,7 @@ export default function EmailDraftEditorPage() {
         <CardHeader>
           <CardTitle>Draft editor</CardTitle>
           <CardDescription>
-            Edit markdown content, schema, and status. Save before publishing.
+            Edit markdown content and define a short trigger summary. Save before publishing.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -300,6 +316,36 @@ export default function EmailDraftEditorPage() {
             <div className="grid gap-2">
               <Label htmlFor="description">Description</Label>
               <Input id="description" name="description" defaultValue={draft.description ?? ''} />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="trigger-summary">When this email sends (plain language)</Label>
+              <Input
+                id="trigger-summary"
+                name="trigger_summary"
+                defaultValue={draft.trigger_summary}
+                maxLength={200}
+                required
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="trigger-event-key">Trigger event key (optional)</Label>
+                <Input
+                  id="trigger-event-key"
+                  name="trigger_event_key"
+                  defaultValue={draft.trigger_event_key ?? ''}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="trigger-owner">Trigger owner file (optional)</Label>
+                <Input
+                  id="trigger-owner"
+                  name="trigger_owner"
+                  defaultValue={draft.trigger_owner ?? ''}
+                />
+              </div>
             </div>
 
             <div className="grid gap-2">
@@ -344,6 +390,11 @@ export default function EmailDraftEditorPage() {
               ) : (
                 <span className="text-xs text-emerald-600">Current draft passes publish validation.</span>
               )}
+            </div>
+
+            <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+              <span className="font-medium">This email sends when:</span>{' '}
+              {draft.trigger_summary || 'Trigger summary is missing.'}
             </div>
           </fetcher.Form>
         </CardContent>

--- a/web/app/routes/manage/email-drafts.tsx
+++ b/web/app/routes/manage/email-drafts.tsx
@@ -1,4 +1,5 @@
 import { Link, redirect, useFetcher, useLoaderData } from 'react-router'
+import { useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -108,16 +109,23 @@ export default function EmailDraftsPage() {
   const { drafts, channelFilter, statusFilter } = useLoaderData<typeof loader>()
   const fetcher = useFetcher<ActionData>()
   const creating = fetcher.state === 'submitting'
+  const [showCreateForm, setShowCreateForm] = useState(false)
 
   return (
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle className="text-xl">Create email draft</CardTitle>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-xl">Create email draft</CardTitle>
+            <Button type="button" variant="outline" onClick={() => setShowCreateForm(previous => !previous)}>
+              {showCreateForm ? 'Hide form' : 'New draft'}
+            </Button>
+          </div>
           <CardDescription>
             Draft keys are stable identifiers used by send logic. Add a short plain-language trigger.
           </CardDescription>
         </CardHeader>
+        {showCreateForm ? (
         <CardContent>
           <fetcher.Form method="post" className="grid gap-4 md:grid-cols-2">
             <input type="hidden" name="intent" value="create-draft" />
@@ -176,6 +184,7 @@ export default function EmailDraftsPage() {
           </fetcher.Form>
           {fetcher.data?.error ? <p className="mt-3 text-sm text-red-500">{fetcher.data.error}</p> : null}
         </CardContent>
+        ) : null}
       </Card>
 
       <Card>

--- a/web/app/routes/manage/email-drafts.tsx
+++ b/web/app/routes/manage/email-drafts.tsx
@@ -60,6 +60,9 @@ export async function action({ request }: Route.ActionArgs) {
 
   const title = String(formData.get('title') ?? '').trim()
   const draftKey = normalizeDraftKey(String(formData.get('draft_key') ?? ''))
+  const triggerSummary = String(formData.get('trigger_summary') ?? '').trim()
+  const triggerEventKey = String(formData.get('trigger_event_key') ?? '').trim()
+  const triggerOwner = String(formData.get('trigger_owner') ?? '').trim()
   const channel = String(formData.get('channel') ?? '')
 
   if (!title) {
@@ -70,6 +73,14 @@ export async function action({ request }: Route.ActionArgs) {
     return { error: 'Draft key is required.' } satisfies ActionData
   }
 
+  if (!triggerSummary) {
+    return { error: 'When this email sends is required.' } satisfies ActionData
+  }
+
+  if (triggerSummary.length > 200) {
+    return { error: 'When this email sends must be 200 characters or fewer.' } satisfies ActionData
+  }
+
   if (channel !== 'auth' && channel !== 'transactional') {
     return { error: 'Select a valid channel.' } satisfies ActionData
   }
@@ -78,6 +89,9 @@ export async function action({ request }: Route.ActionArgs) {
     const created = await createDraft({
       draftKey,
       title,
+      triggerSummary,
+      triggerEventKey: triggerEventKey || null,
+      triggerOwner: triggerOwner || null,
       channel,
       actorUserId: auth.user.id,
     })
@@ -101,11 +115,11 @@ export default function EmailDraftsPage() {
         <CardHeader>
           <CardTitle className="text-xl">Create email draft</CardTitle>
           <CardDescription>
-            Draft keys are stable identifiers used by server send logic. Use lowercase and underscores.
+            Draft keys are stable identifiers used by send logic. Add a short plain-language trigger.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <fetcher.Form method="post" className="grid gap-4 md:grid-cols-[1fr_1fr_180px_auto]">
+          <fetcher.Form method="post" className="grid gap-4 md:grid-cols-2">
             <input type="hidden" name="intent" value="create-draft" />
             <div className="grid gap-2">
               <Label htmlFor="title">Title</Label>
@@ -128,7 +142,33 @@ export default function EmailDraftsPage() {
                 <option value="auth">auth</option>
               </select>
             </div>
-            <div className="flex items-end">
+            <div className="grid gap-2 md:col-span-2">
+              <Label htmlFor="trigger-summary">When this email sends (plain language)</Label>
+              <Input
+                id="trigger-summary"
+                name="trigger_summary"
+                placeholder="Sent to family emails when staff approves enrollment."
+                maxLength={200}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="trigger-event-key">Trigger event key (optional)</Label>
+              <Input
+                id="trigger-event-key"
+                name="trigger_event_key"
+                placeholder="workshop_enrollment.family_accepted"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="trigger-owner">Trigger owner file (optional)</Label>
+              <Input
+                id="trigger-owner"
+                name="trigger_owner"
+                placeholder="web/app/routes/manage/workshop-enrollment.tsx"
+              />
+            </div>
+            <div className="flex items-end md:col-span-2">
               <Button type="submit" disabled={creating}>
                 {creating ? 'Creating...' : 'Create draft'}
               </Button>
@@ -156,6 +196,7 @@ export default function EmailDraftsPage() {
                     <th className="px-3 py-2 font-medium">Title</th>
                     <th className="px-3 py-2 font-medium">Key</th>
                     <th className="px-3 py-2 font-medium">Channel</th>
+                    <th className="px-3 py-2 font-medium">When this sends</th>
                     <th className="px-3 py-2 font-medium">Status</th>
                     <th className="px-3 py-2 font-medium">Updated</th>
                   </tr>
@@ -170,6 +211,7 @@ export default function EmailDraftsPage() {
                       </td>
                       <td className="px-3 py-2 font-mono text-xs">{draft.draft_key}</td>
                       <td className="px-3 py-2">{draft.channel}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{draft.trigger_summary || '-'}</td>
                       <td className="px-3 py-2">{draft.status}</td>
                       <td className="px-3 py-2 text-muted-foreground">
                         {new Intl.DateTimeFormat(undefined, {

--- a/web/app/routes/manage/nav.ts
+++ b/web/app/routes/manage/nav.ts
@@ -5,7 +5,7 @@ export type ManageNavItem = {
 }
 
 export type ManageNavSection = {
-  key: 'class-management' | 'form-management' | 'user-management' | 'system'
+  key: 'class-management' | 'form-management' | 'user-management' | 'email' | 'system'
   label: string
   stickerSrc: string
   defaultCollapsed: boolean
@@ -60,14 +60,22 @@ export const manageSections: ManageNavSection[] = [
     ],
   },
   {
+    key: 'email',
+    label: 'Email',
+    stickerSrc: '/stickers/radish.png',
+    defaultCollapsed: true,
+    items: [
+      { to: '/manage/email-message', label: 'Email messages', description: 'Outbound transactional email log with delivery status and template data.' },
+      { to: '/manage/email-drafts', label: 'Email drafts', description: 'Markdown drafts with versioning, preview, and publish flow.' },
+    ],
+  },
+  {
     key: 'system',
     label: 'System',
     stickerSrc: '/stickers/radish.png',
     defaultCollapsed: true,
     items: [
       { to: '/manage/login-event', label: 'Login events', description: 'Successful sign-in metadata and source context.' },
-      { to: '/manage/email-message', label: 'Email messages', description: 'Outbound transactional email log with delivery status and template data.' },
-      { to: '/manage/email-drafts', label: 'Email drafts', description: 'Markdown drafts with versioning, preview, and publish flow.' },
       { to: '/manage/semester-form-requirement', label: 'Semester surveys', description: 'Map one pre/post survey form per semester.' },
       { to: '/manage/role-permission', label: 'Role permissions', description: 'Permissions assigned to each role.' },
       { to: '/manage/request-metadata', label: 'Request metadata', description: 'Validate proxy headers and extracted request metadata.' },

--- a/web/tests/e2e/admin-enrollment-approval.spec.ts
+++ b/web/tests/e2e/admin-enrollment-approval.spec.ts
@@ -314,10 +314,26 @@ const getLatestEnrollmentForGuardian = async (guardianEmail: string) => {
     throw new Error(guardianProfileError?.message ?? 'Guardian profile not found')
   }
 
+  const { data: links, error: linksError } = await adminSupabase
+    .from('person_guardian_child')
+    .select('child_profile_id')
+    .eq('guardian_profile_id', guardianProfile.id)
+
+  if (linksError) {
+    throw new Error(linksError.message)
+  }
+
+  const familyProfileIds = Array.from(
+    new Set([
+      guardianProfile.id,
+      ...(links ?? []).map(link => link.child_profile_id).filter((id): id is string => Boolean(id)),
+    ])
+  )
+
   const { data: enrollments, error: enrollmentError } = await adminSupabase
     .from('workshop_enrollment')
     .select('id, status, requested_at')
-    .eq('profile_id', guardianProfile.id)
+    .in('profile_id', familyProfileIds)
     .order('requested_at', { ascending: false })
     .limit(25)
 

--- a/web/tests/e2e/admin-enrollment-approval.spec.ts
+++ b/web/tests/e2e/admin-enrollment-approval.spec.ts
@@ -12,7 +12,10 @@ const uniqueSuffix = () => {
   return `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}${String(now.getMilliseconds()).padStart(3, '0')}`
 }
 
-const fillRequiredFields = async (page: import('@playwright/test').Page) => {
+const fillRequiredFields = async (
+  page: import('@playwright/test').Page,
+  context?: { firstName?: string; surname?: string }
+) => {
   const form = page.locator('form').first()
 
   const requiredTextInputs = form.locator(
@@ -45,6 +48,16 @@ const fillRequiredFields = async (page: import('@playwright/test').Page) => {
 
     if (inputName.includes('postcode') || inputName.includes('postal')) {
       await input.fill('K1A 0B1')
+      continue
+    }
+
+    if (inputName.includes('firstname') || inputName.includes('first_name')) {
+      await input.fill(context?.firstName ?? 'Sai')
+      continue
+    }
+
+    if (inputName.includes('surname') || inputName.includes('last_name') || inputName.includes('lastname')) {
+      await input.fill(context?.surname ?? 'tests')
       continue
     }
 
@@ -149,10 +162,11 @@ const countMissingRequiredFields = async (page: import('@playwright/test').Page)
 const submitStepWithRetry = async (
   page: import('@playwright/test').Page,
   submitName: RegExp | string,
-  maxAttempts = 3
+  maxAttempts = 3,
+  context?: { firstName?: string; surname?: string }
 ) => {
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    await fillRequiredFields(page)
+    await fillRequiredFields(page, context)
 
     const missingBeforeSubmit = await countMissingRequiredFields(page)
     if (missingBeforeSubmit > 0) {
@@ -174,8 +188,11 @@ const submitStepWithRetry = async (
 }
 
 const guardianSignupAndRequestEnrollment = async (page: import('@playwright/test').Page) => {
-  const email = `sai+tests${uniqueSuffix()}@chsolutions.ca`
+  const suffix = uniqueSuffix()
+  const email = `sai+tests${suffix}@chsolutions.ca`
   const password = 'Password123456!'
+  const firstName = 'Sai'
+  const surname = `tests${suffix}`
 
   await page.goto('/sign-up')
   await page.getByRole('button', { name: 'I am a Guardian' }).click()
@@ -206,7 +223,10 @@ const guardianSignupAndRequestEnrollment = async (page: import('@playwright/test
       await page.locator('input[name="additional_guardian_choice"][value="no"]').check()
     }
 
-    await submitStepWithRetry(page, /Save and continue|Saving\.\.\./)
+    await submitStepWithRetry(page, /Save and continue|Saving\.\.\./, 3, {
+      firstName,
+      surname,
+    })
     await page.waitForLoadState('networkidle')
   }
 
@@ -266,7 +286,10 @@ const guardianSignupAndRequestEnrollment = async (page: import('@playwright/test
 
   await expect(preProgramLink).toBeVisible()
   await preProgramLink.click()
-  await submitStepWithRetry(page, 'Save and continue', 4)
+  await submitStepWithRetry(page, 'Save and continue', 4, {
+    firstName,
+    surname,
+  })
 
   const enrollAction = page.getByRole('button', { name: /Request enrollment|Join waitlist/ }).first()
   await expect(enrollAction).toBeVisible()
@@ -275,7 +298,7 @@ const guardianSignupAndRequestEnrollment = async (page: import('@playwright/test
   await expect(page).toHaveURL(/\/home\?/)
   await expect(page).toHaveURL(/enrollmentStatus=success/)
 
-  return { guardianEmail: email }
+  return { guardianEmail: email, firstName, surname }
 }
 
 const getLatestEnrollmentForGuardian = async (guardianEmail: string) => {
@@ -291,19 +314,106 @@ const getLatestEnrollmentForGuardian = async (guardianEmail: string) => {
     throw new Error(guardianProfileError?.message ?? 'Guardian profile not found')
   }
 
-  const { data: enrollment, error: enrollmentError } = await adminSupabase
+  const { data: enrollments, error: enrollmentError } = await adminSupabase
     .from('workshop_enrollment')
-    .select('id, status')
+    .select('id, status, requested_at')
     .eq('profile_id', guardianProfile.id)
     .order('requested_at', { ascending: false })
-    .limit(1)
-    .single()
+    .limit(25)
 
-  if (enrollmentError || !enrollment?.id) {
+  if (enrollmentError) {
     throw new Error(enrollmentError?.message ?? 'Enrollment not found for guardian')
   }
 
+  const enrollment = (enrollments ?? []).find(row => row.status === 'pending' || row.status === 'waitlisted')
+    ?? (enrollments ?? [])[0]
+
+  if (!enrollment?.id) {
+    throw new Error('Enrollment not found for guardian')
+  }
+
   return enrollment
+}
+
+const waitForEnrollmentStatus = async (guardianEmail: string, expectedStatus: 'approved') => {
+  const enrollment = await getLatestEnrollmentForGuardian(guardianEmail)
+  return waitForEnrollmentRecordStatus(enrollment.id, expectedStatus)
+}
+
+const waitForEnrollmentRecordStatus = async (enrollmentId: string, expectedStatus: 'approved') => {
+  const adminSupabase = getAdminSupabaseClient()
+  const started = Date.now()
+  while (Date.now() - started < 20_000) {
+    const { data, error } = await adminSupabase
+      .from('workshop_enrollment')
+      .select('id, status, requested_at')
+      .eq('id', enrollmentId)
+      .single()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    if (data?.status === expectedStatus) return data
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+  throw new Error(`Enrollment did not reach status ${expectedStatus} in time`)
+}
+
+const waitForAcceptedEmailLog = async ({
+  enrollmentId,
+  recipientEmail,
+}: {
+  enrollmentId: string
+  recipientEmail: string
+}) => {
+  const adminSupabase = getAdminSupabaseClient()
+  const normalizedEmail = recipientEmail.toLowerCase()
+  const started = Date.now()
+
+  while (Date.now() - started < 20_000) {
+    const { data, error } = await adminSupabase
+      .from('email_message')
+      .select('id, status, template_key, to_email, workshop_enrollment_id, error_message, created_at')
+      .eq('workshop_enrollment_id', enrollmentId)
+      .eq('template_key', 'family_enrollment_accepted_v1')
+      .eq('to_email', normalizedEmail)
+      .order('created_at', { ascending: false })
+      .limit(1)
+
+    if (error) throw new Error(error.message)
+    if ((data ?? []).length > 0) {
+      return data?.[0]
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+
+  throw new Error('No accepted-email log row found for guardian after approval')
+}
+
+const assertGuardianProfileName = async ({
+  guardianEmail,
+  firstName,
+  surname,
+}: {
+  guardianEmail: string
+  firstName: string
+  surname: string
+}) => {
+  const adminSupabase = getAdminSupabaseClient()
+  const { data, error } = await adminSupabase
+    .from('profile')
+    .select('firstname, surname')
+    .eq('email', guardianEmail)
+    .single()
+
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Guardian profile not found for name verification')
+  }
+
+  expect(data.firstname).toBe(firstName)
+  expect(data.surname).toBe(surname)
 }
 
 test.describe.serial('admin-managed enrollment lifecycle', () => {
@@ -319,7 +429,9 @@ test.describe.serial('admin-managed enrollment lifecycle', () => {
   })
 
   test('guardian requests enrollment and admin accepts it', async ({ page }) => {
-    const { guardianEmail } = await guardianSignupAndRequestEnrollment(page)
+    const { guardianEmail, firstName, surname } = await guardianSignupAndRequestEnrollment(page)
+    await assertGuardianProfileName({ guardianEmail, firstName, surname })
+
     const enrollment = await getLatestEnrollmentForGuardian(guardianEmail)
 
     await expect(['pending', 'waitlisted']).toContain(enrollment.status)
@@ -336,7 +448,14 @@ test.describe.serial('admin-managed enrollment lifecycle', () => {
 
     expect(response.ok()).toBeTruthy()
 
-    const updated = await getLatestEnrollmentForGuardian(guardianEmail)
+    const updated = await waitForEnrollmentRecordStatus(enrollment.id, 'approved')
     expect(updated.status).toBe('approved')
+
+    const acceptedEmailLog = await waitForAcceptedEmailLog({
+      enrollmentId: enrollment.id,
+      recipientEmail: guardianEmail,
+    })
+    expect(acceptedEmailLog.template_key).toBe('family_enrollment_accepted_v1')
+    expect(acceptedEmailLog.to_email).toBe(guardianEmail.toLowerCase())
   })
 })

--- a/web/tests/e2e/admin-enrollment-approval.spec.ts
+++ b/web/tests/e2e/admin-enrollment-approval.spec.ts
@@ -1,0 +1,342 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  ensureReusableAdminAccount,
+  getAdminSupabaseClient,
+  hasAdminServiceEnv,
+  loginAsAdmin,
+} from './helpers/admin-account'
+
+const uniqueSuffix = () => {
+  const now = new Date()
+  return `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}${String(now.getMilliseconds()).padStart(3, '0')}`
+}
+
+const fillRequiredFields = async (page: import('@playwright/test').Page) => {
+  const form = page.locator('form').first()
+
+  const requiredTextInputs = form.locator(
+    'input[required]:not([type="hidden"]):not([type="radio"]):not([type="checkbox"])'
+  )
+
+  const inputCount = await requiredTextInputs.count()
+  for (let index = 0; index < inputCount; index += 1) {
+    const input = requiredTextInputs.nth(index)
+    const currentValue = await input.inputValue()
+    if (currentValue.trim()) continue
+
+    const inputType = (await input.getAttribute('type')) ?? 'text'
+    const inputName = ((await input.getAttribute('name')) ?? '').toLowerCase()
+
+    if (inputType === 'date') {
+      await input.fill('2012-05-10')
+      continue
+    }
+
+    if (inputType === 'number') {
+      await input.fill('2')
+      continue
+    }
+
+    if (inputType === 'email') {
+      await input.fill(`sai+tests${uniqueSuffix()}@chsolutions.ca`)
+      continue
+    }
+
+    if (inputName.includes('postcode') || inputName.includes('postal')) {
+      await input.fill('K1A 0B1')
+      continue
+    }
+
+    await input.fill('Auto value')
+  }
+
+  const requiredSelectNames = await form
+    .locator('select[required]')
+    .evaluateAll(selects =>
+      Array.from(new Set(selects.map(select => select.getAttribute('name')).filter((name): name is string => Boolean(name))))
+    )
+
+  for (const name of requiredSelectNames) {
+    const select = form.locator(`select[name="${name}"]`).first()
+    if (!(await select.isVisible())) continue
+    if (!(await select.isEnabled())) continue
+
+    const value = await select.inputValue()
+    if (value) continue
+
+    const options = await select.locator('option').all()
+    for (const option of options) {
+      const optionValue = (await option.getAttribute('value')) ?? ''
+      const disabled = (await option.getAttribute('disabled')) !== null
+      if (!optionValue || disabled) continue
+      await select.selectOption(optionValue)
+      break
+    }
+  }
+
+  const checkboxNames = await form
+    .locator('input[type="checkbox"][name^="question_"], input[type="checkbox"][required]')
+    .evaluateAll(inputs =>
+      Array.from(new Set(inputs.map(input => input.getAttribute('name')).filter((name): name is string => Boolean(name))))
+    )
+
+  for (const name of checkboxNames) {
+    const checkbox = form.locator(`input[type="checkbox"][name="${name}"]`).first()
+    if (!(await checkbox.isVisible())) continue
+    if (!(await checkbox.isEnabled())) continue
+    await checkbox.check()
+  }
+
+  const radioNames = await form
+    .locator('input[type="radio"][required]')
+    .evaluateAll(inputs =>
+      Array.from(new Set(inputs.map(input => input.getAttribute('name')).filter((name): name is string => Boolean(name))))
+    )
+
+  for (const name of radioNames) {
+    const checked = await form.locator(`input[type="radio"][name="${name}"]:checked`).count()
+    if (checked > 0) continue
+    await form.locator(`input[type="radio"][name="${name}"]`).first().check()
+  }
+}
+
+const countMissingRequiredFields = async (page: import('@playwright/test').Page) => {
+  const form = page.locator('form').first()
+  return form.evaluate(formEl => {
+    const getVisible = (element: HTMLElement) => {
+      const style = window.getComputedStyle(element)
+      return style.display !== 'none' && style.visibility !== 'hidden' && element.offsetParent !== null
+    }
+
+    let missing = 0
+
+    const requiredInputs = Array.from(
+      formEl.querySelectorAll<HTMLInputElement>('input[required]:not([type="hidden"])')
+    ).filter(input => !input.disabled && getVisible(input))
+
+    const handledRadioNames = new Set<string>()
+
+    for (const input of requiredInputs) {
+      if (input.type === 'radio') {
+        if (!input.name || handledRadioNames.has(input.name)) continue
+        handledRadioNames.add(input.name)
+        const checked = formEl.querySelector(`input[type="radio"][name="${CSS.escape(input.name)}"]:checked`)
+        if (!checked) missing += 1
+        continue
+      }
+
+      if (input.type === 'checkbox') {
+        if (!input.checked) missing += 1
+        continue
+      }
+
+      if (!input.value.trim()) missing += 1
+    }
+
+    const requiredSelects = Array.from(formEl.querySelectorAll<HTMLSelectElement>('select[required]')).filter(
+      select => !select.disabled && getVisible(select)
+    )
+
+    for (const select of requiredSelects) {
+      if (!select.value) missing += 1
+    }
+
+    return missing
+  })
+}
+
+const submitStepWithRetry = async (
+  page: import('@playwright/test').Page,
+  submitName: RegExp | string,
+  maxAttempts = 3
+) => {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    await fillRequiredFields(page)
+
+    const missingBeforeSubmit = await countMissingRequiredFields(page)
+    if (missingBeforeSubmit > 0) {
+      await page.waitForTimeout(400)
+      continue
+    }
+
+    const submitButton = page.getByRole('button', { name: submitName }).first()
+    await submitButton.click()
+    await page.waitForTimeout(500)
+
+    const errorPrompt = page.locator('p.text-red-500').first()
+    if ((await errorPrompt.count()) === 0 || !(await errorPrompt.isVisible())) {
+      return
+    }
+  }
+
+  throw new Error('Form could not be submitted cleanly after retries')
+}
+
+const guardianSignupAndRequestEnrollment = async (page: import('@playwright/test').Page) => {
+  const email = `sai+tests${uniqueSuffix()}@chsolutions.ca`
+  const password = 'Password123456!'
+
+  await page.goto('/sign-up')
+  await page.getByRole('button', { name: 'I am a Guardian' }).click()
+  await page.getByLabel('Gmail').fill(email)
+  await page.getByLabel('Password', { exact: true }).fill(password)
+  await page.getByLabel('Repeat Password').fill(password)
+  await page.getByLabel(/I have read and agree to the/i).check()
+  await page.getByRole('button', { name: 'Next' }).click()
+
+  await expect(page).toHaveURL(/\/auth\/sign-up-details/)
+
+  for (let step = 0; step < 20; step += 1) {
+    if (page.url().includes('/home')) break
+
+    const saveAndContinue = page.getByRole('button', { name: /Save and continue|Saving\.\.\./ })
+    await Promise.race([
+      page.waitForURL(/\/home/, { timeout: 10000 }),
+      saveAndContinue.first().waitFor({ state: 'visible', timeout: 10000 }),
+    ])
+
+    if (page.url().includes('/home')) break
+
+    if ((await page.locator('input[name="question_child_has_email"][value="No"]').count()) > 0) {
+      await page.locator('input[name="question_child_has_email"][value="No"]').check()
+    }
+
+    if ((await page.locator('input[name="additional_guardian_choice"][value="no"]').count()) > 0) {
+      await page.locator('input[name="additional_guardian_choice"][value="no"]').check()
+    }
+
+    await submitStepWithRetry(page, /Save and continue|Saving\.\.\./)
+    await page.waitForLoadState('networkidle')
+  }
+
+  await expect(page).toHaveURL(/\/home/)
+
+  const manageEnrollmentsLink = page.locator('a[href="/enroll"]').first()
+  if ((await manageEnrollmentsLink.count()) > 0) {
+    await manageEnrollmentsLink.click({ timeout: 5000 })
+  } else {
+    await page.goto('/enroll')
+  }
+
+  if (!page.url().includes('/enroll')) {
+    await page.goto('/enroll')
+  }
+  await expect(page).toHaveURL(/\/enroll/)
+
+  const preProgramLink = page.getByRole('link', { name: 'Complete pre-program survey' })
+
+  if (page.url().match(/\/enroll\/[^/]+$/) && (await preProgramLink.count()) === 0) {
+    const changeSemesterLink = page.getByRole('link', { name: 'Change semester' })
+    if ((await changeSemesterLink.count()) > 0) {
+      await changeSemesterLink.click()
+      await expect(page).toHaveURL(/\/enroll$/)
+    }
+  }
+
+  if (page.url().endsWith('/enroll')) {
+    const rows = page.locator('tbody tr')
+    const rowCount = await rows.count()
+    let openedSurvey = false
+
+    for (let index = 0; index < rowCount; index += 1) {
+      const row = rows.nth(index)
+      const selectSemesterLink = row.getByRole('link', { name: 'Select semester' })
+      if ((await selectSemesterLink.count()) === 0) continue
+
+      await selectSemesterLink.click()
+      await expect(page).toHaveURL(/\/enroll\/[^/]+$/)
+
+      if ((await preProgramLink.count()) > 0) {
+        openedSurvey = true
+        break
+      }
+
+      const changeSemesterLink = page.getByRole('link', { name: 'Change semester' })
+      if ((await changeSemesterLink.count()) > 0) {
+        await changeSemesterLink.click()
+        await expect(page).toHaveURL(/\/enroll$/)
+      }
+    }
+
+    if (!openedSurvey) {
+      throw new Error('Could not find a semester with a pre-program survey link')
+    }
+  }
+
+  await expect(preProgramLink).toBeVisible()
+  await preProgramLink.click()
+  await submitStepWithRetry(page, 'Save and continue', 4)
+
+  const enrollAction = page.getByRole('button', { name: /Request enrollment|Join waitlist/ }).first()
+  await expect(enrollAction).toBeVisible()
+  await enrollAction.click()
+
+  await expect(page).toHaveURL(/\/home\?/)
+  await expect(page).toHaveURL(/enrollmentStatus=success/)
+
+  return { guardianEmail: email }
+}
+
+const getLatestEnrollmentForGuardian = async (guardianEmail: string) => {
+  const adminSupabase = getAdminSupabaseClient()
+
+  const { data: guardianProfile, error: guardianProfileError } = await adminSupabase
+    .from('profile')
+    .select('id')
+    .eq('email', guardianEmail)
+    .single()
+
+  if (guardianProfileError || !guardianProfile?.id) {
+    throw new Error(guardianProfileError?.message ?? 'Guardian profile not found')
+  }
+
+  const { data: enrollment, error: enrollmentError } = await adminSupabase
+    .from('workshop_enrollment')
+    .select('id, status')
+    .eq('profile_id', guardianProfile.id)
+    .order('requested_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (enrollmentError || !enrollment?.id) {
+    throw new Error(enrollmentError?.message ?? 'Enrollment not found for guardian')
+  }
+
+  return enrollment
+}
+
+test.describe.serial('admin-managed enrollment lifecycle', () => {
+  test.skip(!hasAdminServiceEnv(), 'Requires SUPABASE_URL and SUPABASE_SECRET_KEY for admin setup')
+
+  test.beforeAll(async () => {
+    await ensureReusableAdminAccount()
+  })
+
+  test('creates or reuses shared admin account for admin tests', async ({ page }) => {
+    await loginAsAdmin(page)
+    await expect(page).toHaveURL(/\/manage/)
+  })
+
+  test('guardian requests enrollment and admin accepts it', async ({ page }) => {
+    const { guardianEmail } = await guardianSignupAndRequestEnrollment(page)
+    const enrollment = await getLatestEnrollmentForGuardian(guardianEmail)
+
+    await expect(['pending', 'waitlisted']).toContain(enrollment.status)
+
+    await loginAsAdmin(page)
+
+    const response = await page.request.post('/manage/workshop-enrollment', {
+      form: {
+        intent: 'update-status',
+        enrollment_id: enrollment.id,
+        status: 'approved',
+      },
+    })
+
+    expect(response.ok()).toBeTruthy()
+
+    const updated = await getLatestEnrollmentForGuardian(guardianEmail)
+    expect(updated.status).toBe('approved')
+  })
+})

--- a/web/tests/e2e/helpers/admin-account.ts
+++ b/web/tests/e2e/helpers/admin-account.ts
@@ -1,0 +1,143 @@
+import { expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const ADMIN_EMAIL = 'sai+testsadmin@chsolutions.ca'
+export const ADMIN_PASSWORD = 'Password123456!'
+
+const readLocalEnv = () => {
+  const envPath = path.join(process.cwd(), '.env.local')
+  if (!fs.existsSync(envPath)) {
+    return {} as Record<string, string>
+  }
+  const raw = fs.readFileSync(envPath, 'utf8')
+  const lines = raw.split(/\r?\n/)
+  const values: Record<string, string> = {}
+
+  for (const line of lines) {
+    if (!line || line.trim().startsWith('#')) continue
+    const index = line.indexOf('=')
+    if (index <= 0) continue
+    const key = line.slice(0, index).trim()
+    const value = line.slice(index + 1).trim()
+    if (key) values[key] = value
+  }
+
+  return values
+}
+
+const getServiceEnv = () => {
+  const fileEnv = readLocalEnv()
+  return {
+    SUPABASE_URL: process.env.SUPABASE_URL || fileEnv.SUPABASE_URL || fileEnv.VITE_SUPABASE_URL,
+    SUPABASE_SECRET_KEY: process.env.SUPABASE_SECRET_KEY || fileEnv.SUPABASE_SECRET_KEY,
+  }
+}
+
+export const hasAdminServiceEnv = () => {
+  const env = getServiceEnv()
+  return Boolean(env.SUPABASE_URL && env.SUPABASE_SECRET_KEY)
+}
+
+export const getAdminSupabaseClient = () => {
+  const env = getServiceEnv()
+  const supabaseUrl = env.SUPABASE_URL
+  const serviceRoleKey = env.SUPABASE_SECRET_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      'Missing SUPABASE_URL and SUPABASE_SECRET_KEY (set in environment or web/.env.local)'
+    )
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  })
+}
+
+const findAuthUserByEmail = async (adminSupabase: ReturnType<typeof getAdminSupabaseClient>, email: string) => {
+  let page = 1
+
+  while (true) {
+    const { data, error } = await adminSupabase.auth.admin.listUsers({ page, perPage: 200 })
+    if (error) throw new Error(error.message)
+
+    const users = data?.users ?? []
+    const found = users.find(user => (user.email ?? '').toLowerCase() === email.toLowerCase())
+    if (found) return found
+
+    if (users.length < 200) break
+    page += 1
+  }
+
+  return null
+}
+
+export const ensureReusableAdminAccount = async () => {
+  const adminSupabase = getAdminSupabaseClient()
+  let user = await findAuthUserByEmail(adminSupabase, ADMIN_EMAIL)
+
+  if (!user) {
+    const { data, error } = await adminSupabase.auth.admin.createUser({
+      email: ADMIN_EMAIL,
+      password: ADMIN_PASSWORD,
+      email_confirm: true,
+      user_metadata: { role: 'admin' },
+    })
+
+    if (error) throw new Error(`Unable to create admin user: ${error.message}`)
+    user = data.user
+  }
+
+  if (!user) {
+    throw new Error('Admin user creation returned no user record')
+  }
+
+  const { error: updateError } = await adminSupabase.auth.admin.updateUserById(user.id, {
+    password: ADMIN_PASSWORD,
+    email_confirm: true,
+    user_metadata: {
+      ...(user.user_metadata ?? {}),
+      role: 'admin',
+    },
+  })
+
+  if (updateError) {
+    throw new Error(`Unable to normalize admin user password/metadata: ${updateError.message}`)
+  }
+
+  const { error: profileError } = await adminSupabase
+    .from('profile')
+    .upsert(
+      {
+        user_id: user.id,
+        role: 'admin',
+        email: ADMIN_EMAIL,
+        firstname: 'Sai',
+        surname: 'Tests Admin',
+        password_set: true,
+      },
+      { onConflict: 'email' }
+    )
+
+  if (profileError) {
+    throw new Error(`Unable to upsert admin profile: ${profileError.message}`)
+  }
+
+  const { error: roleError } = await adminSupabase
+    .from('user_roles')
+    .upsert({ user_id: user.id, role: 'admin', assigned_by: user.id }, { onConflict: 'user_id' })
+
+  if (roleError) {
+    throw new Error(`Unable to upsert admin role: ${roleError.message}`)
+  }
+}
+
+export const loginAsAdmin = async (page: import('@playwright/test').Page) => {
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(ADMIN_EMAIL)
+  await page.getByLabel('Password').fill(ADMIN_PASSWORD)
+  await page.getByRole('button', { name: 'Login' }).click()
+  await expect(page).toHaveURL(/\/manage/)
+}

--- a/web/tests/e2e/helpers/admin-account.ts
+++ b/web/tests/e2e/helpers/admin-account.ts
@@ -135,7 +135,15 @@ export const ensureReusableAdminAccount = async () => {
 }
 
 export const loginAsAdmin = async (page: import('@playwright/test').Page) => {
+  await page.context().clearCookies()
   await page.goto('/login')
+
+  const emailInput = page.getByLabel('Email')
+  if (!(await emailInput.isVisible({ timeout: 3000 }).catch(() => false))) {
+    await page.goto('/logout')
+    await page.goto('/login')
+  }
+
   await page.getByLabel('Email').fill(ADMIN_EMAIL)
   await page.getByLabel('Password').fill(ADMIN_PASSWORD)
   await page.getByRole('button', { name: 'Login' }).click()

--- a/web/tests/unit/email-drafts.spec.ts
+++ b/web/tests/unit/email-drafts.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test'
+
+import { renderEmailDraft } from '../../app/lib/email/drafts/renderer.server'
+import { validateDraftForPublish } from '../../app/lib/email/drafts/validators'
+
+test('renderer interpolates variables and reports missing placeholders', async () => {
+  const rendered = renderEmailDraft({
+    subjectMarkdown: 'Enrollment for {{workshopName}}',
+    bodyMarkdown: 'Hello {{actorName}} and {{missingValue}}',
+    variables: {
+      workshopName: 'Spring Kitchen',
+      actorName: 'Alex',
+    },
+  })
+
+  expect(rendered.subject).toBe('Enrollment for Spring Kitchen')
+  expect(rendered.text).toContain('Hello Alex and {{missingValue}}')
+  expect(rendered.missingVariables).toEqual(['missingValue'])
+})
+
+test('publish validation requires trigger summary for transactional drafts', async () => {
+  const missingTrigger = validateDraftForPublish({
+    channel: 'transactional',
+    triggerSummary: '   ',
+    subjectMarkdown: 'Subject',
+    bodyMarkdown: 'Body',
+    variablesSchema: {},
+  })
+
+  expect(missingTrigger.ok).toBeFalsy()
+  expect(missingTrigger.errors).toContain('A short trigger summary is required for transactional drafts.')
+
+  const authWithoutTrigger = validateDraftForPublish({
+    channel: 'auth',
+    triggerSummary: '',
+    subjectMarkdown: 'Subject',
+    bodyMarkdown: 'Body',
+    variablesSchema: {},
+  })
+
+  expect(authWithoutTrigger.ok).toBeTruthy()
+})
+
+test('publish validation enforces required placeholders from schema', async () => {
+  const validation = validateDraftForPublish({
+    channel: 'transactional',
+    triggerSummary: 'Sent right after enrollment request.',
+    subjectMarkdown: 'Enrollment received',
+    bodyMarkdown: 'Hello {{actorName}}',
+    variablesSchema: {
+      required: ['actorName', 'workshopName'],
+    },
+  })
+
+  expect(validation.ok).toBeFalsy()
+  expect(validation.errors).toContain(
+    'Required variable {{workshopName}} is missing from subject/body markdown.'
+  )
+})


### PR DESCRIPTION
## What
- add transactional draft trigger metadata and seeded draft records
- enable feature-flagged draft resolver path for transactional sends and resend compatibility
- improve email draft editor UX (advanced technical fields + collapsed create panel)
- add reusable admin account e2e helper and guardian enrollment admin-approval test

## Verification
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:e2e`