### PR TITLE
Add person activity tab and explicit IP geo diagnostics

### DIFF
--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -40,6 +40,7 @@ export default [
       route("family", "routes/manage/person.family.tsx"),
       route("enrollments", "routes/manage/person.enrollments.tsx"),
       route("form-submissions", "routes/manage/person.form-submissions.tsx"),
+      route("activity", "routes/manage/person.activity.tsx"),
       route("attendance", "routes/manage/person.attendance.tsx"),
       route("discrepancies", "routes/manage/person.discrepancies.tsx"),
     ]),

--- a/web/app/routes/manage/person.activity.tsx
+++ b/web/app/routes/manage/person.activity.tsx
@@ -1,0 +1,116 @@
+import { useMemo } from 'react'
+import { useOutletContext } from 'react-router'
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import type { PersonLoaderData } from './person.shared'
+import { formatDateTime } from './person.shared'
+
+const geoStatusLabel: Record<PersonLoaderData['activityEvents'][number]['geo_status'], string> = {
+  geo_available: 'Geo available',
+  no_ip_captured: 'No IP captured',
+  invalid_ip_value: 'Invalid IP value',
+  ip_present_not_cached: 'IP present, lookup not cached',
+  cached_no_geo: 'Lookup cached, no geo result',
+}
+
+export default function ManagePersonActivityPage() {
+  const { activityEvents, formNameById } = useOutletContext<PersonLoaderData>()
+
+  const rows = useMemo(
+    () =>
+      activityEvents.map(event => {
+        const sourceLabel = event.source === 'form_submission' ? 'Form submission' : 'Login event'
+        const sourceDetail =
+          event.source === 'form_submission'
+            ? event.form_id
+              ? formNameById[event.form_id] ?? event.form_id.slice(0, 8)
+              : '-'
+            : event.login_method ?? '-'
+
+        const successLabel = event.source === 'login_event'
+          ? event.login_success === null
+            ? '-'
+            : event.login_success
+              ? 'Yes'
+              : 'No'
+          : '-'
+
+        const geoLabel = [event.city, event.region, event.country_code].filter(Boolean).join(', ') || '-'
+
+        return {
+          ...event,
+          sourceLabel,
+          sourceDetail,
+          successLabel,
+          geoLabel,
+        }
+      }),
+    [activityEvents, formNameById]
+  )
+
+  return (
+    <section className="rounded-lg border bg-card p-4 space-y-3">
+      <div>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Latest submission and login events</h2>
+        <p className="text-xs text-muted-foreground">
+          Shows raw IP capture fields, parsed IP, geolocation status, and explicit reason when location is unknown.
+        </p>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>When</TableHead>
+            <TableHead>Source</TableHead>
+            <TableHead>Source detail</TableHead>
+            <TableHead>Success</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>IP candidate</TableHead>
+            <TableHead>Parsed IP</TableHead>
+            <TableHead>Geo status</TableHead>
+            <TableHead>Geo</TableHead>
+            <TableHead>Reason</TableHead>
+            <TableHead>Forwarded chain</TableHead>
+            <TableHead>Event ID</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={12} className="text-center text-sm text-muted-foreground">
+                No recent submission or login events for this person.
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map(row => (
+              <TableRow key={`${row.source}-${row.event_id}-${row.occurred_at}`}>
+                <TableCell>{formatDateTime(row.occurred_at)}</TableCell>
+                <TableCell>{row.sourceLabel}</TableCell>
+                <TableCell>{row.sourceDetail}</TableCell>
+                <TableCell>{row.successLabel}</TableCell>
+                <TableCell>{row.login_email ?? '-'}</TableCell>
+                <TableCell className="font-mono text-xs">{row.ip_candidate ?? '-'}</TableCell>
+                <TableCell className="font-mono text-xs">{row.ip_address ?? '-'}</TableCell>
+                <TableCell>{geoStatusLabel[row.geo_status]}</TableCell>
+                <TableCell>{row.geoLabel}</TableCell>
+                <TableCell className="max-w-[22rem]">{row.geo_reason}</TableCell>
+                <TableCell className="max-w-[18rem] truncate" title={row.forwarded_for ?? undefined}>
+                  {row.forwarded_for ?? '-'}
+                </TableCell>
+                <TableCell className="font-mono text-xs">{row.event_id.slice(0, 8)}</TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </section>
+  )
+}

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -3,6 +3,14 @@ import { useOutletContext } from 'react-router'
 import type { PersonLoaderData } from './person.shared'
 import { formatDate, formatDateTime } from './person.shared'
 
+const geoStatusLabel: Record<PersonLoaderData['ipEvidence'][number]['geo_status'], string> = {
+  geo_available: 'Geo available',
+  no_ip_captured: 'No IP captured',
+  invalid_ip_value: 'Invalid IP value',
+  ip_present_not_cached: 'IP present, lookup not cached',
+  cached_no_geo: 'Lookup cached, no geo result',
+}
+
 export default function ManagePersonOverviewPage() {
   const { profile, ipEvidence } = useOutletContext<PersonLoaderData>()
 
@@ -31,13 +39,16 @@ export default function ManagePersonOverviewPage() {
                   <span className="font-medium">Source:</span> {entry.source === 'form_submission' ? 'Form submission' : 'Login event'}
                 </p>
                 <p><span className="font-medium">When:</span> {formatDateTime(entry.occurred_at)}</p>
-                <p><span className="font-medium">IP:</span> {entry.ip_address}</p>
+                <p><span className="font-medium">IP candidate:</span> {entry.ip_candidate ?? '-'}</p>
+                <p><span className="font-medium">Parsed IP:</span> {entry.ip_address ?? '-'}</p>
                 <p>
                   <span className="font-medium">Geo:</span>{' '}
-                  {[entry.city, entry.region, entry.country_code].filter(Boolean).join(', ') || 'Unknown'}
+                  {[entry.city, entry.region, entry.country_code].filter(Boolean).join(', ') || '-'}
                 </p>
+                <p><span className="font-medium">Geo status:</span> {geoStatusLabel[entry.geo_status]}</p>
+                <p><span className="font-medium">Reason:</span> {entry.geo_reason}</p>
                 <p>
-                  <span className="font-medium">Timezone:</span> {entry.timezone ?? 'Unknown'}
+                  <span className="font-medium">Timezone:</span> {entry.timezone ?? '-'}
                 </p>
               </li>
             ))}

--- a/web/app/routes/manage/person.shared.ts
+++ b/web/app/routes/manage/person.shared.ts
@@ -33,10 +33,43 @@ export type SuspiciousSignalRow = {
 
 export type PersonLoaderData = {
   profile: ProfileRow
+  activityEvents: Array<{
+    source: 'form_submission' | 'login_event'
+    event_id: string
+    occurred_at: string
+    form_id: string | null
+    login_method: string | null
+    login_success: boolean | null
+    login_email: string | null
+    forwarded_for: string | null
+    ip_candidate: string | null
+    ip_address: string | null
+    geo_status:
+      | 'geo_available'
+      | 'no_ip_captured'
+      | 'invalid_ip_value'
+      | 'ip_present_not_cached'
+      | 'cached_no_geo'
+    geo_reason: string
+    country_code: string | null
+    region: string | null
+    city: string | null
+    timezone: string | null
+    latitude: number | null
+    longitude: number | null
+  }>
   ipEvidence: Array<{
     source: 'form_submission' | 'login_event'
     occurred_at: string
-    ip_address: string
+    ip_candidate: string | null
+    ip_address: string | null
+    geo_status:
+      | 'geo_available'
+      | 'no_ip_captured'
+      | 'invalid_ip_value'
+      | 'ip_present_not_cached'
+      | 'cached_no_geo'
+    geo_reason: string
     country_code: string | null
     region: string | null
     city: string | null

--- a/web/app/routes/manage/person.tsx
+++ b/web/app/routes/manage/person.tsx
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net'
+
 import { Link, NavLink, Outlet, redirect, useLoaderData, useLocation } from 'react-router'
 
 import { requireAuth } from '@/lib/auth.server'
@@ -10,16 +12,80 @@ import type { LoaderFunctionArgs } from 'react-router'
 import type { PersonLoaderData, ProfileRow, SuspiciousSignalRow } from './person.shared'
 import { profileLabel } from './person.shared'
 
-const parsePrimaryIp = (ip: unknown, forwardedFor: string | null | undefined) => {
+const primaryForwardedToken = (forwardedFor: string | null | undefined) => {
+  if (typeof forwardedFor !== 'string' || !forwardedFor.trim()) return null
+  return forwardedFor
+    .split(',')
+    .map(part => part.trim())
+    .find(Boolean) ?? null
+}
+
+const resolveIpCandidate = (ip: unknown, forwardedFor: string | null | undefined) => {
   if (typeof ip === 'string' && ip.trim()) return ip.trim()
-  if (typeof forwardedFor === 'string' && forwardedFor.trim()) {
-    const first = forwardedFor
-      .split(',')
-      .map(part => part.trim())
-      .find(Boolean)
-    if (first) return first
+  return primaryForwardedToken(forwardedFor)
+}
+
+const normalizeIp = (ipCandidate: string | null) => {
+  if (!ipCandidate) return null
+  if (ipCandidate.length > 64) return null
+  return isIP(ipCandidate) ? ipCandidate : null
+}
+
+const geoStatusReasonFor = (input: {
+  ipCandidate: string | null
+  normalizedIp: string | null
+  geo:
+    | {
+        country_code: string | null
+        region: string | null
+        city: string | null
+        timezone: string | null
+        latitude: number | null
+        longitude: number | null
+      }
+    | null
+}) => {
+  if (!input.ipCandidate) {
+    return {
+      status: 'no_ip_captured' as const,
+      reason: 'No IP was captured for this event.',
+    }
   }
-  return null
+
+  if (!input.normalizedIp) {
+    return {
+      status: 'invalid_ip_value' as const,
+      reason: 'An IP-like value exists but is not a valid IP address.',
+    }
+  }
+
+  if (!input.geo) {
+    return {
+      status: 'ip_present_not_cached' as const,
+      reason: 'IP captured, but no cached geolocation entry yet (lookup likely not triggered).',
+    }
+  }
+
+  const hasGeoValue = Boolean(
+    input.geo.country_code ||
+      input.geo.region ||
+      input.geo.city ||
+      input.geo.timezone ||
+      input.geo.latitude !== null ||
+      input.geo.longitude !== null
+  )
+
+  if (!hasGeoValue) {
+    return {
+      status: 'cached_no_geo' as const,
+      reason: 'Lookup was attempted and cached, but no location details were returned.',
+    }
+  }
+
+  return {
+    status: 'geo_available' as const,
+    reason: 'Geolocation is available from cache.',
+  }
 }
 
 const personTabs = [
@@ -27,6 +93,7 @@ const personTabs = [
   { to: '/manage/person/family', label: 'Family' },
   { to: '/manage/person/enrollments', label: 'Enrollments' },
   { to: '/manage/person/form-submissions', label: 'Form submissions' },
+  { to: '/manage/person/activity', label: 'Activity and IP logs' },
   { to: '/manage/person/attendance', label: 'Attendance' },
   { to: '/manage/person/discrepancies', label: 'Discrepancies' },
 ]
@@ -60,34 +127,52 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const [latestFormSubmissionResult, latestLoginEventResult] = await Promise.all([
     adminClient
       .from('form_submission')
-      .select('submitted_at, ip_address, forwarded_for')
+      .select('id, form_id, submitted_at, ip_address, forwarded_for')
       .eq('profile_id', profileRow.id)
       .order('submitted_at', { ascending: false })
-      .limit(1),
+      .limit(25),
     profileRow.user_id
       ? adminClient
           .from('login_event')
-          .select('event_at, ip_address, forwarded_for')
+          .select('id, event_at, email, login_method, success, ip_address, forwarded_for')
           .eq('user_id', profileRow.user_id)
           .order('event_at', { ascending: false })
-          .limit(1)
+          .limit(25)
       : Promise.resolve({ data: [] as Array<Record<string, unknown>> }),
   ])
 
-  const ipCandidates = [
+  const activityCandidates = [
     ...(latestFormSubmissionResult.data ?? []).map(row => ({
       source: 'form_submission' as const,
+      event_id: typeof row.id === 'string' ? row.id : '',
       occurred_at: typeof row.submitted_at === 'string' ? row.submitted_at : '',
-      ip_address: parsePrimaryIp(row.ip_address, typeof row.forwarded_for === 'string' ? row.forwarded_for : null),
+      form_id: typeof row.form_id === 'string' ? row.form_id : null,
+      login_method: null,
+      login_success: null,
+      login_email: null,
+      forwarded_for: typeof row.forwarded_for === 'string' ? row.forwarded_for : null,
+      ip_candidate: resolveIpCandidate(row.ip_address, typeof row.forwarded_for === 'string' ? row.forwarded_for : null),
     })),
     ...((latestLoginEventResult.data ?? []) as Array<Record<string, unknown>>).map(row => ({
       source: 'login_event' as const,
+      event_id: typeof row.id === 'string' ? row.id : '',
       occurred_at: typeof row.event_at === 'string' ? row.event_at : '',
-      ip_address: parsePrimaryIp(row.ip_address, typeof row.forwarded_for === 'string' ? row.forwarded_for : null),
+      form_id: null,
+      login_method: typeof row.login_method === 'string' ? row.login_method : null,
+      login_success: typeof row.success === 'boolean' ? row.success : null,
+      login_email: typeof row.email === 'string' ? row.email : null,
+      forwarded_for: typeof row.forwarded_for === 'string' ? row.forwarded_for : null,
+      ip_candidate: resolveIpCandidate(row.ip_address, typeof row.forwarded_for === 'string' ? row.forwarded_for : null),
     })),
-  ].filter(row => row.ip_address && row.occurred_at)
+  ].filter(row => row.occurred_at)
 
-  const uniqueIps = Array.from(new Set(ipCandidates.map(row => row.ip_address as string)))
+  const uniqueIps = Array.from(
+    new Set(
+      activityCandidates
+        .map(row => normalizeIp(row.ip_candidate))
+        .filter((ipAddress): ipAddress is string => Boolean(ipAddress))
+    )
+  )
   const geoByIp = new Map<
     string,
     {
@@ -118,14 +203,29 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   }
 
-  const ipEvidence = ipCandidates
+  const activityEvents = activityCandidates
     .map(row => {
-      const ipAddress = row.ip_address as string
-      const geo = geoByIp.get(ipAddress)
+      const normalizedIp = normalizeIp(row.ip_candidate)
+      const geo = normalizedIp ? geoByIp.get(normalizedIp) ?? null : null
+      const { status, reason } = geoStatusReasonFor({
+        ipCandidate: row.ip_candidate,
+        normalizedIp,
+        geo,
+      })
+
       return {
         source: row.source,
+        event_id: row.event_id,
         occurred_at: row.occurred_at,
-        ip_address: ipAddress,
+        form_id: row.form_id,
+        login_method: row.login_method,
+        login_success: row.login_success,
+        login_email: row.login_email,
+        forwarded_for: row.forwarded_for,
+        ip_candidate: row.ip_candidate,
+        ip_address: normalizedIp,
+        geo_status: status,
+        geo_reason: reason,
         country_code: geo?.country_code ?? null,
         region: geo?.region ?? null,
         city: geo?.city ?? null,
@@ -135,6 +235,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       }
     })
     .sort((left, right) => right.occurred_at.localeCompare(left.occurred_at))
+
+  const ipEvidence = activityEvents.slice(0, 8)
 
   const seen = new Set<string>([profileRow.id])
   const queue: string[] = [profileRow.id]
@@ -292,6 +394,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return {
     profile: profileRow as ProfileRow,
+    activityEvents,
     ipEvidence,
     familyProfiles,
     primaryChildByGuardian,


### PR DESCRIPTION
## What changed
- add a new Manage Person tab: Activity and IP logs
- show latest submission/login events with raw capture data (forwarded chain, IP candidate, parsed IP)
- add explicit geo status + reason states so unknown geo is diagnosable
- keep overview page concise but explicit by showing status/reason for recent IP evidence

## Verification
- npm run test:e2e -- tests/e2e/admin-enrollment-approval.spec.ts tests/e2e/guardian-signup-enroll.spec.ts
- npm run typecheck
