### PR TITLE
Refine person geo diagnostics and sticky manage navbar

### DIFF
--- a/web/app/components/navbar.tsx
+++ b/web/app/components/navbar.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import type { User } from '@supabase/supabase-js'
-import { Link } from 'react-router'
+import { Link, useLocation } from 'react-router'
 import { LogOut, User as UserIcon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -12,8 +12,11 @@ type NavbarProps = {
 }
 
 export function Navbar({ user, role }: NavbarProps) {
+  const location = useLocation()
+  const isManagePage = location.pathname === '/manage' || location.pathname.startsWith('/manage/')
+
   return (
-    <header className="h-16 border-b bg-background/80 backdrop-blur">
+    <header className={cn('h-16 border-b bg-background/80 backdrop-blur', isManagePage ? 'sticky top-0 z-50' : '')}>
       <div className="flex h-full w-full items-center justify-between px-6">
         <Link
           to="/"

--- a/web/app/routes/manage/person.activity.tsx
+++ b/web/app/routes/manage/person.activity.tsx
@@ -17,6 +17,7 @@ const geoStatusLabel: Record<PersonLoaderData['activityEvents'][number]['geo_sta
   geo_available: 'Geo available',
   no_ip_captured: 'No IP captured',
   invalid_ip_value: 'Invalid IP value',
+  geo_provider_disabled: 'Geo provider disabled',
   ip_present_not_cached: 'IP present, lookup not cached',
   cached_no_geo: 'Lookup cached, no geo result',
 }

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -7,6 +7,7 @@ const geoStatusLabel: Record<PersonLoaderData['ipEvidence'][number]['geo_status'
   geo_available: 'Geo available',
   no_ip_captured: 'No IP captured',
   invalid_ip_value: 'Invalid IP value',
+  geo_provider_disabled: 'Geo provider disabled',
   ip_present_not_cached: 'IP present, lookup not cached',
   cached_no_geo: 'Lookup cached, no geo result',
 }

--- a/web/app/routes/manage/person.shared.ts
+++ b/web/app/routes/manage/person.shared.ts
@@ -48,6 +48,7 @@ export type PersonLoaderData = {
       | 'geo_available'
       | 'no_ip_captured'
       | 'invalid_ip_value'
+      | 'geo_provider_disabled'
       | 'ip_present_not_cached'
       | 'cached_no_geo'
     geo_reason: string
@@ -67,6 +68,7 @@ export type PersonLoaderData = {
       | 'geo_available'
       | 'no_ip_captured'
       | 'invalid_ip_value'
+      | 'geo_provider_disabled'
       | 'ip_present_not_cached'
       | 'cached_no_geo'
     geo_reason: string

--- a/web/app/routes/manage/person.tsx
+++ b/web/app/routes/manage/person.tsx
@@ -3,6 +3,7 @@ import { isIP } from 'node:net'
 import { Link, NavLink, Outlet, redirect, useLoaderData, useLocation } from 'react-router'
 
 import { requireAuth } from '@/lib/auth.server'
+import { resolveIpGeolocation } from '@/lib/geoip.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { Button } from '@/components/ui/button'
@@ -34,6 +35,7 @@ const normalizeIp = (ipCandidate: string | null) => {
 const geoStatusReasonFor = (input: {
   ipCandidate: string | null
   normalizedIp: string | null
+  geoProviderEnabled: boolean
   geo:
     | {
         country_code: string | null
@@ -60,9 +62,16 @@ const geoStatusReasonFor = (input: {
   }
 
   if (!input.geo) {
+    if (!input.geoProviderEnabled) {
+      return {
+        status: 'geo_provider_disabled' as const,
+        reason: 'IP captured, but GEOIP_PROVIDER is disabled (set GEOIP_PROVIDER=ipapi or ipinfo).',
+      }
+    }
+
     return {
       status: 'ip_present_not_cached' as const,
-      reason: 'IP captured, but no cached geolocation entry yet (lookup likely not triggered).',
+      reason: 'IP captured, but no cached geolocation entry is available yet (lookup may have failed or timed out).',
     }
   }
 
@@ -185,6 +194,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   >()
 
+  const geoProvider = (process.env.GEOIP_PROVIDER ?? 'none').trim().toLowerCase()
+  const geoProviderEnabled = geoProvider === 'ipapi' || geoProvider === 'ipinfo'
+
   if (uniqueIps.length) {
     const { data: geoRows } = await (adminClient.from('ip_geolocation_cache' as any) as any)
       .select('ip, country_code, region, city, timezone, latitude, longitude')
@@ -203,6 +215,24 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   }
 
+  if (geoProviderEnabled && uniqueIps.length) {
+    const missingIps = uniqueIps.filter(ip => !geoByIp.has(ip)).slice(0, 20)
+    await Promise.all(
+      missingIps.map(async ip => {
+        const location = await resolveIpGeolocation(ip)
+        if (!location) return
+        geoByIp.set(ip, {
+          country_code: location.countryCode,
+          region: location.region,
+          city: location.city,
+          timezone: location.timezone,
+          latitude: location.latitude,
+          longitude: location.longitude,
+        })
+      })
+    )
+  }
+
   const activityEvents = activityCandidates
     .map(row => {
       const normalizedIp = normalizeIp(row.ip_candidate)
@@ -210,6 +240,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       const { status, reason } = geoStatusReasonFor({
         ipCandidate: row.ip_candidate,
         normalizedIp,
+        geoProviderEnabled,
         geo,
       })
 


### PR DESCRIPTION
## What changed
- keep navbar sticky on manage routes
- improve person activity geo diagnostics statuses and reasons
- distinguish provider-disabled from uncached lookup states for IP geo evidence

## Verification
- npm run typecheck (web/)
