### PR TITLE
Expand seed scenarios and add riding analytics counts

### DIFF
--- a/docs/transactional-email-migration-runbook.md
+++ b/docs/transactional-email-migration-runbook.md
@@ -1,0 +1,53 @@
+# Transactional Email Migration Runbook
+
+This runbook covers rollout from legacy inline templates to `email_draft`-backed transactional templates.
+
+## Current transactional template keys
+- `family_enrollment_requested_v1`
+- `family_enrollment_accepted_v1`
+
+## Env flags
+- Mode (preferred): `EMAIL_DRAFT_MODE_<TEMPLATE_KEY_NORMALIZED>` where value is `legacy`, `shadow`, or `draft`.
+- Backward-compatible boolean (temporary): `EMAIL_DRAFT_USE_<TEMPLATE_KEY_NORMALIZED>=true` to force `draft` mode.
+- Fallback policy: `EMAIL_DRAFT_FALLBACK_POLICY=fallback-legacy|fail-closed`.
+
+Example normalized keys:
+- `EMAIL_DRAFT_MODE_FAMILY_ENROLLMENT_REQUESTED_V1`
+- `EMAIL_DRAFT_MODE_FAMILY_ENROLLMENT_ACCEPTED_V1`
+
+## Migration modes
+- `legacy`: send using legacy renderer only.
+- `shadow`: send legacy email, but also render draft and log parity (`match`/`mismatch`).
+- `draft`: send using published draft when available.
+
+## Rollout plan
+1. Verify both transactional drafts exist and are published in manage > email drafts.
+2. Set both templates to `shadow` mode.
+3. Trigger real enrollment requested/accepted flows in staging.
+4. Check logs for parity output:
+   - `[email][migration][shadow][match]`
+   - `[email][migration][shadow][mismatch]`
+   - `[email][migration][shadow][draft-missing]`
+5. Fix mismatches or missing drafts, then re-run checks.
+6. Move one template to `draft` mode, keep the other in `shadow`.
+7. Monitor send outcomes in `email_message` and logs for at least one business cycle.
+8. Move the second template to `draft` mode.
+
+## Fallback and rollback
+- If draft content is missing in `draft` mode:
+  - `fallback-legacy` sends legacy content and records fallback metadata.
+  - `fail-closed` fails send with explicit error.
+- Emergency rollback: set template mode to `legacy` and redeploy.
+
+## Verification checklist
+- New sends include migration metadata in `email_message.template_data`:
+  - `_migration_mode`
+  - `_template_source`
+  - optional `_parity_check`
+  - optional `_fallback_applied`, `_fallback_reason`
+- `resendEmailMessageById` behavior:
+  - uses draft rendering when mode is not `legacy` and draft exists
+  - falls back to legacy rendering otherwise
+- Unit coverage includes:
+  - mode parsing (`legacy|shadow|draft` + boolean compatibility)
+  - parity checks for requested/accepted templates

--- a/supabase/seeds/dummy-data/class-section-sample.sql
+++ b/supabase/seeds/dummy-data/class-section-sample.sql
@@ -1,39 +1,137 @@
--- Seed enrollment and attendance scenarios for prior and current semesters.
+-- Seed enrollment and attendance scenarios using fewer students and semesters.
 
-insert into public.profile (id, role, firstname, surname, email, phone, postcode, partner_program)
+insert into public.profile (
+  id,
+  role,
+  firstname,
+  surname,
+  email,
+  phone,
+  street_address,
+  city,
+  province,
+  postcode,
+  federal_electoral_district_name,
+  partner_program
+)
 values
