### PR TITLE
zoom-api: Swagger UI documentation improvements

### DIFF
--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -19,7 +19,7 @@ def _zoom() -> ZoomClient:
 
 
 class CreateMeetingRequest(BaseModel):
-    topic: str
+    topic: str = Field(description="Meeting title.", examples=["Summer Lunch Program - Week 3"])
     start_time: str = Field(
         description="Meeting start time in ISO 8601 format. Include a timezone offset or 'Z' for UTC — "
         "e.g. '2026-06-15T10:00:00Z' (for UTC) or '2026-06-15T10:00:00-04:00' (for EDT). "
@@ -29,28 +29,39 @@ class CreateMeetingRequest(BaseModel):
     duration: int = Field(description="Meeting duration in minutes.", examples=[60])
 
 
+class CreateMeetingResponse(BaseModel):
+    id: int = Field(description="Numeric meeting ID used for registration.")
+    uuid: str = Field(description="Unique meeting UUID used for participant reports.")
+    join_url: str = Field(description="URL participants use to join the meeting.")
+
+
 class Registrant(BaseModel):
-    first_name: str
-    last_name: str
-    email: str
+    first_name: str = Field(description="Registrant's first name.", examples=["Jane"])
+    last_name: str = Field(description="Registrant's last name.", examples=["Doe"])
+    email: str = Field(description="Registrant's email address.", examples=["jane.doe@example.com"])
 
 
 # --- Liveness / auth checks ---
 
 @app.get("/health")
-def health():
+def health() -> dict[str, str]:
+    """Unauthenticated liveness check. Returns `{"status": "ok"}` if the server is running."""
     return {"status": "ok"}
 
 
 @app.get("/healthz", dependencies=[Depends(get_api_key)])
-def healthz():
+def healthz() -> dict[str, str]:
+    """Authenticated readiness check. Returns `{"status": "ok"}` if the server is running and the API key is valid."""
     return {"status": "ok"}
 
 
 # --- Zoom credential check ---
 
 @app.post("/zoom/connect", dependencies=[Depends(get_api_key)])
-def zoom_connect():
+def zoom_connect() -> dict:
+    """Validates the configured Zoom Server-to-Server OAuth credentials by calling the Zoom /users/me endpoint.
+    Returns the full Zoom user profile on success, or raises an HTTP error if credentials are invalid.
+    """
     return _zoom().validate_credentials()
 
 
@@ -58,9 +69,13 @@ def zoom_connect():
 
 @app.get("/meetings/past", dependencies=[Depends(get_api_key)])
 def list_past_meetings(
-    days: int = Query(default=30, ge=1, le=365),
-    force_refresh: bool = Query(default=False),
-):
+    days: int = Query(default=30, ge=1, le=365, description="Number of days to look back for past meetings."),
+    force_refresh: bool = Query(default=False, description="Bypass the in-memory cache and fetch fresh data from Zoom."),
+) -> dict:
+    """Returns a list of past meetings for the authenticated Zoom user within the specified date range.
+    Results are cached in memory; use `force_refresh=true` to bypass the cache.
+    Response shape mirrors the Zoom Reports API: a `meetings` array with id, uuid, topic, start_time, and duration per meeting.
+    """
     cache_key = f"past_meetings:{days}"
     if not force_refresh:
         cached = get_cached(_past_meetings_cache, cache_key)
@@ -74,8 +89,14 @@ def list_past_meetings(
 @app.get("/meetings/{uuid}/participants", dependencies=[Depends(get_api_key)])
 def get_participants(
     uuid: str,
-    force_refresh: bool = Query(default=False),
-):
+    force_refresh: bool = Query(default=False, description="Bypass the in-memory cache and fetch fresh data from Zoom."),
+) -> dict:
+    """Returns the participant attendance report for a completed meeting.
+    The `uuid` must be double-URL-encoded if it contains special characters (handled automatically by this service).
+    Results are cached in memory; use `force_refresh=true` to bypass the cache.
+    Response shape mirrors the Zoom Reports API: a `participants` array with name, user_email, join_time, and leave_time per attendee.
+    Note: this endpoint returns a 500 error if the meeting is still in progress — reports are only available after a meeting ends.
+    """
     cache_key = f"participants:{uuid}"
     if not force_refresh:
         cached = get_cached(_participants_cache, cache_key)
