### PR TITLE
Add admin-triggered GeoIP backfill tooling

### DIFF
--- a/web/app/lib/geoip.server.ts
+++ b/web/app/lib/geoip.server.ts
@@ -48,6 +48,202 @@ const normalizeIp = (value: string) => {
   return isIP(trimmed) ? trimmed : null
 }
 
+const firstForwardedToken = (value: unknown) => {
+  if (typeof value !== 'string' || !value.trim()) return null
+  return (
+    value
+      .split(',')
+      .map(part => part.trim())
+      .find(Boolean) ?? null
+  )
+}
+
+const ipCandidateFromRow = (row: { ip_address?: unknown; forwarded_for?: unknown }) => {
+  if (typeof row.ip_address === 'string' && row.ip_address.trim()) {
+    return row.ip_address.trim()
+  }
+  return firstForwardedToken(row.forwarded_for)
+}
+
+const chunkArray = <T,>(items: T[], size: number) => {
+  if (size <= 0 || !items.length) return [] as T[][]
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+export type GeoipBackfillPreview = {
+  provider: string
+  providerEnabled: boolean
+  scannedRows: {
+    formSubmission: number
+    loginEvent: number
+  }
+  uniqueIpCount: number
+  cachedIpCount: number
+  missingIpCount: number
+  missingIpsSample: string[]
+}
+
+type BackfillCandidateOptions = {
+  recentLimitPerSource?: number
+  sampleSize?: number
+}
+
+const collectGeoipBackfillCandidates = async (
+  options: BackfillCandidateOptions = {}
+): Promise<GeoipBackfillPreview & { missingIps: string[] }> => {
+  const recentLimitPerSource =
+    Number.isFinite(options.recentLimitPerSource) && (options.recentLimitPerSource ?? 0) > 0
+      ? Math.floor(options.recentLimitPerSource as number)
+      : 4000
+  const sampleSize =
+    Number.isFinite(options.sampleSize) && (options.sampleSize ?? 0) > 0
+      ? Math.floor(options.sampleSize as number)
+      : 25
+
+  const provider = parseText(process.env.GEOIP_PROVIDER)?.toLowerCase() ?? 'none'
+  const providerEnabled = provider === 'ipapi' || provider === 'ipinfo'
+
+  const [formSubmissionResult, loginEventResult] = await Promise.all([
+    (adminClient.from('form_submission' as any) as any)
+      .select('ip_address, forwarded_for')
+      .order('submitted_at', { ascending: false })
+      .limit(recentLimitPerSource),
+    (adminClient.from('login_event' as any) as any)
+      .select('ip_address, forwarded_for')
+      .order('event_at', { ascending: false })
+      .limit(recentLimitPerSource),
+  ])
+
+  const scannedRows = {
+    formSubmission: (formSubmissionResult.data ?? []).length,
+    loginEvent: (loginEventResult.data ?? []).length,
+  }
+
+  const uniqueIps = new Set<string>()
+  for (const row of (formSubmissionResult.data ?? []) as Array<Record<string, unknown>>) {
+    const candidate = ipCandidateFromRow({
+      ip_address: row.ip_address,
+      forwarded_for: row.forwarded_for,
+    })
+    const normalized = candidate ? normalizeIp(candidate) : null
+    if (normalized) uniqueIps.add(normalized)
+  }
+  for (const row of (loginEventResult.data ?? []) as Array<Record<string, unknown>>) {
+    const candidate = ipCandidateFromRow({
+      ip_address: row.ip_address,
+      forwarded_for: row.forwarded_for,
+    })
+    const normalized = candidate ? normalizeIp(candidate) : null
+    if (normalized) uniqueIps.add(normalized)
+  }
+
+  const uniqueIpList = Array.from(uniqueIps)
+  const cachedIps = new Set<string>()
+
+  for (const chunk of chunkArray(uniqueIpList, 150)) {
+    const { data: cachedRows } = await (adminClient.from('ip_geolocation_cache' as any) as any)
+      .select('ip')
+      .in('ip', chunk)
+    for (const row of cachedRows ?? []) {
+      if (typeof row.ip === 'string' && row.ip) cachedIps.add(row.ip)
+    }
+  }
+
+  const missingIps = uniqueIpList.filter(ip => !cachedIps.has(ip))
+
+  return {
+    provider,
+    providerEnabled,
+    scannedRows,
+    uniqueIpCount: uniqueIpList.length,
+    cachedIpCount: cachedIps.size,
+    missingIpCount: missingIps.length,
+    missingIpsSample: missingIps.slice(0, sampleSize),
+    missingIps,
+  }
+}
+
+export const previewGeoipBackfill = async (options: BackfillCandidateOptions = {}) => {
+  const { missingIps, ...preview } = await collectGeoipBackfillCandidates(options)
+  void missingIps
+  return preview
+}
+
+export type GeoipBackfillRunResult = GeoipBackfillPreview & {
+  attempted: number
+  resolved: number
+  unresolved: number
+  attemptedIpsSample: string[]
+}
+
+export const runGeoipBackfill = async (options: {
+  recentLimitPerSource?: number
+  maxLookups?: number
+} = {}): Promise<GeoipBackfillRunResult> => {
+  const maxLookups =
+    Number.isFinite(options.maxLookups) && (options.maxLookups ?? 0) > 0
+      ? Math.min(1000, Math.floor(options.maxLookups as number))
+      : 200
+
+  const preview = await collectGeoipBackfillCandidates({
+    recentLimitPerSource: options.recentLimitPerSource,
+    sampleSize: 50,
+  })
+
+  const attemptIps = preview.missingIps.slice(0, maxLookups)
+  if (!attemptIps.length || !preview.providerEnabled) {
+    return {
+      provider: preview.provider,
+      providerEnabled: preview.providerEnabled,
+      scannedRows: preview.scannedRows,
+      uniqueIpCount: preview.uniqueIpCount,
+      cachedIpCount: preview.cachedIpCount,
+      missingIpCount: preview.missingIpCount,
+      missingIpsSample: preview.missingIpsSample,
+      attempted: 0,
+      resolved: 0,
+      unresolved: 0,
+      attemptedIpsSample: [],
+    }
+  }
+
+  let resolved = 0
+  let unresolved = 0
+  for (const chunk of chunkArray(attemptIps, 8)) {
+    const results = await Promise.allSettled(chunk.map(ip => resolveIpGeolocation(ip)))
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value) {
+        resolved += 1
+      } else {
+        unresolved += 1
+      }
+    }
+  }
+
+  const refreshedPreview = await collectGeoipBackfillCandidates({
+    recentLimitPerSource: options.recentLimitPerSource,
+    sampleSize: 50,
+  })
+
+  return {
+    provider: refreshedPreview.provider,
+    providerEnabled: refreshedPreview.providerEnabled,
+    scannedRows: refreshedPreview.scannedRows,
+    uniqueIpCount: refreshedPreview.uniqueIpCount,
+    cachedIpCount: refreshedPreview.cachedIpCount,
+    missingIpCount: refreshedPreview.missingIpCount,
+    missingIpsSample: refreshedPreview.missingIpsSample,
+    attempted: attemptIps.length,
+    resolved,
+    unresolved,
+    attemptedIpsSample: attemptIps.slice(0, 25),
+  }
+}
+
 const parseNumber = (value: unknown) => {
   if (typeof value === 'number' && Number.isFinite(value)) return value
   if (typeof value === 'string') {

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -74,6 +74,7 @@ export default [
     route("invites", "routes/manage/invites.tsx"),
     route("discrepancies", "routes/manage/discrepancies.tsx"),
     route("request-metadata", "routes/manage/request-metadata.tsx"),
+    route("geoip-backfill", "routes/manage/geoip-backfill.tsx"),
     route("federal-electoral-district/enrichment", "routes/manage/federal-electoral-district.enrichment.ts"),
     route("federal-electoral-district", "routes/manage/federal-electoral-district.tsx"),
     route("semester", "routes/manage/semester.tsx"),

--- a/web/app/routes/manage/geoip-backfill.tsx
+++ b/web/app/routes/manage/geoip-backfill.tsx
@@ -1,0 +1,127 @@
+import { Form, useActionData, useLoaderData, useNavigation } from 'react-router'
+
+import { requireAuth } from '@/lib/auth.server'
+import { previewGeoipBackfill, runGeoipBackfill } from '@/lib/geoip.server'
+import { isRoleAtLeast } from '@/lib/roles'
+
+import type { Route } from './+types/geoip-backfill'
+
+type ActionData = {
+  error?: string
+  result?: Awaited<ReturnType<typeof runGeoipBackfill>>
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'admin')) {
+    throw new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const preview = await previewGeoipBackfill()
+  return { preview }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'admin')) {
+    return { error: 'Unauthorized' } satisfies ActionData
+  }
+
+  const formData = await request.formData()
+  const maxLookupsRaw = Number(formData.get('max_lookups') ?? 200)
+  const maxLookups = Number.isFinite(maxLookupsRaw) && maxLookupsRaw > 0
+    ? Math.min(1000, Math.floor(maxLookupsRaw))
+    : 200
+
+  const result = await runGeoipBackfill({ maxLookups })
+  return { result } satisfies ActionData
+}
+
+export default function GeoipBackfillPage() {
+  const { preview } = useLoaderData<typeof loader>()
+  const actionData = useActionData<typeof action>() as ActionData | undefined
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state === 'submitting'
+
+  return (
+    <div className="space-y-4">
+      <header>
+        <p className="text-sm uppercase tracking-wide text-muted-foreground">System</p>
+        <h1 className="text-2xl font-semibold">GeoIP backfill</h1>
+        <p className="text-sm text-muted-foreground">
+          Manually backfill geolocation cache from recent login and submission IP records.
+        </p>
+      </header>
+
+      <section className="rounded-lg border bg-card p-4 space-y-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Current coverage</h2>
+        <div className="grid gap-2 text-sm md:grid-cols-2">
+          <p><span className="font-medium">Provider:</span> {preview.provider}</p>
+          <p><span className="font-medium">Provider enabled:</span> {preview.providerEnabled ? 'Yes' : 'No'}</p>
+          <p><span className="font-medium">Scanned form submissions:</span> {preview.scannedRows.formSubmission}</p>
+          <p><span className="font-medium">Scanned login events:</span> {preview.scannedRows.loginEvent}</p>
+          <p><span className="font-medium">Unique valid IPs:</span> {preview.uniqueIpCount}</p>
+          <p><span className="font-medium">Cached IPs:</span> {preview.cachedIpCount}</p>
+          <p><span className="font-medium">Missing cache entries:</span> {preview.missingIpCount}</p>
+        </div>
+        {preview.missingIpsSample.length ? (
+          <div className="pt-2">
+            <p className="text-xs font-medium text-muted-foreground">Sample missing IPs</p>
+            <pre className="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 text-xs">
+              {JSON.stringify(preview.missingIpsSample, null, 2)}
+            </pre>
+          </div>
+        ) : null}
+      </section>
+
+      <Form method="post" className="rounded-lg border bg-card p-4 space-y-3">
+        <label className="grid gap-1 text-sm md:max-w-xs">
+          <span className="text-muted-foreground">Max lookups this run (1-1000)</span>
+          <input
+            name="max_lookups"
+            type="number"
+            min={1}
+            max={1000}
+            defaultValue={200}
+            className="h-10 rounded border border-input bg-background px-3"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
+        >
+          {isSubmitting ? 'Running backfill...' : 'Run GeoIP backfill'}
+        </button>
+      </Form>
+
+      {actionData?.error ? (
+        <section className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          {actionData.error}
+        </section>
+      ) : null}
+
+      {actionData?.result ? (
+        <section className="rounded-lg border bg-card p-4 space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Last run result</h2>
+          <div className="grid gap-2 text-sm md:grid-cols-2">
+            <p><span className="font-medium">Attempted lookups:</span> {actionData.result.attempted}</p>
+            <p><span className="font-medium">Resolved:</span> {actionData.result.resolved}</p>
+            <p><span className="font-medium">Unresolved:</span> {actionData.result.unresolved}</p>
+            <p><span className="font-medium">Cached after run:</span> {actionData.result.cachedIpCount}</p>
+            <p><span className="font-medium">Missing after run:</span> {actionData.result.missingIpCount}</p>
+            <p><span className="font-medium">Provider enabled:</span> {actionData.result.providerEnabled ? 'Yes' : 'No'}</p>
+          </div>
+          {actionData.result.attemptedIpsSample.length ? (
+            <div className="pt-2">
+              <p className="text-xs font-medium text-muted-foreground">Attempted IPs sample</p>
+              <pre className="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 text-xs">
+                {JSON.stringify(actionData.result.attemptedIpsSample, null, 2)}
+              </pre>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+    </div>
+  )
+}

--- a/web/app/routes/manage/nav.ts
+++ b/web/app/routes/manage/nav.ts
@@ -92,6 +92,7 @@ export const manageSections: ManageNavSection[] = [
       { to: '/manage/semester-form-requirement', label: 'Semester surveys', description: 'Map one pre/post survey form per semester.' },
       { to: '/manage/role-permission', label: 'Role permissions', description: 'Permissions assigned to each role.' },
       { to: '/manage/request-metadata', label: 'Request metadata', description: 'Validate proxy headers and extracted request metadata.' },
+      { to: '/manage/geoip-backfill', label: 'GeoIP backfill', description: 'Admin-triggered geolocation cache backfill for recent IP records.' },
       { to: '/manage/user-roles', label: 'User roles', description: 'The role each user currently holds.' },
       { to: '/manage/sign-up-terms-consent', label: 'Terms consent', description: 'Accepted terms snapshots captured at signup.' },
       { to: '/manage/sign-up-terms', label: 'Sign-up terms', description: 'Active terms copy shown during account creation.' },


### PR DESCRIPTION
## What changed
- add manage geoip-backfill admin page to preview and run GeoIP cache backfills
- add backfill candidate collection and run helpers in web/app/lib/geoip.server.ts
- wire the page into manage routes and system navigation

## Verification
- npm run typecheck (web/)
