### PR TITLE
Fix signup guardrail and add auth claim diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,38 +1,44 @@
 # AGENTS.md
 
 ## Repo shape
-- Runtime app lives in `web/` (React Router v7 SSR + Vite + TypeScript + Supabase).
-- Use `web/package.json` scripts for app work; root `package.json` has no scripts.
-- Routing is explicitly declared in `web/app/routes.ts` (not filesystem auto-routing).
-- App shell and auth/onboarding guard wiring start in `web/app/root.tsx`.
-- Path aliases `~/` and `@/` both map to `web/app/*` (`web/tsconfig.json`).
+- Runtime app is `web/` (React Router v7 SSR + Vite + TypeScript + Supabase).
+- Run app commands from `web/`; root `package.json` has dependencies only (no scripts).
+- Routing is explicit in `web/app/routes.ts` (not filesystem routing).
+- App-wide auth/onboarding guard behavior starts in `web/app/root.tsx` and `web/app/lib/auth.server.ts`.
+- Path aliases `~/` and `@/` both resolve to `web/app/*` (`web/tsconfig.json`).
 
 ## Setup and env
-- First-time local setup: `cp web/.env.template web/.env.local` from repo root.
-- Start Supabase from repo root: `supabase start --debug`, then pull keys with `supabase status -o json` into `web/.env.local`.
-- Local app/test URL is `http://localhost:5173`.
-- `ONBOARDING_MODE` resolves to `role` unless explicitly set to `permission` (`web/app/lib/auth.server.ts`).
-- `SUPABASE_SECRET_KEY` is service-role only; never expose it to client code or loader-returned data.
+- First-time setup from repo root: `cp web/.env.template web/.env.local`.
+- Start local Supabase from repo root: `supabase start --debug`; pull keys via `supabase status -o json` and populate `web/.env.local`.
+- Local URL for dev and Playwright defaults: `http://localhost:5173`.
+- `ONBOARDING_MODE` defaults to `role` unless explicitly `permission` (`web/app/lib/auth.server.ts`).
+- Keep `SUPABASE_SECRET_KEY` server-only; never return it from loaders or client code.
 
 ## Commands
-- Install deps: `npm ci` in `web/` (CI uses `npm ci`; `npm install` is fine for local updates).
-- Dev server: `npm run dev` (from `web/`).
-- Typecheck gate: `npm run typecheck` (also regenerates React Router types).
-- Build/start: `npm run build` then `npm run start` (from `web/`).
-- Tests: `npm run test` (Playwright).
-- Focused tests: `npm run test:e2e -- tests/e2e/guardian-signup-enroll.spec.ts --grep "..."`.
-- `npm run test:unit` currently points to `tests/unit` with `--pass-with-no-tests`; this repo currently only has `tests/e2e/`.
+- Install deps: `npm ci` in `web/`.
+- Dev server: `npm run dev` (in `web/`).
+- Typecheck (also regenerates router types): `npm run typecheck`.
+- Build/start smoke: `npm run build && npm run start`.
+- E2E suite: `npm run test` or `npm run test:e2e`.
+- Single spec / grep: `npm run test:e2e -- tests/e2e/guardian-signup-enroll.spec.ts --grep "..."`.
+- `npm run test:unit` targets `tests/unit` with `--pass-with-no-tests`; current repo tests live in `web/tests/e2e`.
 
