### PR TITLE
Fix manage lookup reliability and document auth consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,4 +41,7 @@
 - Signup details route is `/auth/sign-up-details` (hyphenated); `/auth/signup-details` does not exist.
 - `createClient()` in `web/app/lib/supabase/server.ts` returns `headers`; preserve/pass them on redirects/responses or auth cookies break.
 - Keep onboarding completion logic consistent between guard checks and signup-details loader; mismatches can cause redirect loops between `/auth/sign-up-details` and `/home`.
+- In manage table definitions/loaders, avoid lookup mappings against `auth.users`; use `public.profile` keyed by `user_id` for user email/name display fields to avoid environment-specific `auth` schema failures.
+- For large lookup mappings that use `.in(...)`, batch ID lists; large single-shot `IN` lookups can fail in production and render blank display fields.
+- `auth.users.raw_user_meta_data.role` can differ from effective auth; use `requireAuth(...).claims.role` / JWT claims (from `custom_access_token_hook`) when debugging permissions.
 - Email templates are configured in `supabase/config.toml` and rendered from `supabase/templates/*.html`.

--- a/CODE_STANDARDS.md
+++ b/CODE_STANDARDS.md
@@ -27,7 +27,13 @@ SCHEMA & MIGRATIONS
 - On initial signup, pass the `role` field in `signUp(options.data)` so that the `on_auth_user_created_set_role` trigger
   reads `raw_user_meta_data->>'role'` and populates `public.user_roles` accordingly.
 - On initial signup, insert the user’s app role into `public.user_roles` (user_id, role, assigned_by) to ensure RLS and permission mappings apply correctly.
+- Treat `public.user_roles.role` as the source of truth for authorization. `auth.users.raw_user_meta_data.role` can drift and is not authoritative for app access checks.
+- When debugging access, verify JWT `claims.user_role`/`claims.permissions` (from `custom_access_token_hook`) rather than only `auth.users.raw_user_meta_data`.
 - Use `SUPABASE_SECRET_KEY` for service-role admin operations in server-only code (e.g. `inviteUserByEmail`).
+
+- MANAGE TABLE LOOKUPS
+- Do not use `auth.users` as a generic lookup table in manage loaders; PostgREST schema exposure may block `auth` in some environments. Prefer `public.profile` lookups keyed by `user_id` for user email/name display columns.
+- For `.in(...)` lookups over large ID sets in loaders, batch IDs to avoid gateway/fetch failures on production-sized datasets.
 
 - UI
 - Prefer `supabase/ui` components and existing ShadCN primitives before introducing new UI primitives.

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -54,7 +54,9 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
     lookupMappings: [
       {
         keyColumn: 'user_id',
-        table: 'auth.users',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
         valueColumn: 'email',
         resultColumn: 'user_email',
       },
@@ -180,7 +182,14 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
         valueColumn: 'description',
         resultColumn: 'workshop_description',
       },
-      { keyColumn: 'decided_by', table: 'auth.users', valueColumn: 'email', resultColumn: 'decided_by_email' },
+      {
+        keyColumn: 'decided_by',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
+        valueColumn: 'email',
+        resultColumn: 'decided_by_email',
+      },
     ],
     editor: {
       primaryKey: ['id'],
@@ -214,7 +223,14 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
         select: 'id, firstname, surname, email',
         format: 'profile_display',
       },