-  ('22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'student', 'Layla', 'Khan', null, null, null, null),
-  ('33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'student', 'Avery', 'Lee', 'avery.lee@example.com', '4165550103', 'A1A 1A1', 'Thorncliffe Park -TNO'),
-  ('44444444-dddd-dddd-dddd-444444444444'::uuid, 'student', 'Noah', 'Silva', null, null, null, null),
-  ('55555555-eeee-eeee-eeee-555555555555'::uuid, 'student', 'Mina', 'Patel', null, null, null, null),
-  ('66666666-ffff-ffff-ffff-666666666666'::uuid, 'student', 'Sofia', 'Nguyen', null, null, null, null),
-  ('77777777-1111-1111-1111-777777777777'::uuid, 'student', 'Arjun', 'Singh', null, null, null, null),
-  ('88888888-2222-2222-2222-888888888888'::uuid, 'student', 'Rayan', 'Ali', null, null, null, null),
-  ('99999999-3333-3333-3333-999999999999'::uuid, 'student', 'Zara', 'Brown', null, null, null, null),
-  ('aaaaaaaa-4444-4444-4444-aaaaaaaa4444'::uuid, 'student', 'Ibrahim', 'Ahmed', null, null, null, null),
-  ('bbbbbbbb-5555-5555-5555-bbbbbbbb5555'::uuid, 'student', 'Mila', 'Johnson', null, null, null, null),
-  ('cccccccc-6666-6666-6666-cccccccc6666'::uuid, 'student', 'Lucas', 'Wilson', null, null, null, null),
-  ('dddddddd-7777-7777-7777-dddddddd7777'::uuid, 'student', 'Aisha', 'Martin', null, null, null, null),
-  ('eeeeeeee-8888-8888-8888-eeeeeeee8888'::uuid, 'student', 'Omar', 'Garcia', null, null, null, null)
+  (
+    '22222222-bbbb-bbbb-bbbb-222222222222'::uuid,
+    'student',
+    'Layla',
+    'Khan',
+    null,
+    null,
+    '45 Overlea Blvd',
+    'Toronto',
+    'ON',
+    'M4H 1C3',
+    'Don Valley West',
+    null
+  ),
+  (
+    '33333333-bbbb-bbbb-bbbb-333333333333'::uuid,
+    'student',
+    'Avery',
+    'Lee',
+    'avery.lee@example.com',
+    '4165550103',
+    '91 Rylander Blvd',
+    'Toronto',
+    'ON',
+    'M1B 5M5',
+    'Scarborough North',
+    'Thorncliffe Park -TNO'
+  ),
+  (
+    '44444444-dddd-dddd-dddd-444444444444'::uuid,
+    'student',
+    'Noah',
+    'Silva',
+    null,
+    null,
+    '2 Berkeley St',
+    'Toronto',
+    'ON',
+    'M5A 4J5',
+    'Toronto Centre',
+    null
+  ),
+  (
+    '55555555-eeee-eeee-eeee-555555555555'::uuid,
+    'student',
+    'Mina',
+    'Patel',
+    null,
+    null,
+    '1050 Kipling Ave',
+    'Etobicoke',
+    'ON',
+    'M9B 5L6',
+    'Etobicoke Centre',
+    null
+  ),
+  (
+    '66666666-ffff-ffff-ffff-666666666666'::uuid,
+    'student',
+    'Sofia',
+    'Nguyen',
+    null,
+    null,
+    '150 Borough Dr',
+    'Scarborough',
+    'ON',
+    'M1P 4N7',
+    'Scarborough Centre—Don Valley East',
+    null
+  ),
+  (
+    '77777777-1111-1111-1111-777777777777'::uuid,
+    'student',
+    'Arjun',
+    'Singh',
+    null,
+    null,
+    '30 Regent St',
+    'Toronto',
+    'ON',
+    'M5A 0E2',
+    'Toronto Centre',
+    null
+  )
 on conflict (id) do update
   set role = excluded.role,
       firstname = excluded.firstname,
       surname = excluded.surname,
       email = excluded.email,
       phone = excluded.phone,
+      street_address = excluded.street_address,
+      city = excluded.city,
+      province = excluded.province,
       postcode = excluded.postcode,
+      federal_electoral_district_name = excluded.federal_electoral_district_name,
       partner_program = excluded.partner_program;
 
 insert into public.semester (id, name, description, starts_at, ends_at, enrollment_open_at, enrollment_close_at)
-values (
-  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
-  'Prior Summer Semester',
-  'Previous-year semester for enrollment and attendance scenario seeds.',
-  date_trunc('year', now()) - interval '1 year' + interval '5 months',
-  date_trunc('year', now()) - interval '1 year' + interval '6 months' - interval '1 second',
-  now() - interval '30 days',
-  now() + interval '1 year'
-)
+values
+  (
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+    'Prior Summer Semester',
+    'Previous-year semester for attendance and gift-card reconciliation scenarios.',
+    date_trunc('year', now()) - interval '1 year' + interval '5 months',
+    date_trunc('year', now()) - interval '1 year' + interval '6 months' - interval '1 second',
+    now() - interval '300 days',
+    now() - interval '180 days'
+  ),
+  (
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+    'Current Summer Semester',
+    'Current-year semester for approved, pending, waitlisted, and declined states.',
+    date_trunc('year', now()) + interval '5 months',
+    date_trunc('year', now()) + interval '6 months' - interval '1 second',
+    date_trunc('year', now()) + interval '3 months',
+    date_trunc('year', now()) + interval '5 months' - interval '1 second'
+  )
 on conflict (id) do update
   set name = excluded.name,
       description = excluded.description,
@@ -51,15 +149,34 @@ insert into public.workshop (
   capacity,
   wait_list_capacity
 )
-values (
-  '11111111-1111-1111-1111-111111111111'::uuid,
-  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
-  'Prior Semester - Family Cooking',
-  now() - interval '30 days',
-  now() + interval '1 year',
-  5,
-  2
-)
+values
+  (
+    '11111111-1111-1111-1111-111111111111'::uuid,
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+    'Prior Semester - Family Cooking',
+    now() - interval '360 days',
+    now() - interval '210 days',
+    4,
+    2
+  ),
+  (
+    'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+    'Current Session A - Enrollment Triage',
+    date_trunc('year', now()) + interval '3 months',
+    date_trunc('year', now()) + interval '5 months' - interval '1 second',
+    3,
+    2
+  ),
+  (
+    'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+    'Current Session B - Remaining Capacity',
+    date_trunc('year', now()) + interval '3 months',
+    date_trunc('year', now()) + interval '5 months' - interval '1 second',
+    2,
+    1
+  )
 on conflict (id) do update
   set semester_id = excluded.semester_id,
       description = excluded.description,
@@ -76,93 +193,6 @@ values
     date_trunc('year', now()) - interval '1 year' + interval '5 months' + interval '6 days 16 hours',
     date_trunc('year', now()) - interval '1 year' + interval '5 months' + interval '6 days 17 hours 30 minutes'
   ),
-  (
-    'aaaaaaaa-2222-2222-2222-aaaaaaaa2222'::uuid,
-    '11111111-1111-1111-1111-111111111111'::uuid,
-    date_trunc('year', now()) - interval '1 year' + interval '5 months' + interval '13 days 16 hours',
-    date_trunc('year', now()) - interval '1 year' + interval '5 months' + interval '13 days 17 hours 30 minutes'
-  )
-on conflict (id) do update
-  set workshop_id = excluded.workshop_id,
-      starts_at = excluded.starts_at,
-      ends_at = excluded.ends_at;
-
-insert into public.workshop_enrollment (workshop_id, semester_id, profile_id, status)
-values
-  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'approved'),
-  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'approved'),
-  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'approved')
-on conflict (semester_id, profile_id) do update
-  set workshop_id = excluded.workshop_id,
-      status = excluded.status;
-
-insert into public.class_attendance (class_id, profile_id, status)
-values
-  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'present'),
-  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'present'),
-  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'absent'),
-  ('aaaaaaaa-2222-2222-2222-aaaaaaaa2222'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'present'),
-  ('aaaaaaaa-2222-2222-2222-aaaaaaaa2222'::uuid, '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'absent'),
-  ('aaaaaaaa-2222-2222-2222-aaaaaaaa2222'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'present')
-on conflict (class_id, profile_id) do update
-  set status = excluded.status;
-
-insert into public.semester (id, name, description, starts_at, ends_at, enrollment_open_at, enrollment_close_at)
-values (
-  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
-  'Current Summer Semester',
-  'Current-year semester for enrollment and waitlist scenario seeds.',
-  date_trunc('year', now()) + interval '5 months',
-  date_trunc('year', now()) + interval '6 months' - interval '1 second',
-  date_trunc('year', now()) + interval '3 months',
-  date_trunc('year', now()) + interval '5 months' - interval '1 second'
-)
-on conflict (id) do update
-  set name = excluded.name,
-      description = excluded.description,
-      starts_at = excluded.starts_at,
-      ends_at = excluded.ends_at,
-      enrollment_open_at = excluded.enrollment_open_at,
-      enrollment_close_at = excluded.enrollment_close_at;
-
-insert into public.workshop (
-  id,
-  semester_id,
-  description,
-  enrollment_open_at,
-  enrollment_close_at,
-  capacity,
-  wait_list_capacity
-)
-values
-  (
-    'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
-    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
-    'June Session A - Overflow Interest',
-    date_trunc('year', now()) + interval '3 months',
-    date_trunc('year', now()) + interval '5 months' - interval '1 second',
-    5,
-    2
-  ),
-  (
-    'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
-    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
-    'June Session B - Waitlist In Progress',
-    date_trunc('year', now()) + interval '3 months',
-    date_trunc('year', now()) + interval '5 months' - interval '1 second',
-    5,
-    2
-  )
-on conflict (id) do update
-  set semester_id = excluded.semester_id,
-      description = excluded.description,
-      enrollment_open_at = excluded.enrollment_open_at,
-      enrollment_close_at = excluded.enrollment_close_at,
-      capacity = excluded.capacity,
-      wait_list_capacity = excluded.wait_list_capacity;
-
-insert into public.class (id, workshop_id, starts_at, ends_at)
-values
   (
     'bbbbbbbb-1111-1111-1111-bbbbbbbb1111'::uuid,
     'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
@@ -182,22 +212,26 @@ on conflict (id) do update
 
 insert into public.workshop_enrollment (workshop_id, semester_id, profile_id, status)
 values
-  -- Workshop A: accepted < capacity (4 < 5), total enrollments > capacity (7 > 5)
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'approved'),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'approved'),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'approved'),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '55555555-eeee-eeee-eeee-555555555555'::uuid, 'approved'),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '66666666-ffff-ffff-ffff-666666666666'::uuid, 'pending'),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '77777777-1111-1111-1111-777777777777'::uuid, 'pending'),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '88888888-2222-2222-2222-888888888888'::uuid, 'waitlisted'),
+  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'approved'),
+  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'revoked'),
+  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'approved'),
 
-  -- Workshop B: accepted == capacity (5), waitlisted < waitlist capacity (1 < 2)
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '99999999-3333-3333-3333-999999999999'::uuid, 'approved'),
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'aaaaaaaa-4444-4444-4444-aaaaaaaa4444'::uuid, 'approved'),
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'bbbbbbbb-5555-5555-5555-bbbbbbbb5555'::uuid, 'approved'),
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'cccccccc-6666-6666-6666-cccccccc6666'::uuid, 'approved'),
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'dddddddd-7777-7777-7777-dddddddd7777'::uuid, 'approved'),
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'eeeeeeee-8888-8888-8888-eeeeeeee8888'::uuid, 'waitlisted')
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'approved'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'pending'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'waitlisted'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '55555555-eeee-eeee-eeee-555555555555'::uuid, 'rejected'),
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '66666666-ffff-ffff-ffff-666666666666'::uuid, 'approved'),
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, '77777777-1111-1111-1111-777777777777'::uuid, 'pending')
 on conflict (semester_id, profile_id) do update
   set workshop_id = excluded.workshop_id,
       status = excluded.status;
+
+insert into public.class_attendance (class_id, profile_id, status)
+values
+  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'present'),
+  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'absent'),
+  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'present'),
+  ('bbbbbbbb-1111-1111-1111-bbbbbbbb1111'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'unknown'),
+  ('bbbbbbbb-2222-2222-2222-bbbbbbbb2222'::uuid, '66666666-ffff-ffff-ffff-666666666666'::uuid, 'present')
+on conflict (class_id, profile_id) do update
+  set status = excluded.status;