-## Database and schema workflow
-- Source of truth is declarative SQL in `supabase/schemas/` (see `CODE_STANDARDS.md`).
-- Do not manually edit existing files in `supabase/migrations/`; generate forward migrations instead.
-- Typical flow from repo root: edit schema SQL -> `supabase db diff -f <name>` -> `supabase migration up`.
-- Regenerate DB types after schema changes: `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
-- New tables/features need matching `app_permissions` + `role_permission` seeds and RLS policies in the same change (`CODE_STANDARDS.md`).
-
-## Gotchas that break flows
-- Never edit generated router types in `web/.react-router/types/`.
-- If you add/move a route file, also update `web/app/routes.ts` or it will 404.
-- `createClient()` in `web/app/lib/supabase/server.ts` returns response `headers`; preserve/pass them on redirects and responses to avoid auth session bugs.
+## Testing quirks
 - Playwright auto-starts `npm run dev -- --port 5173` when `PLAYWRIGHT_BASE_URL` is unset (`web/playwright.config.ts`).
-- Email templates configured in `supabase/config.toml` live under `supabase/templates/` and are inline-HTML templates.
+- Admin E2E helpers require service-role env (`SUPABASE_URL` + `SUPABASE_SECRET_KEY`), read from process env or `web/.env.local` (`web/tests/e2e/helpers/admin-account.ts`).
+
+## Database workflow
+- Source of truth is declarative SQL in `supabase/schemas/` (`CODE_STANDARDS.md`).
+- Do not hand-edit existing `supabase/migrations/*`; generate forward migrations from schema changes.
+- Typical flow from repo root: edit `supabase/schemas/*` -> `supabase db diff -f <name>` -> `supabase migration up`.
+- Regenerate DB types after schema changes:
+  `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
+- New features/tables must ship with `app_permissions` + `role_permission` seeds and RLS policies in the same change.
+
+## High-risk gotchas
+- Never edit generated files in `web/.react-router/types/`.
+- If you add/move routes under `web/app/routes/**`, also update `web/app/routes.ts` or the route 404s.
+- Signup details route is `/auth/sign-up-details` (hyphenated); `/auth/signup-details` does not exist.
+- `createClient()` in `web/app/lib/supabase/server.ts` returns `headers`; preserve/pass them on redirects/responses or auth cookies break.
+- Keep onboarding completion logic consistent between guard checks and signup-details loader; mismatches can cause redirect loops between `/auth/sign-up-details` and `/home`.
+- Email templates are configured in `supabase/config.toml` and rendered from `supabase/templates/*.html`.

--- a/web/app/lib/auth.server.ts
+++ b/web/app/lib/auth.server.ts
@@ -73,7 +73,8 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
   }
 
   const mode = getOnboardingMode();
-  const isUnassigned = auth.claims.role === "unassigned";
+  const effectiveRole = signUpStatus.role ?? auth.claims.role;
+  const isUnassigned = effectiveRole === "unassigned";
   const hasSiteRead = auth.claims.permissions.includes("site.read");
   const needsOnboarding = isUnassigned;
   const permissionBlocked = isUnassigned && mode === "permission" && !hasSiteRead;
@@ -85,6 +86,8 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
       mode,
       allowMyForms: Boolean(opts?.allowMyForms),
       role: auth.claims.role,
+      effectiveRole,
+      signUpStatusRole: signUpStatus.role,
       permissions: auth.claims.permissions,
       onboardingComplete: auth.claims.onboardingComplete,
       permissionBlocked,

--- a/web/app/lib/onboarding.server.ts
+++ b/web/app/lib/onboarding.server.ts
@@ -11,6 +11,9 @@ export type SignUpDetailsStatus = {
   waitingOnGuardians?: boolean
 }
 
+const isSignUpDetailsRole = (role: string | null | undefined): role is 'guardian' | 'student' =>
+  role === 'guardian' || role === 'student'
+
 type Condition = {
   all?: Condition[]
   any?: Condition[]
@@ -97,7 +100,7 @@ export const getProfileSignUpCompletion = async (
     .filter(Boolean)
 
   if (!relevantForms.length) {
-    return false
+    return true
   }
 
   const formsComplete = relevantForms.every(formId => submittedFormIds.has(formId))
@@ -170,10 +173,15 @@ export async function getSignUpDetailsStatus(
   if (!role || role === 'unassigned') {
     return { isComplete: false, profileId: profile.id, role, waitingOnGuardians: false }
   }
+
+  if (!isSignUpDetailsRole(role)) {
+    return { isComplete: true, profileId: profile.id, role, waitingOnGuardians: false }
+  }
+
   const formsComplete = await getProfileSignUpCompletionWithContext(
     supabase,
     profile.id,
-    role as Database['public']['Enums']['app_role']
+    role
   )
 
   if (role === 'student') {

--- a/web/app/routes/manage/request-metadata.tsx
+++ b/web/app/routes/manage/request-metadata.tsx
@@ -28,9 +28,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
   )
 
   return {
+    authDebug: {
+      userId: auth.user.id,
+      email: auth.user.email ?? null,
+      userMetadataRole:
+        typeof auth.user.user_metadata?.role === 'string' ? auth.user.user_metadata.role : null,
+      claims: auth.claims,
+    },
     metadata,
     headers,
-    note: 'Use this page in Railway staging to verify which proxy/network headers arrive at the app.',
+    note: 'Use this page in production/staging to verify incoming headers and server-side auth claims.',
   }
 }
 
@@ -43,6 +50,11 @@ export default function RequestMetadataPage() {
         <h1 className="text-2xl font-semibold">Request metadata diagnostics</h1>
         <p className="text-sm text-muted-foreground">{data.note}</p>
       </div>
+
+      <section className="rounded-lg border bg-card p-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Server auth snapshot</h2>
+        <pre className="mt-2 overflow-x-auto rounded bg-muted p-3 text-xs">{JSON.stringify(data.authDebug, null, 2)}</pre>
+      </section>
 
       <section className="rounded-lg border bg-card p-4">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Extracted metadata</h2>


### PR DESCRIPTION
## What changed
- fix signup-details completion guardrail logic for guardian/student vs non-signup roles
- treat no required signup forms as complete to prevent /auth/sign-up-details <-> /home redirect loops
- update AGENTS.md with verified repo workflow and high-risk gotchas
- add server auth snapshot (claims + user metadata role) to /manage/request-metadata for production diagnostics

## Verification
- npm run typecheck (web/)