@@ -87,7 +108,10 @@ def get_participants(
 
 
 @app.post("/meetings", dependencies=[Depends(get_api_key)])
-def create_meeting(body: CreateMeetingRequest):
+def create_meeting(body: CreateMeetingRequest) -> CreateMeetingResponse:
+    """Creates a scheduled Zoom meeting for the authenticated user.
+    Returns the numeric meeting `id` (used for registration), the `uuid` (used for participant reports), and the `join_url`.
+    """
     result = _zoom().create_meeting(
         topic=body.topic,
         start_time=body.start_time,
@@ -97,7 +121,11 @@ def create_meeting(body: CreateMeetingRequest):
 
 
 @app.post("/meetings/{meeting_id}/registrants", dependencies=[Depends(get_api_key)])
-def register_participants(meeting_id: str, registrants: list[Registrant]):
+def register_participants(meeting_id: str, registrants: list[Registrant]) -> list[dict]:
+    """Bulk-registers a list of participants for a scheduled meeting.
+    Use the numeric meeting `id` (not the uuid) from `POST /meetings` as `meeting_id`.
+    Each registrant is registered individually; results are returned as a list of Zoom registrant response objects.
+    """
     return _zoom().register_participants(
         meeting_id=meeting_id,
         registrants=[r.model_dump() for r in registrants],

--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, FastAPI, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.auth import get_api_key
 from app.cache import _participants_cache, _past_meetings_cache, get_cached, set_cached
@@ -20,7 +20,12 @@ def _zoom() -> ZoomClient:
 
 class CreateMeetingRequest(BaseModel):
     topic: str
-    start_time: str  # ISO 8601, e.g. "2026-06-15T10:00:00"
+    start_time: str = Field(
+        description="Meeting start time in ISO 8601 format. Include a timezone offset or 'Z' for UTC — "
+        "e.g. '2026-06-15T10:00:00Z' (for UTC) or '2026-06-15T10:00:00-04:00' (for EDT). "
+        "Bare datetimes with no offset are interpreted as UTC by Zoom.",
+        examples=["2026-06-15T10:00:00Z"],
+    )
     duration: int    # minutes
 
 

--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -26,7 +26,7 @@ class CreateMeetingRequest(BaseModel):
         "Bare datetimes with no offset are interpreted as UTC by Zoom.",
         examples=["2026-06-15T10:00:00Z"],
     )
-    duration: int    # minutes
+    duration: int = Field(description="Meeting duration in minutes.", examples=[60])
 
 
 class Registrant(BaseModel):

--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -1,11 +1,11 @@
-from fastapi import Depends, FastAPI, Query
+from fastapi import Depends, FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from app.auth import get_api_key
 from app.cache import _participants_cache, _past_meetings_cache, get_cached, set_cached
 from app.config import settings
 from app.transforms import transform_meetings, transform_participants
-from app.zoom import ZoomClient
+from app.zoom import MeetingInProgressError, ZoomClient
 
 app = FastAPI(title="Zoom API Service")
 
@@ -95,14 +95,17 @@ def get_participants(
     The `uuid` must be double-URL-encoded if it contains special characters (handled automatically by this service).
     Results are cached in memory; use `force_refresh=true` to bypass the cache.
     Response shape mirrors the Zoom Reports API: a `participants` array with name, user_email, join_time, and leave_time per attendee.
-    Note: this endpoint returns a 500 error if the meeting is still in progress — reports are only available after a meeting ends.
+    Returns 409 if the meeting is still in progress or the report has not yet been generated.
     """
     cache_key = f"participants:{uuid}"
     if not force_refresh:
         cached = get_cached(_participants_cache, cache_key)
         if cached is not None:
             return cached
-    result = _zoom().get_participants(uuid)
+    try:
+        result = _zoom().get_participants(uuid)
+    except MeetingInProgressError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     set_cached(_participants_cache, cache_key, result)
     return transform_participants(result)
 

--- a/zoom-api/app/zoom.py
+++ b/zoom-api/app/zoom.py
@@ -6,6 +6,10 @@ ZOOM_OAUTH_URL = "https://zoom.us/oauth/token"
 ZOOM_API_BASE = "https://api.zoom.us/v2"
 
 
+class MeetingInProgressError(Exception):
+    pass
+
+
 class ZoomClient:
     def __init__(self, account_id: str, client_id: str, client_secret: str):
         self.account_id = account_id
@@ -75,5 +79,13 @@ class ZoomClient:
             params={"page_size": 300},
             headers=self._headers(),
         )
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 400:
+                raise MeetingInProgressError(
+                    "Meeting report not available. The meeting may still be in progress, "
+                    "or the report may not yet have been generated."
+                ) from e
+            raise
         return r.json()

--- a/zoom-api/tests/test_main.py
+++ b/zoom-api/tests/test_main.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import httpx
+
 
 # ── Mock helpers ──────────────────────────────────────────────────────────────
 
@@ -60,6 +62,16 @@ def ok(data):
     m = Mock()
     m.json.return_value = data
     m.raise_for_status.return_value = None
+    return m
+
+
+def zoom_error(status_code: int):
+    response = Mock()
+    response.status_code = status_code
+    m = Mock()
+    m.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"{status_code} Error", request=Mock(), response=response
+    )
     return m
 
 
@@ -174,6 +186,14 @@ def test_get_participants_force_refresh(client, headers):
 
 def test_get_participants_missing_auth(client):
     assert client.get("/meetings/abc123/participants").status_code == 401
+
+
+def test_get_participants_meeting_in_progress(client, headers):
+    with patch("app.zoom.httpx.post", return_value=ok(TOKEN_RESP)), \
+         patch("app.zoom.httpx.get", return_value=zoom_error(400)):
+        resp = client.get("/meetings/abc123/participants", headers=headers)
+    assert resp.status_code == 409
+    assert "in progress" in resp.json()["detail"].lower()
 
 
 # ── POST /meetings ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#248** — `start_time` field now shows ISO 8601 format requirements with UTC and EDT examples in Swagger UI
- **#249** — `duration` field now explicitly documented as minutes in Swagger UI
- **#250** — Added type hints and return annotations to all route handlers, docstrings describing accepted params and response shapes, and `Field` descriptions/examples to all request model fields
- **#251** — `/meetings/{uuid}/participants` now returns `409 Conflict` (instead of `500`) when Zoom reports are unavailable due to an in-progress meeting, with a descriptive error message

## Test plan

- [ ] 28 tests passing (`pytest tests/ -v`)
- [ ] Swagger UI: `POST /meetings` shows `start_time` description and example, `duration` shows "minutes"
- [ ] Swagger UI: all endpoints show docstrings as descriptions; `POST /meetings` shows full response schema
- [ ] Call `/meetings/{uuid}/participants` with a UUID for an in-progress meeting — confirm 409 with meaningful detail message

🤖 Generated with [Claude Code](https://claude.com/claude-code)