### PR TITLE
Stabilize enrollment e2e with active seeded windows

### DIFF
--- a/supabase/seeds/dummy-data/class-section-sample.sql
+++ b/supabase/seeds/dummy-data/class-section-sample.sql
@@ -127,10 +127,10 @@ values
     'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
     'Current Summer Semester',
     'Current-year semester for approved, pending, waitlisted, and declined states.',
-    date_trunc('year', now()) + interval '5 months',
-    date_trunc('year', now()) + interval '6 months' - interval '1 second',
-    date_trunc('year', now()) + interval '3 months',
-    date_trunc('year', now()) + interval '5 months' - interval '1 second'
+    now() + interval '14 days',
+    now() + interval '120 days',
+    now() - interval '30 days',
+    now() + interval '45 days'
   )
 on conflict (id) do update
   set name = excluded.name,
@@ -163,8 +163,8 @@ values
     'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
     'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
     'Current Session A - Enrollment Triage',
-    date_trunc('year', now()) + interval '3 months',
-    date_trunc('year', now()) + interval '5 months' - interval '1 second',
+    now() - interval '30 days',
+    now() + interval '45 days',
     3,
     2
   ),
@@ -172,8 +172,8 @@ values
     'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
     'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
     'Current Session B - Remaining Capacity',
-    date_trunc('year', now()) + interval '3 months',
-    date_trunc('year', now()) + interval '5 months' - interval '1 second',
+    now() - interval '30 days',
+    now() + interval '45 days',
     2,
     1
   )
@@ -196,14 +196,14 @@ values
   (
     'bbbbbbbb-1111-1111-1111-bbbbbbbb1111'::uuid,
     'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
-    date_trunc('year', now()) + interval '5 months' + interval '5 days 16 hours',
-    date_trunc('year', now()) + interval '5 months' + interval '5 days 17 hours 30 minutes'
+    now() + interval '20 days',
+    now() + interval '20 days 90 minutes'
   ),
   (
     'bbbbbbbb-2222-2222-2222-bbbbbbbb2222'::uuid,
     'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
-    date_trunc('year', now()) + interval '5 months' + interval '7 days 17 hours',
-    date_trunc('year', now()) + interval '5 months' + interval '7 days 18 hours 30 minutes'
+    now() + interval '22 days',
+    now() + interval '22 days 90 minutes'
   )
 on conflict (id) do update
   set workshop_id = excluded.workshop_id,

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -145,22 +145,26 @@ export async function loader({ request }: Route.LoaderArgs) {
       .order('requested_at', { ascending: false }),
   ])
 
-  const semesters: SemesterRow[] = (semesterData ?? []).map((s: any) => ({
-    id: String(s.id),
-    name: s.name ? String(s.name) : null,
-    starts_at: String(s.starts_at),
-    ends_at: String(s.ends_at),
-    enrollment_open_at: s.enrollment_open_at ? String(s.enrollment_open_at) : null,
-    enrollment_close_at: s.enrollment_close_at ? String(s.enrollment_close_at) : null,
-    workshops: (s.workshop ?? []).map((w: any) => ({
-      id: String(w.id),
-      description: w.description ? String(w.description) : null,
-      enrollment_open_at: w.enrollment_open_at ? String(w.enrollment_open_at) : null,
-      enrollment_close_at: w.enrollment_close_at ? String(w.enrollment_close_at) : null,
-      capacity: Number(w.capacity ?? 0),
-      wait_list_capacity: Number(w.wait_list_capacity ?? 0),
-    })),
-  }))
+  const semesters: SemesterRow[] = (semesterData ?? [])
+    .map((s: any) => ({
+      id: String(s.id),
+      name: s.name ? String(s.name) : null,
+      starts_at: String(s.starts_at),
+      ends_at: String(s.ends_at),
+      enrollment_open_at: s.enrollment_open_at ? String(s.enrollment_open_at) : null,
+      enrollment_close_at: s.enrollment_close_at ? String(s.enrollment_close_at) : null,
+      workshops: (s.workshop ?? [])
+        .filter((w: any) => typeof w?.id === 'string' && Boolean(w.id))
+        .map((w: any) => ({
+          id: String(w.id),
+          description: w.description ? String(w.description) : null,
+          enrollment_open_at: w.enrollment_open_at ? String(w.enrollment_open_at) : null,
+          enrollment_close_at: w.enrollment_close_at ? String(w.enrollment_close_at) : null,
+          capacity: Number(w.capacity ?? 0),
+          wait_list_capacity: Number(w.wait_list_capacity ?? 0),
+        })),
+    }))
+    .filter(semester => semester.workshops.length > 0)
 
   if (!selectedSemesterId) {
     const nowIso = new Date().toISOString()


### PR DESCRIPTION
## What changed
- filter enrollment semesters to only those with actual workshops in web/app/routes/enroll.tsx
- update dummy current-semester/workshop/class dates to be active relative to now() in supabase/seeds/dummy-data/class-section-sample.sql

## Why
- e2e signup/enrollment flow could land on a closed or non-actionable semester and fail before enrollment submit

## Verification
- supabase db reset
- npx playwright test tests/e2e/guardian-signup-enroll.spec.ts
- npx playwright test tests/e2e/admin-enrollment-approval.spec.ts
- npm run test