--- a/supabase/seeds/dummy-data/gift-card-sample.sql
+++ b/supabase/seeds/dummy-data/gift-card-sample.sql
@@ -1,72 +1,20 @@
--- Sample gift card uploads and assets tied to last year's attendance.
-with last_year_semester as (
-  insert into public.semester (id, name, description, starts_at, ends_at, enrollment_open_at, enrollment_close_at)
-  values (
-    'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid,
-    'Summer 2025',
-    'Prior-year semester used for gift card sample data.',
-    '2025-06-03T00:00:00Z',
-    '2025-08-30T23:59:59Z',
-    '2025-02-01T00:00:00Z',
-    '2025-05-15T23:59:59Z'
-  )
-  on conflict (id) do update
-    set name = excluded.name,
-        description = excluded.description,
-        starts_at = excluded.starts_at,
-        ends_at = excluded.ends_at,
-        enrollment_open_at = excluded.enrollment_open_at,
-        enrollment_close_at = excluded.enrollment_close_at
-  returning id
-), last_year_workshop as (
-  insert into public.workshop (id, semester_id, description, enrollment_open_at, enrollment_close_at, capacity, wait_list_capacity)
-  values (
-    'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid,
-    (select id from last_year_semester),
-    '2025 Summer Workshop - Sample',
-    '2025-02-01T00:00:00Z',
-    '2025-05-15T23:59:59Z',
-    5,
-    2
-  )
-  on conflict (id) do update
-    set semester_id = excluded.semester_id,
-        description = excluded.description,
-        enrollment_open_at = excluded.enrollment_open_at,
-        enrollment_close_at = excluded.enrollment_close_at,
-        capacity = excluded.capacity,
-        wait_list_capacity = excluded.wait_list_capacity
-  returning id
-), last_year_class as (
-  insert into public.class (id, workshop_id, starts_at, ends_at)
-  values (
-    '11111111-ffff-ffff-ffff-111111111111'::uuid,
-    (select id from last_year_workshop),
-    '2025-06-10T16:00:00Z',
-    '2025-06-10T17:30:00Z'
-  )
-  on conflict (id) do update
-    set workshop_id = excluded.workshop_id,
-        starts_at = excluded.starts_at,
-        ends_at = excluded.ends_at
-  returning id
-), enrollments as (
-  insert into public.workshop_enrollment (workshop_id, semester_id, profile_id, status)
-  values
-    ((select id from last_year_workshop), (select id from last_year_semester), '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'approved'),
-    ((select id from last_year_workshop), (select id from last_year_semester), '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'approved')
-  on conflict (semester_id, profile_id) do update
-    set status = excluded.status
-  returning id
-), attendance as (
-  insert into public.class_attendance (class_id, profile_id, status)
-  values
-    ((select id from last_year_class), '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'present'),
-    ((select id from last_year_class), '33333333-bbbb-bbbb-bbbb-333333333333'::uuid, 'present')
-  on conflict (class_id, profile_id) do update
-    set status = excluded.status
-  returning id
-), upload_batch as (
+-- Sample gift card uploads and assets tied to the existing prior semester seed.
+
+insert into public.workshop_enrollment (workshop_id, semester_id, profile_id, status)
+values
+  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'approved'),
+  ('11111111-1111-1111-1111-111111111111'::uuid, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'approved')
+on conflict (semester_id, profile_id) do update
+  set status = excluded.status;
+
+insert into public.class_attendance (class_id, profile_id, status)
+values
+  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'present'),
+  ('aaaaaaaa-1111-1111-1111-aaaaaaaa1111'::uuid, '44444444-dddd-dddd-dddd-444444444444'::uuid, 'present')
+on conflict (class_id, profile_id) do update
+  set status = excluded.status;
+
+with upload_batch as (
   insert into public.gift_card_upload (
     id, uploaded_by, provider, upload_type, status, file_name, file_size, total_cards, processed_cards
   )
@@ -114,7 +62,7 @@ values
   ),
   (
     (select id from upload_batch),
-    '33333333-bbbb-bbbb-bbbb-333333333333'::uuid,
+    '44444444-dddd-dddd-dddd-444444444444'::uuid,
     40.00,
     'https://example.com/gift-card/bravo',
     'used',

--- a/supabase/seeds/dummy-data/profile-onboarding-seed.sql
+++ b/supabase/seeds/dummy-data/profile-onboarding-seed.sql
@@ -1,17 +1,86 @@
 -- Seed sample guardian/student profiles and guardian-child links.
-insert into public.profile (id, role, email, firstname, surname, phone, postcode, partner_program)
+insert into public.profile (
+  id,
+  role,
+  email,
+  firstname,
+  surname,
+  phone,
+  street_address,
+  city,
+  province,
+  postcode,
+  federal_electoral_district_name,
+  partner_program
+)
 values
-  ('11111111-aaaa-aaaa-aaaa-111111111111'::uuid, 'guardian', 'guardian1@example.com', 'Amina', 'Khan', '4165550101', 'A1A 1A1', 'Thorncliffe Park -TNO'),
-  ('22222222-bbbb-bbbb-bbbb-222222222222'::uuid, 'student', null, 'Layla', 'Khan', null, null, null),
-  ('33333333-cccc-cccc-cccc-333333333333'::uuid, 'guardian', 'guardian2@example.com', 'Marco', 'Silva', '4165550102', 'B2B 2B2', 'Corktown Community'),
-  ('44444444-dddd-dddd-dddd-444444444444'::uuid, 'student', null, 'Noah', 'Silva', null, null, null)
+  (
+    '11111111-aaaa-aaaa-aaaa-111111111111'::uuid,
+    'guardian',
+    'guardian1@example.com',
+    'Amina',
+    'Khan',
+    '4165550101',
+    '45 Overlea Blvd',
+    'Toronto',
+    'ON',
+    'M4H 1C3',
+    'Don Valley West',
+    'Thorncliffe Park -TNO'
+  ),
+  (
+    '22222222-bbbb-bbbb-bbbb-222222222222'::uuid,
+    'student',
+    null,
+    'Layla',
+    'Khan',
+    null,
+    '45 Overlea Blvd',
+    'Toronto',
+    'ON',
+    'M4H 1C3',
+    'Don Valley West',
+    null
+  ),
+  (
+    '33333333-cccc-cccc-cccc-333333333333'::uuid,
+    'guardian',
+    'guardian2@example.com',
+    'Marco',
+    'Silva',
+    '4165550102',
+    '2 Berkeley St',
+    'Toronto',
+    'ON',
+    'M5A 4J5',
+    'Toronto Centre',
+    'Corktown Community'
+  ),
+  (
+    '44444444-dddd-dddd-dddd-444444444444'::uuid,
+    'student',
+    null,
+    'Noah',
+    'Silva',
+    null,
+    '2 Berkeley St',
+    'Toronto',
+    'ON',
+    'M5A 4J5',
+    'Toronto Centre',
+    null
+  )
 on conflict (id) do update
   set role = excluded.role,
       email = excluded.email,
       firstname = excluded.firstname,
       surname = excluded.surname,
       phone = excluded.phone,
+      street_address = excluded.street_address,
+      city = excluded.city,
+      province = excluded.province,
       postcode = excluded.postcode,
+      federal_electoral_district_name = excluded.federal_electoral_district_name,
       partner_program = excluded.partner_program;
 
 insert into public.person_guardian_child (guardian_profile_id, child_profile_id, primary_child)

--- a/supabase/seeds/dummy-data/suspicious-signal-demo.sql
+++ b/supabase/seeds/dummy-data/suspicious-signal-demo.sql
@@ -1,5 +1,6 @@
 -- Demo seed data for discrepancy review workflows.
 -- This creates a small family with conflicting addresses and two open suspicious signals.
+-- Reuses the current semester/workshop from class-section-sample.sql.
 
 insert into public.profile (
   id,
@@ -10,7 +11,8 @@ insert into public.profile (
   street_address,
   city,
   province,
-  postcode
+  postcode,
+  federal_electoral_district_name
 )
 values
   (
@@ -19,21 +21,23 @@ values
     'Gina',
     'Guardian',
     'seed.guardian.discrepancy@example.com',
-    '100 Main Street',
-    'Toronto',
+    '110 Laurier Ave W',
+    'Ottawa',
     'ON',
-    'M5V1A1'
+    'K1P 1J1',
+    'Ottawa Centre'
   ),
   (
-    '22222222-2222-4222-8222-222222222222',
+    '22222222-2222-4222-8222-222222222229',
     'student',
     'Sam',
     'Student',
     'seed.student.discrepancy@example.com',
-    '900 Pine Avenue',
-    'Vancouver',
-    'BC',
-    'V5K0A1'
+    '216 Ontario St',
+    'Kingston',
+    'ON',
+    'K7L 2Y4',
+    'Kingston and the Islands'
   )
 on conflict (id) do nothing;
 
@@ -46,51 +50,11 @@ insert into public.person_guardian_child (
 values (
   '33333333-3333-4333-8333-333333333333',
   '11111111-1111-4111-8111-111111111111',
-  '22222222-2222-4222-8222-222222222222',
+  '22222222-2222-4222-8222-222222222229',
   true
 )
 on conflict (guardian_profile_id, child_profile_id)
 do update set primary_child = excluded.primary_child;
-
-insert into public.semester (
-  id,
-  name,
-  description,
-  starts_at,
-  ends_at,
-  enrollment_open_at,
-  enrollment_close_at
-)
-values (
-  '66666666-6666-4666-8666-666666666666',
-  'Seed Semester - Discrepancy Demo',
-  'Semester used for suspicious enrollment seed data.',
-  '2026-06-01T00:00:00Z',
-  '2026-08-31T23:59:59Z',
-  '2026-05-01T00:00:00Z',
-  '2026-07-15T23:59:59Z'
-)
-on conflict (id) do nothing;
-
-insert into public.workshop (
-  id,
-  semester_id,
-  description,
-  enrollment_open_at,
-  enrollment_close_at,
-  capacity,
-  wait_list_capacity
-)
-values (
-  '77777777-7777-4777-8777-777777777777',
-  '66666666-6666-4666-8666-666666666666',
-  'Seed Workshop - Suspicious Enrollment Demo',
-  '2026-05-15T00:00:00Z',
-  '2026-07-01T00:00:00Z',
-  20,
-  10
-)
-on conflict (id) do nothing;
 
 insert into public.workshop_enrollment (
   id,
@@ -102,9 +66,9 @@ insert into public.workshop_enrollment (
 )
 values (
   '88888888-8888-4888-8888-888888888888',
-  '77777777-7777-4777-8777-777777777777',
-  '66666666-6666-4666-8666-666666666666',
-  '22222222-2222-4222-8222-222222222222',
+  'cccccccc-cccc-cccc-cccc-cccccccccccc',
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  '22222222-2222-4222-8222-222222222229',
   'pending',
   now()
 )
@@ -123,10 +87,10 @@ insert into public.suspicious_signal (
 values
   (
     '44444444-4444-4444-8444-444444444444',
-    '22222222-2222-4222-8222-222222222222',
+    '22222222-2222-4222-8222-222222222229',
     array[
       '11111111-1111-4111-8111-111111111111'::uuid,
-      '22222222-2222-4222-8222-222222222222'::uuid
+      '22222222-2222-4222-8222-222222222229'::uuid
     ],
     'address_mismatch',
     'medium',
@@ -154,7 +118,7 @@ values
         ),
         jsonb_build_object(
           'profile_id',
-          '22222222-2222-4222-8222-222222222222',
+          '22222222-2222-4222-8222-222222222229',
           'role',
           'student',
           'label',
@@ -176,10 +140,10 @@ values
   ),
   (
     '55555555-5555-4555-8555-555555555555',
-    '22222222-2222-4222-8222-222222222222',
+    '22222222-2222-4222-8222-222222222229',
     array[
       '11111111-1111-4111-8111-111111111111'::uuid,
-      '22222222-2222-4222-8222-222222222222'::uuid
+      '22222222-2222-4222-8222-222222222229'::uuid
     ],
     'network_distance_anomaly',
     'high',
@@ -207,7 +171,7 @@ values
         ),
         jsonb_build_object(
           'profile_id',
-          '22222222-2222-4222-8222-222222222222',
+          '22222222-2222-4222-8222-222222222229',
           'submitted_at_local',
           'May 15, 2026, 9:10 AM',
           'ip_address',

--- a/supabase/seeds/dummy-data/zzz_cross-table-scenarios.sql
+++ b/supabase/seeds/dummy-data/zzz_cross-table-scenarios.sql
@@ -1,0 +1,303 @@
+-- Cross-table scenario coverage with a compact dataset.
+-- Covers form submissions/answers, login events, and email message states.
+
+with selected_forms as (
+  select
+    (
+      select id
+      from public.form
+      where name = 'Profile Information'
+      order by id desc
+      limit 1
+    ) as profile_form_id,
+    (
+      select id
+      from public.form
+      where name = 'Guardian Consent'
+      order by id desc
+      limit 1
+    ) as consent_form_id,
+    (
+      select id
+      from public.form
+      where name = 'Pre-Semester Survey - bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+      order by id desc
+      limit 1
+    ) as pre_survey_form_id
+), submission_rows as (
+  select
+    '10000000-0000-0000-0000-000000000001'::uuid as id,
+    profile_form_id as form_id,
+    '11111111-aaaa-aaaa-aaaa-111111111111'::uuid as profile_id,
+    null::uuid as user_id,
+    '198.51.100.11'::inet as ip_address,
+    '198.51.100.11'::text as forwarded_for,
+    'seed-browser/1.0'::text as user_agent,
+    'en-CA'::text as accept_language,
+    'https://example.local/sign-up'::text as referer,
+    'https://example.local'::text as origin,
+    now() - interval '5 days' as submitted_at,
+    '{"seed":true,"scenario":"profile-information-complete"}'::jsonb as metadata
+  from selected_forms
+
+  union all
+
+  select
+    '10000000-0000-0000-0000-000000000002'::uuid,
+    consent_form_id,
+    '11111111-aaaa-aaaa-aaaa-111111111111'::uuid,
+    null::uuid,
+    '198.51.100.11'::inet,
+    '198.51.100.11'::text,
+    'seed-browser/1.0'::text,
+    'en-CA'::text,
+    'https://example.local/sign-up'::text,
+    'https://example.local'::text,
+    now() - interval '4 days',
+    '{"seed":true,"scenario":"consent-submitted"}'::jsonb
+  from selected_forms
+
+  union all
+
+  select
+    '10000000-0000-0000-0000-000000000003'::uuid,
+    pre_survey_form_id,
+    '22222222-bbbb-bbbb-bbbb-222222222222'::uuid,
+    null::uuid,
+    '203.0.113.12'::inet,
+    '203.0.113.12'::text,
+    'seed-browser/1.0'::text,
+    'en-CA'::text,
+    'https://example.local/enroll'::text,
+    'https://example.local'::text,
+    now() - interval '3 days',
+    '{"seed":true,"scenario":"pre-survey-submitted"}'::jsonb
+  from selected_forms
+)
+insert into public.form_submission (
+  id,
+  form_id,
+  profile_id,
+  user_id,
+  ip_address,
+  forwarded_for,
+  user_agent,
+  accept_language,
+  referer,
+  origin,
+  submitted_at,
+  metadata
+)
+select
+  id,
+  form_id,
+  profile_id,
+  user_id,
+  ip_address,
+  forwarded_for,
+  user_agent,
+  accept_language,
+  referer,
+  origin,
+  submitted_at,
+  metadata
+from submission_rows
+where form_id is not null
+on conflict (id) do update
+  set form_id = excluded.form_id,
+      profile_id = excluded.profile_id,
+      ip_address = excluded.ip_address,
+      forwarded_for = excluded.forwarded_for,
+      user_agent = excluded.user_agent,
+      accept_language = excluded.accept_language,
+      referer = excluded.referer,
+      origin = excluded.origin,
+      submitted_at = excluded.submitted_at,
+      metadata = excluded.metadata;
+
+with answer_rows as (
+  select * from (
+    values
+      ('20000000-0000-0000-0000-000000000001'::uuid, '10000000-0000-0000-0000-000000000001'::uuid, 'guardian_self_firstname'::text, '"Amina"'::jsonb),
+      ('20000000-0000-0000-0000-000000000002'::uuid, '10000000-0000-0000-0000-000000000002'::uuid, 'guardian_consent_privacy'::text, 'true'::jsonb),
+      ('20000000-0000-0000-0000-000000000003'::uuid, '10000000-0000-0000-0000-000000000003'::uuid, 'pre_skill_follow_recipe'::text, '"Agree"'::jsonb)
+  ) as seed(id, submission_id, question_code, value)
+)
+insert into public.form_answer (id, submission_id, question_code, value)
+select seed.id, seed.submission_id, seed.question_code, seed.value
+from answer_rows seed
+join public.form_submission fs on fs.id = seed.submission_id
+join public.form_question fq on fq.question_code = seed.question_code
+on conflict (id) do update
+  set value = excluded.value;
+
+insert into public.login_event (
+  id,
+  user_id,
+  email,
+  login_method,
+  success,
+  ip_address,
+  forwarded_for,
+  user_agent,
+  accept_language,
+  referer,
+  origin,
+  metadata,
+  event_at
+)
+values
+  (
+    '30000000-0000-0000-0000-000000000001'::uuid,
+    null,
+    'guardian1@example.com',
+    'password',
+    true,
+    '198.51.100.11'::inet,
+    '198.51.100.11',
+    'seed-browser/1.0',
+    'en-CA',
+    'https://example.local/login',
+    'https://example.local',
+    '{"seed":true,"scenario":"successful-login"}'::jsonb,
+    now() - interval '2 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000002'::uuid,
+    null,
+    'seed.guardian.discrepancy@example.com',
+    'password',
+    false,
+    '203.0.113.200'::inet,
+    '203.0.113.200',
+    'seed-browser/1.0',
+    'en-US',
+    'https://example.local/login',
+    'https://example.local',
+    '{"seed":true,"scenario":"failed-login"}'::jsonb,
+    now() - interval '1 day'
+  )
+on conflict (id) do update
+  set email = excluded.email,
+      login_method = excluded.login_method,
+      success = excluded.success,
+      ip_address = excluded.ip_address,
+      forwarded_for = excluded.forwarded_for,
+      user_agent = excluded.user_agent,
+      accept_language = excluded.accept_language,
+      referer = excluded.referer,
+      origin = excluded.origin,
+      metadata = excluded.metadata,
+      event_at = excluded.event_at;
+
+insert into public.email_message (
+  id,
+  to_email,
+  subject,
+  template_key,
+  template_data,
+  provider,
+  provider_message_id,
+  status,
+  error_message,
+  sent_at,
+  failed_at,
+  triggered_by_user_id,
+  recipient_user_id,
+  profile_id,
+  family_profile_id,
+  workshop_enrollment_id,
+  event_key
+)
+values
+  (
+    '40000000-0000-0000-0000-000000000001'::uuid,
+    'guardian1@example.com',
+    'Enrollment request received',
+    'family_enrollment_pending_v1',
+    '{"workshopName":"Current Session A - Enrollment Triage"}'::jsonb,
+    'resend',
+    null,
+    'queued',
+    null,
+    null,
+    null,
+    null,
+    null,
+    '11111111-aaaa-aaaa-aaaa-111111111111'::uuid,
+    '11111111-aaaa-aaaa-aaaa-111111111111'::uuid,
+    null,
+    'seed:email:queued:1'
+  ),
+  (
+    '40000000-0000-0000-0000-000000000002'::uuid,
+    'guardian1@example.com',
+    'Enrollment approved',
+    'family_enrollment_accepted_v1',
+    '{"workshopName":"Current Session A - Enrollment Triage"}'::jsonb,
+    'resend',
+    'resend-seed-accepted-1',
+    'sent',
+    null,
+    now() - interval '12 hours',
+    null,
+    null,
+    null,
+    '22222222-bbbb-bbbb-bbbb-222222222222'::uuid,
+    '11111111-aaaa-aaaa-aaaa-111111111111'::uuid,
+    null,
+    'seed:email:sent:1'
+  ),
+  (
+    '40000000-0000-0000-0000-000000000003'::uuid,
+    'seed.guardian.discrepancy@example.com',
+    'Suspicious activity detected',
+    'security_alert_v1',
+    '{"signal":"network_distance_anomaly"}'::jsonb,
+    'resend',
+    null,
+    'failed',
+    'SMTP timeout in seed simulation',
+    null,
+    now() - interval '6 hours',
+    null,
+    null,
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    null,
+    'seed:email:failed:1'
+  ),
+  (
+    '40000000-0000-0000-0000-000000000004'::uuid,
+    'family+skipped@example.com',
+    'Duplicate message skipped',
+    'family_enrollment_accepted_v1',
+    '{"reason":"duplicate event key"}'::jsonb,
+    'resend',
+    null,
+    'skipped',
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    '88888888-8888-4888-8888-888888888888'::uuid,
+    'seed:email:skipped:1'
+  )
+on conflict (id) do update
+  set to_email = excluded.to_email,
+      subject = excluded.subject,
+      template_key = excluded.template_key,
+      template_data = excluded.template_data,
+      provider = excluded.provider,
+      provider_message_id = excluded.provider_message_id,
+      status = excluded.status,
+      error_message = excluded.error_message,
+      sent_at = excluded.sent_at,
+      failed_at = excluded.failed_at,
+      profile_id = excluded.profile_id,
+      family_profile_id = excluded.family_profile_id,
+      workshop_enrollment_id = excluded.workshop_enrollment_id,
+      event_key = excluded.event_key;

--- a/web/app/lib/email/migration.ts
+++ b/web/app/lib/email/migration.ts
@@ -1,0 +1,58 @@
+export type TemplateMigrationMode = 'legacy' | 'shadow' | 'draft'
+
+const normalizeFlagValue = (value: string | undefined) =>
+  (value ?? '').trim().toLowerCase()
+
+export const migrationModeEnvKey = (templateKey: string) =>
+  `EMAIL_DRAFT_MODE_${templateKey.toUpperCase().replaceAll(/[^A-Z0-9]/g, '_')}`
+
+export const legacyMigrationFlagEnvKey = (templateKey: string) =>
+  `EMAIL_DRAFT_USE_${templateKey.toUpperCase().replaceAll(/[^A-Z0-9]/g, '_')}`
+
+export const parseTemplateMigrationMode = ({
+  templateKey,
+  env,
+}: {
+  templateKey: string
+  env: Record<string, string | undefined>
+}): TemplateMigrationMode => {
+  const nextModeRaw = normalizeFlagValue(env[migrationModeEnvKey(templateKey)])
+  if (nextModeRaw === 'legacy' || nextModeRaw === 'shadow' || nextModeRaw === 'draft') {
+    return nextModeRaw
+  }
+
+  // Backward compatibility while switching from boolean flags to mode flags.
+  const legacyFlag = normalizeFlagValue(env[legacyMigrationFlagEnvKey(templateKey)])
+  if (legacyFlag === '1' || legacyFlag === 'true' || legacyFlag === 'yes' || legacyFlag === 'on') {
+    return 'draft'
+  }
+
+  return 'legacy'
+}
+
+const normalizeText = (value: string) => value.replace(/\s+/g, ' ').trim()
+
+const normalizeHtml = (value: string) =>
+  value
+    .replace(/>\s+</g, '><')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+export const compareRenderedEmail = ({
+  legacy,
+  draft,
+}: {
+  legacy: { subject: string; text: string; html: string }
+  draft: { subject: string; text: string; html: string }
+}) => {
+  const subjectMatch = normalizeText(legacy.subject) === normalizeText(draft.subject)
+  const textMatch = normalizeText(legacy.text) === normalizeText(draft.text)
+  const htmlMatch = normalizeHtml(legacy.html) === normalizeHtml(draft.html)
+
+  return {
+    matched: subjectMatch && textMatch && htmlMatch,
+    subjectMatch,
+    textMatch,
+    htmlMatch,
+  }
+}

--- a/web/app/lib/email/send-email.server.ts
+++ b/web/app/lib/email/send-email.server.ts
@@ -1,6 +1,11 @@
 import type { Json } from '@/lib/database.types'
 import { resolvePublishedDraftByKey } from '@/lib/email/drafts/service.server'
 import {
+  compareRenderedEmail,
+  parseTemplateMigrationMode,
+  type TemplateMigrationMode,
+} from '@/lib/email/migration'
+import {
   emailTemplates,
   type EmailTemplateKey,
   type EmailTemplateMap,
@@ -40,11 +45,10 @@ type SendTransactionalEmailResult = {
   error: string | null
 }
 
-const parseBooleanFlag = (value: string | undefined) =>
-  value === '1' || value === 'true' || value === 'yes' || value === 'on'
-
-const migrationFlagForTemplate = (templateKey: string) =>
-  `EMAIL_DRAFT_USE_${templateKey.toUpperCase().replaceAll(/[^A-Z0-9]/g, '_')}`
+const TEMPLATE_FALLBACK_POLICY =
+  (process.env.EMAIL_DRAFT_FALLBACK_POLICY === 'fail-closed'
+    ? 'fail-closed'
+    : 'fallback-legacy') as 'fallback-legacy' | 'fail-closed'
 
 const normalizeTemplateVariables = (value: Json): Record<string, unknown> => {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -52,6 +56,44 @@ const normalizeTemplateVariables = (value: Json): Record<string, unknown> => {
   }
   return {}
 }
+
+const withMigrationMeta = ({
+  templateData,
+  mode,
+  source,
+  parity,
+  fallbackApplied,
+  fallbackReason,
+}: {
+  templateData: Json
+  mode: TemplateMigrationMode
+  source: 'legacy' | 'draft'
+  parity?: {
+    matched: boolean
+    subjectMatch: boolean
+    textMatch: boolean
+    htmlMatch: boolean
+  }
+  fallbackApplied?: boolean
+  fallbackReason?: string
+}): Json => {
+  if (!templateData || typeof templateData !== 'object' || Array.isArray(templateData)) {
+    return templateData
+  }
+
+  const payload = templateData as Record<string, unknown>
+  return {
+    ...payload,
+    _migration_mode: mode,
+    _template_source: source,
+    ...(parity ? { _parity_check: parity } : {}),
+    ...(fallbackApplied ? { _fallback_applied: true } : {}),
+    ...(fallbackReason ? { _fallback_reason: fallbackReason } : {}),
+  }
+}
+
+const renderLegacyTemplate = <K extends EmailTemplateKey>(templateKey: K, templateData: EmailTemplateMap[K]) =>
+  emailTemplates[templateKey].render(templateData)
 
 export const sendTransactionalEmail = async ({
   toEmail,
@@ -178,41 +220,143 @@ export const sendTemplateEmail = async <K extends EmailTemplateKey>({
   familyProfileId,
   workshopEnrollmentId,
 }: SendTemplateEmailArgs<K>) => {
-  const migrationFlag = migrationFlagForTemplate(templateKey)
-  const shouldUseDraft = parseBooleanFlag(process.env[migrationFlag])
-  let resolved = null as { subject: string; html: string; text: string } | null
+  const mode = parseTemplateMigrationMode({
+    templateKey,
+    env: process.env,
+  })
 
-  if (shouldUseDraft) {
-    try {
-      resolved = await resolvePublishedDraftByKey({
-        draftKey: templateKey,
-        variables: templateData as Record<string, unknown>,
-      })
+  const legacy = renderLegacyTemplate(templateKey, templateData)
+  const draft = await resolvePublishedDraftByKey({
+    draftKey: templateKey,
+    variables: templateData as Record<string, unknown>,
+  })
 
-      if (!resolved) {
-        console.warn('[email] draft resolver returned null, using legacy template', {
+  if (mode === 'shadow') {
+    if (draft) {
+      const parity = compareRenderedEmail({ legacy, draft })
+      console.info(
+        parity.matched
+          ? '[email][migration][shadow][match]'
+          : '[email][migration][shadow][mismatch]',
+        {
           templateKey,
-          migrationFlag,
-        })
-      }
-    } catch (error) {
-      console.error('[email] draft resolver failed, using legacy template', {
+          parity,
+        }
+      )
+
+      return sendTransactionalEmail({
+        toEmail,
+        subject: legacy.subject,
+        html: legacy.html,
+        text: legacy.text,
         templateKey,
-        migrationFlag,
-        error,
+        templateData: withMigrationMeta({
+          templateData: templateData as Json,
+          mode,
+          source: 'legacy',
+          parity,
+        }),
+        eventKey,
+        triggeredByUserId,
+        recipientUserId,
+        profileId,
+        familyProfileId,
+        workshopEnrollmentId,
       })
     }
+
+    console.warn('[email][migration][shadow][published-draft-not-found]', { templateKey })
+
+    return sendTransactionalEmail({
+      toEmail,
+      subject: legacy.subject,
+      html: legacy.html,
+      text: legacy.text,
+      templateKey,
+      templateData: withMigrationMeta({
+        templateData: templateData as Json,
+        mode,
+        source: 'legacy',
+        fallbackApplied: true,
+        fallbackReason: 'published-draft-not-found',
+      }),
+      eventKey,
+      triggeredByUserId,
+      recipientUserId,
+      profileId,
+      familyProfileId,
+      workshopEnrollmentId,
+    })
   }
 
-  const template = resolved ?? emailTemplates[templateKey].render(templateData)
+  if (mode === 'draft') {
+    if (draft) {
+      return sendTransactionalEmail({
+        toEmail,
+        subject: draft.subject,
+        html: draft.html,
+        text: draft.text,
+        templateKey,
+        templateData: withMigrationMeta({
+          templateData: templateData as Json,
+          mode,
+          source: 'draft',
+        }),
+        eventKey,
+        triggeredByUserId,
+        recipientUserId,
+        profileId,
+        familyProfileId,
+        workshopEnrollmentId,
+      })
+    }
+
+    if (TEMPLATE_FALLBACK_POLICY === 'fail-closed') {
+      return {
+        status: 'failed',
+        id: null,
+        error: `Draft mode enabled but no published draft found for template ${templateKey}`,
+      }
+    }
+
+    console.warn('[email][migration][draft][fallback-legacy]', {
+      templateKey,
+      fallbackPolicy: TEMPLATE_FALLBACK_POLICY,
+    })
+
+    return sendTransactionalEmail({
+      toEmail,
+      subject: legacy.subject,
+      html: legacy.html,
+      text: legacy.text,
+      templateKey,
+      templateData: withMigrationMeta({
+        templateData: templateData as Json,
+        mode,
+        source: 'legacy',
+        fallbackApplied: true,
+        fallbackReason: 'published-draft-not-found',
+      }),
+      eventKey,
+      triggeredByUserId,
+      recipientUserId,
+      profileId,
+      familyProfileId,
+      workshopEnrollmentId,
+    })
+  }
 
   return sendTransactionalEmail({
     toEmail,
-    subject: template.subject,
-    html: template.html,
-    text: template.text,
+    subject: legacy.subject,
+    html: legacy.html,
+    text: legacy.text,
     templateKey,
-    templateData: templateData as Json,
+    templateData: withMigrationMeta({
+      templateData: templateData as Json,
+      mode,
+      source: 'legacy',
+    }),
     eventKey,
     triggeredByUserId,
     recipientUserId,
@@ -241,19 +385,28 @@ export const resendEmailMessageById = async ({
     return { ok: false, error: error?.message ?? 'Email message not found' }
   }
 
+  const mode = parseTemplateMigrationMode({
+    templateKey: message.template_key,
+    env: process.env,
+  })
+
   const draftRendered = await resolvePublishedDraftByKey({
     draftKey: message.template_key,
     variables: normalizeTemplateVariables(message.template_data),
   })
 
-  if (draftRendered) {
+  if (draftRendered && mode !== 'legacy') {
     const resendResult = await sendTransactionalEmail({
       toEmail: message.to_email,
       subject: draftRendered.subject,
       html: draftRendered.html,
       text: draftRendered.text,
       templateKey: message.template_key,
-      templateData: message.template_data,
+      templateData: withMigrationMeta({
+        templateData: message.template_data,
+        mode,
+        source: 'draft',
+      }),
       eventKey: null,
       triggeredByUserId,
       recipientUserId: message.recipient_user_id,
@@ -282,7 +435,17 @@ export const resendEmailMessageById = async ({
     html: rendered.html,
     text: rendered.text,
     templateKey: message.template_key,
-    templateData: message.template_data,
+    templateData: withMigrationMeta({
+      templateData: message.template_data,
+      mode,
+      source: 'legacy',
+      ...(mode !== 'legacy'
+        ? {
+            fallbackApplied: true,
+            fallbackReason: draftRendered ? 'mode-set-legacy' : 'published-draft-not-found',
+          }
+        : {}),
+    }),
     eventKey: null,
     triggeredByUserId,
     recipientUserId: message.recipient_user_id,

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -73,6 +73,7 @@ export default [
     route("invites", "routes/manage/invites.tsx"),
     route("discrepancies", "routes/manage/discrepancies.tsx"),
     route("request-metadata", "routes/manage/request-metadata.tsx"),
+    route("federal-electoral-district/enrichment", "routes/manage/federal-electoral-district.enrichment.ts"),
     route("federal-electoral-district", "routes/manage/federal-electoral-district.tsx"),
     route("semester", "routes/manage/semester.tsx"),
     route("semester-form-requirement", "routes/manage/semester-form-requirement.tsx"),

--- a/web/app/routes/manage/federal-electoral-district.enrichment.ts
+++ b/web/app/routes/manage/federal-electoral-district.enrichment.ts
@@ -11,6 +11,22 @@ const statusBucketFor = (status: Database['public']['Enums']['workshop_enrollmen
   return null
 }
 
+const canonicalRiding = (value: string) =>
+  value
+    .normalize('NFKC')
+    .trim()
+    .replace(/[—–−]/g, '-')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+
+const ridingNameVariants = (value: string) => {
+  const trimmed = value.trim()
+  const variants = new Set<string>([trimmed])
+  variants.add(trimmed.replace(/[—–−]/g, '-'))
+  variants.add(trimmed.replace(/-/g, '—'))
+  return Array.from(variants)
+}
+
 export async function loader({ request }: { request: Request }) {
   const auth = await requireAuth(request)
   if (!isRoleAtLeast(auth.claims.role, 'staff')) {
@@ -39,10 +55,20 @@ export async function loader({ request }: { request: Request }) {
     {}
   )
 
+  const requestedRidingByCanonical = new Map(
+    ridingNames.map(riding => [canonicalRiding(riding), riding])
+  )
+
+  const lookupRidingNames = Array.from(
+    new Set(
+      ridingNames.flatMap(riding => ridingNameVariants(riding))
+    )
+  )
+
   const { data: profileRows, error: profileError } = await adminClient
     .from('profile')
     .select('id, federal_electoral_district_name')
-    .in('federal_electoral_district_name', ridingNames)
+    .in('federal_electoral_district_name', lookupRidingNames)
 
   if (profileError) {
     console.error('[federal-electoral-district] failed to load profile riding map', profileError)
@@ -57,10 +83,14 @@ export async function loader({ request }: { request: Request }) {
     return Response.json({ byRiding }, { headers: auth.headers })
   }
 
-  const ridingByProfileId = new Map(
+  const requestedRidingByProfileId = new Map(
     (profileRows ?? [])
       .filter(row => typeof row.id === 'string' && typeof row.federal_electoral_district_name === 'string')
-      .map(row => [row.id, row.federal_electoral_district_name])
+      .map(row => {
+        const requested = requestedRidingByCanonical.get(canonicalRiding(row.federal_electoral_district_name))
+        return [row.id, requested ?? null]
+      })
+      .filter((entry): entry is [string, string] => Boolean(entry[1]))
   )
 
   const { data: enrollmentRows, error: enrollmentError } = await adminClient
@@ -77,7 +107,7 @@ export async function loader({ request }: { request: Request }) {
     const profileId = typeof enrollment.profile_id === 'string' ? enrollment.profile_id : ''
     if (!profileId) continue
 
-    const riding = ridingByProfileId.get(profileId)
+    const riding = requestedRidingByProfileId.get(profileId)
     if (!riding) continue
 
     const status = enrollment.status as Database['public']['Enums']['workshop_enrollment_status']

--- a/web/app/routes/manage/federal-electoral-district.enrichment.ts
+++ b/web/app/routes/manage/federal-electoral-district.enrichment.ts
@@ -1,0 +1,91 @@
+import type { Database } from '@/lib/database.types'
+import { requireAuth } from '@/lib/auth.server'
+import { adminClient } from '@/lib/supabase/adminClient'
+import { isRoleAtLeast } from '@/lib/roles'
+
+const statusBucketFor = (status: Database['public']['Enums']['workshop_enrollment_status']) => {
+  if (status === 'approved') return 'accepted'
+  if (status === 'pending') return 'pending'
+  if (status === 'waitlisted') return 'waitlisted'
+  if (status === 'rejected' || status === 'revoked') return 'declined'
+  return null
+}
+
+export async function loader({ request }: { request: Request }) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'staff')) {
+    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const url = new URL(request.url)
+  const ridingNames = Array.from(
+    new Set(
+      url.searchParams
+        .getAll('riding')
+        .map(value => value.trim())
+        .filter(Boolean)
+    )
+  )
+
+  if (!ridingNames.length) {
+    return Response.json({ byRiding: {} }, { headers: auth.headers })
+  }
+
+  const byRiding = ridingNames.reduce<Record<string, { accepted: number; pending: number; waitlisted: number; declined: number }>>(
+    (acc, riding) => {
+      acc[riding] = { accepted: 0, pending: 0, waitlisted: 0, declined: 0 }
+      return acc
+    },
+    {}
+  )
+
+  const { data: profileRows, error: profileError } = await adminClient
+    .from('profile')
+    .select('id, federal_electoral_district_name')
+    .in('federal_electoral_district_name', ridingNames)
+
+  if (profileError) {
+    console.error('[federal-electoral-district] failed to load profile riding map', profileError)
+    return Response.json({ byRiding }, { headers: auth.headers })
+  }
+
+  const profileIds = (profileRows ?? [])
+    .map(profile => profile.id)
+    .filter((profileId): profileId is string => typeof profileId === 'string' && Boolean(profileId))
+
+  if (!profileIds.length) {
+    return Response.json({ byRiding }, { headers: auth.headers })
+  }
+
+  const ridingByProfileId = new Map(
+    (profileRows ?? [])
+      .filter(row => typeof row.id === 'string' && typeof row.federal_electoral_district_name === 'string')
+      .map(row => [row.id, row.federal_electoral_district_name])
+  )
+
+  const { data: enrollmentRows, error: enrollmentError } = await adminClient
+    .from('workshop_enrollment')
+    .select('profile_id, status')
+    .in('profile_id', profileIds)
+
+  if (enrollmentError) {
+    console.error('[federal-electoral-district] failed to load enrollment status counts', enrollmentError)
+    return Response.json({ byRiding }, { headers: auth.headers })
+  }
+
+  for (const enrollment of enrollmentRows ?? []) {
+    const profileId = typeof enrollment.profile_id === 'string' ? enrollment.profile_id : ''
+    if (!profileId) continue
+
+    const riding = ridingByProfileId.get(profileId)
+    if (!riding) continue
+
+    const status = enrollment.status as Database['public']['Enums']['workshop_enrollment_status']
+    const bucket = statusBucketFor(status)
+    if (!bucket) continue
+
+    byRiding[riding][bucket] += 1
+  }
+
+  return Response.json({ byRiding }, { headers: auth.headers })
+}

--- a/web/app/routes/manage/federal-electoral-district.tsx
+++ b/web/app/routes/manage/federal-electoral-district.tsx
@@ -2,7 +2,38 @@ import TableDisplay from './table-display'
 import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
 
-export const loader = createTableLoader('federal-electoral-district')
+import type { Route } from './+types/federal-electoral-district'
+
+const baseLoader = createTableLoader('federal-electoral-district')
+
+export async function loader(args: Route.LoaderArgs) {
+  const base = await baseLoader(args)
+  const columns = base.columns.includes('accepted')
+    ? base.columns
+    : ['code', 'name', 'accepted', 'pending', 'waitlisted', 'declined', ...base.columns.filter(column => !['code', 'name'].includes(column))]
+
+  const rows = (base.rows ?? []).map(row => ({
+    ...row,
+    accepted: '...',
+    pending: '...',
+    waitlisted: '...',
+    declined: '...',
+  }))
+
+  return {
+    ...base,
+    columns,
+    rows,
+    columnMeta: {
+      ...(base.columnMeta ?? {}),
+      accepted: { label: 'accepted', numeric: true },
+      pending: { label: 'pending', numeric: true },
+      waitlisted: { label: 'waitlisted', numeric: true },
+      declined: { label: 'declined', numeric: true },
+    },
+  }
+}
+
 export const action = createTableAction('federal-electoral-district')
 
 export default function FederalElectoralDistrictTablePage() {

--- a/web/app/routes/manage/nav.ts
+++ b/web/app/routes/manage/nav.ts
@@ -5,7 +5,7 @@ export type ManageNavItem = {
 }
 
 export type ManageNavSection = {
-  key: 'class-management' | 'form-management' | 'user-management' | 'email' | 'system'
+  key: 'class-management' | 'form-management' | 'analytics' | 'user-management' | 'email' | 'system'
   label: string
   stickerSrc: string
   defaultCollapsed: boolean
@@ -60,6 +60,19 @@ export const manageSections: ManageNavSection[] = [
     ],
   },
   {
+    key: 'analytics',
+    label: 'Analytics',
+    stickerSrc: '/stickers/stocks.png',
+    defaultCollapsed: true,
+    items: [
+      {
+        to: '/manage/federal-electoral-district',
+        label: 'Federal electoral districts',
+        description: 'Manage whitelist and meal kit flags with enrollment totals by riding status.',
+      },
+    ],
+  },
+  {
     key: 'email',
     label: 'Email',
     stickerSrc: '/stickers/radish.png',
@@ -82,11 +95,6 @@ export const manageSections: ManageNavSection[] = [
       { to: '/manage/user-roles', label: 'User roles', description: 'The role each user currently holds.' },
       { to: '/manage/sign-up-terms-consent', label: 'Terms consent', description: 'Accepted terms snapshots captured at signup.' },
       { to: '/manage/sign-up-terms', label: 'Sign-up terms', description: 'Active terms copy shown during account creation.' },
-      {
-        to: '/manage/federal-electoral-district',
-        label: 'Federal electoral districts',
-        description: 'Manage whitelist and meal kit flags for all federal ridings.',
-      },
       { to: '/manage/semester', label: 'Semesters', description: 'Program semesters and enrollment windows.' },
     ],
   },

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -59,6 +59,17 @@ type WorkshopEnrollmentEnrichmentResponse = {
   byProfileId: Record<string, WorkshopEnrollmentEnrichment>
 }
 
+type FederalElectoralDistrictEnrichment = {
+  accepted: number
+  pending: number
+  waitlisted: number
+  declined: number
+}
+
+type FederalElectoralDistrictEnrichmentResponse = {
+  byRiding: Record<string, FederalElectoralDistrictEnrichment>
+}
+
 type LoaderData = {
   columns: string[]
   rows: Record<string, unknown>[]
@@ -279,10 +290,13 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
   const [editingRowKey, setEditingRowKey] = useState<string | null>(null)
   const [editValues, setEditValues] = useState<Record<string, string>>({})
   const [enrichmentByProfileId, setEnrichmentByProfileId] = useState<Record<string, WorkshopEnrollmentEnrichment>>({})
+  const [enrichmentByRiding, setEnrichmentByRiding] = useState<Record<string, FederalElectoralDistrictEnrichment>>({})
   const loadingEnrichmentProfileIdsRef = useRef<Set<string>>(new Set())
+  const loadingEnrichmentRidingNamesRef = useRef<Set<string>>(new Set())
   const filterButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const filterPopoverRef = useRef<HTMLDivElement | null>(null)
   const isWorkshopEnrollmentTable = tableName === 'class-enrollment'
+  const isFederalElectoralDistrictTable = tableName === 'federal-electoral-district'
 
   useEffect(() => {
     const nextSort = searchParams.get('sort')
@@ -370,16 +384,28 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
     })
 
   const rowsWithEnrichment = useMemo(() => {
-    if (!isWorkshopEnrollmentTable) return rows
-
     return rows.map(row => {
-      const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
-      if (!profileId) return row
-      const enrichment = enrichmentByProfileId[profileId]
-      if (!enrichment) return row
-      return { ...row, ...enrichment }
+      let nextRow = row
+
+      if (isWorkshopEnrollmentTable) {
+        const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+        const enrichment = profileId ? enrichmentByProfileId[profileId] : null
+        if (enrichment) {
+          nextRow = { ...nextRow, ...enrichment }
+        }
+      }
+
+      if (isFederalElectoralDistrictTable) {
+        const ridingName = typeof row.name === 'string' ? row.name.trim() : ''
+        const enrichment = ridingName ? enrichmentByRiding[ridingName] : null
+        if (enrichment) {
+          nextRow = { ...nextRow, ...enrichment }
+        }
+      }
+
+      return nextRow
     })
-  }, [enrichmentByProfileId, isWorkshopEnrollmentTable, rows])
+  }, [enrichmentByProfileId, enrichmentByRiding, isFederalElectoralDistrictTable, isWorkshopEnrollmentTable, rows])
 
   const derivedRows = useMemo(() => {
     let adjustedRows = rowsWithEnrichment.filter(row => rowMatchesFilters(row, filters))
@@ -486,6 +512,71 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
       abortController.abort()
     }
   }, [enrichmentByProfileId, isWorkshopEnrollmentTable, paginatedRows])
+
+  useEffect(() => {
+    if (!isFederalElectoralDistrictTable) return
+
+    const missingRidingNames = Array.from(
+      new Set(
+        paginatedRows
+          .map(row => (typeof row.name === 'string' ? row.name.trim() : ''))
+          .filter(
+            ridingName =>
+              Boolean(ridingName) &&
+              !enrichmentByRiding[ridingName] &&
+              !loadingEnrichmentRidingNamesRef.current.has(ridingName)
+          )
+      )
+    )
+
+    if (!missingRidingNames.length) return
+
+    const requestRidingNames = missingRidingNames.slice(0, 40)
+    requestRidingNames.forEach(ridingName => loadingEnrichmentRidingNamesRef.current.add(ridingName))
+
+    const abortController = new AbortController()
+    void (async () => {
+      try {
+        const searchParams = new URLSearchParams()
+        requestRidingNames.forEach(ridingName => searchParams.append('riding', ridingName))
+        const response = await fetch(`/manage/federal-electoral-district/enrichment?${searchParams.toString()}`, {
+          signal: abortController.signal,
+        })
+
+        if (!response.ok) return
+        const payload = (await response.json()) as FederalElectoralDistrictEnrichmentResponse
+        const fallbackEnrichment: FederalElectoralDistrictEnrichment = {
+          accepted: 0,
+          pending: 0,
+          waitlisted: 0,
+          declined: 0,
+        }
+
+        const resolvedByRiding = requestRidingNames.reduce<Record<string, FederalElectoralDistrictEnrichment>>(
+          (acc, ridingName) => {
+            acc[ridingName] = payload?.byRiding?.[ridingName] ?? fallbackEnrichment
+            return acc
+          },
+          {}
+        )
+
+        setEnrichmentByRiding(prev => ({
+          ...prev,
+          ...resolvedByRiding,
+        }))
+      } catch (error) {
+        if ((error as Error).name !== 'AbortError') {
+          console.error('[table display] federal riding enrichment fetch failed', error)
+        }
+      } finally {
+        requestRidingNames.forEach(ridingName => loadingEnrichmentRidingNamesRef.current.delete(ridingName))
+      }
+    })()
+
+    return () => {
+      abortController.abort()
+    }
+  }, [enrichmentByRiding, isFederalElectoralDistrictTable, paginatedRows])
 
   const updateSort = (column: string) => {
     if (sortColumn !== column) {

--- a/web/tests/unit/email-transactional-migration.spec.ts
+++ b/web/tests/unit/email-transactional-migration.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test'
+
+import { renderEmailDraft } from '../../app/lib/email/drafts/renderer.server'
+import {
+  compareRenderedEmail,
+  legacyMigrationFlagEnvKey,
+  migrationModeEnvKey,
+  parseTemplateMigrationMode,
+} from '../../app/lib/email/migration'
+import { renderFamilyEnrollmentAcceptedEmail } from '../../app/lib/email/templates/family-enrollment-accepted'
+import { renderFamilyEnrollmentRequestedEmail } from '../../app/lib/email/templates/family-enrollment-requested'
+
+const requestedMarkdown = {
+  subject: "We've received your summerlunch+ registration!",
+  body: `Hi,
+
+Thank you for registering for summerlunch+! We're excited to welcome your family this summer.
+
+Your registration has been received and is currently pending approval. Our team will review your information and send you a confirmation email shortly with your program details, class schedule, and next steps.
+
+While you wait, we encourage you to invite additional family members to join your profile.
+
+As a reminder, to help maintain a safe and engaging class environment, all participants must be supervised by a parent or guardian during classes and are expected to keep their cameras on throughout the session.
+
+Registration details:
+- Registered by: {{actorName}} ({{actorEmail}})
+- Workshop: {{workshopName}}
+
+If you have any questions in the meantime, feel free to email us at hello@summerlunchplus.com.
+
+We're looking forward to cooking with you soon!
+
+- The summerlunch+ Team`,
+}
+
+const acceptedMarkdown = {
+  subject: 'Family enrollment accepted',
+  body: `Great news! Your family enrollment for {{workshopName}} has been accepted.`,
+}
+
+test('migration mode parser supports explicit modes and legacy compatibility', async () => {
+  const key = 'family_enrollment_requested_v1'
+  const modeEnv = migrationModeEnvKey(key)
+  const legacyEnv = legacyMigrationFlagEnvKey(key)
+
+  expect(
+    parseTemplateMigrationMode({
+      templateKey: key,
+      env: { [modeEnv]: 'draft' },
+    })
+  ).toBe('draft')
+
+  expect(
+    parseTemplateMigrationMode({
+      templateKey: key,
+      env: { [modeEnv]: 'shadow' },
+    })
+  ).toBe('shadow')
+
+  expect(
+    parseTemplateMigrationMode({
+      templateKey: key,
+      env: { [legacyEnv]: 'true' },
+    })
+  ).toBe('draft')
+
+  expect(
+    parseTemplateMigrationMode({
+      templateKey: key,
+      env: {},
+    })
+  ).toBe('legacy')
+})
+
+test('requested template draft render preserves subject and text semantics', async () => {
+  const vars = {
+    actorName: 'Sai Tests',
+    actorEmail: 'sai+tests123@chsolutions.ca',
+    workshopName: 'Beginner Kitchen',
+  }
+
+  const legacy = renderFamilyEnrollmentRequestedEmail(vars)
+  const draft = renderEmailDraft({
+    subjectMarkdown: requestedMarkdown.subject,
+    bodyMarkdown: requestedMarkdown.body,
+    variables: vars,
+  })
+
+  const parity = compareRenderedEmail({ legacy, draft })
+  expect(parity.subjectMatch).toBeTruthy()
+  expect(parity.textMatch).toBeTruthy()
+})
+
+test('accepted template draft render preserves subject and text semantics', async () => {
+  const vars = {
+    workshopName: 'Beginner Kitchen',
+  }
+
+  const legacy = renderFamilyEnrollmentAcceptedEmail(vars)
+  const draft = renderEmailDraft({
+    subjectMarkdown: acceptedMarkdown.subject,
+    bodyMarkdown: acceptedMarkdown.body,
+    variables: vars,
+  })
+
+  const parity = compareRenderedEmail({ legacy, draft })
+  expect(parity.subjectMatch).toBeTruthy()
+  expect(parity.textMatch).toBeTruthy()
+})


### PR DESCRIPTION
## What changed\n- add analytics sidebar/riding enrichment updates\n- expand Supabase dummy seeds with fewer but richer scenarios\n- use Ontario addresses and explicit federal riding names in seed profiles\n- add cross-table scenario seed coverage for submissions, answers, login events, and email messages\n- normalize riding-name matching in enrichment endpoint so seeded enrollment counts appear in analytics\n\n## Verification\n- npm run typecheck (web)\n- supabase db reset\n