-      { keyColumn: 'recorded_by', table: 'auth.users', valueColumn: 'email', resultColumn: 'recorded_by_email' },
+      {
+        keyColumn: 'recorded_by',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
+        valueColumn: 'email',
+        resultColumn: 'recorded_by_email',
+      },
     ],
   },
   form: {
@@ -522,8 +538,22 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
     columns: ['inviter_user_email', 'invitee_user_email', 'invitee_email', 'role', 'status', 'created_at'],
     order: 'created_at',
     lookupMappings: [
-      { keyColumn: 'inviter_user_id', table: 'auth.users', valueColumn: 'email', resultColumn: 'inviter_user_email' },
-      { keyColumn: 'invitee_user_id', table: 'auth.users', valueColumn: 'email', resultColumn: 'invitee_user_email' },
+      {
+        keyColumn: 'inviter_user_id',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
+        valueColumn: 'email',
+        resultColumn: 'inviter_user_email',
+      },
+      {
+        keyColumn: 'invitee_user_id',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
+        valueColumn: 'email',
+        resultColumn: 'invitee_user_email',
+      },
     ],
   },
   'login-event': {
@@ -547,7 +577,14 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
     ],
     order: 'event_at',
     lookupMappings: [
-      { keyColumn: 'user_id', table: 'auth.users', valueColumn: 'email', resultColumn: 'user_email' },
+      {
+        keyColumn: 'user_id',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
+        valueColumn: 'email',
+        resultColumn: 'user_email',
+      },
     ],
   },
   'email-message': {
@@ -577,8 +614,22 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
     ],
     order: 'created_at',
     lookupMappings: [
-      { keyColumn: 'triggered_by_user_id', table: 'auth.users', valueColumn: 'email', resultColumn: 'triggered_by_email' },
-      { keyColumn: 'recipient_user_id', table: 'auth.users', valueColumn: 'email', resultColumn: 'recipient_user_email' },
+      {
+        keyColumn: 'triggered_by_user_id',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
+        valueColumn: 'email',
+        resultColumn: 'triggered_by_email',
+      },
+      {
+        keyColumn: 'recipient_user_id',
+        table: 'profile',
+        keyColumnInTable: 'user_id',
+        select: 'user_id, email',
+        valueColumn: 'email',
+        resultColumn: 'recipient_user_email',
+      },
       {
         keyColumn: 'profile_id',
         table: 'profile',

--- a/web/app/routes/manage/table-loader.ts
+++ b/web/app/routes/manage/table-loader.ts
@@ -7,6 +7,17 @@ type ForeignKeyOption = {
   label: string
 }
 
+const IN_CLAUSE_BATCH_SIZE = 150
+
+const chunkArray = <T,>(items: T[], size: number) => {
+  if (size <= 0 || !items.length) return [] as T[][]
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
 const fromQualifiedTable = (supabase: ReturnType<typeof createClient>['supabase'], qualifiedTable: string) => {
   const [schema, table, ...rest] = qualifiedTable.split('.')
   if (schema && table && rest.length === 0) {
@@ -323,10 +334,23 @@ export function createTableLoader(tableName: string) {
         const selectColumns = mapping.select
           ? mapping.select
           : [keyColumn, ...(mapping.valueColumns ?? (mapping.valueColumn ? [mapping.valueColumn] : []))].join(', ')
-        const { data: lookupRowsRaw, error: lookupError } = await fromQualifiedTable(supabase, mapping.table)
-          .select(selectColumns)
-          .in(keyColumn, Array.from(ids))
-        if (lookupError) {
+        const lookupRows: Record<string, unknown>[] = []
+        let lookupErrorMessage: string | null = null
+
+        for (const idChunk of chunkArray(Array.from(ids), IN_CLAUSE_BATCH_SIZE)) {
+          const { data: lookupRowsRaw, error: lookupError } = await fromQualifiedTable(supabase, mapping.table)
+            .select(selectColumns)
+            .in(keyColumn, idChunk)
+
+          if (lookupError) {
+            lookupErrorMessage = lookupError.message
+            break
+          }
+
+          lookupRows.push(...((lookupRowsRaw ?? []) as unknown as Record<string, unknown>[]))
+        }
+
+        if (lookupErrorMessage) {
           console.error('[table-loader] lookup mapping failed', {
             tableName,
             sourceTable: definition.table,
@@ -335,7 +359,7 @@ export function createTableLoader(tableName: string) {
             resultColumn: mapping.resultColumn,
             format: mapping.format ?? null,
             idsCount: ids.size,
-            error: lookupError.message,
+            error: lookupErrorMessage,
           })
 
           if (mapping.format === 'profile_display') {
@@ -349,7 +373,6 @@ export function createTableLoader(tableName: string) {
         }
         const valueById = new Map<string, string>()
         const valueObjectById = new Map<string, Record<string, unknown>>()
-        const lookupRows = (lookupRowsRaw ?? []) as unknown as Record<string, unknown>[]
         for (const lookup of lookupRows) {
           const idValue = lookup[keyColumn] as string | undefined
           if (typeof idValue !== 'string') continue


### PR DESCRIPTION
## What changed
- batch IN-clause lookup IDs in manage table loader to avoid production fetch failures on large sets
- add structured lookup error logging and preserve profile-display fallback behavior
- replace manage lookup mappings that queried auth.users with public.profile keyed by user_id
- update CODE_STANDARDS.md and AGENTS.md with guardrails for role/claims debugging and manage lookup patterns

## Verification
- npm run test (web/)
- npm run typecheck (web/)
