### PR TITLE
Add geo hover details and discrepancy profile links

### DIFF
--- a/web/app/routes/manage/form-submission.tsx
+++ b/web/app/routes/manage/form-submission.tsx
@@ -1,8 +1,85 @@
 import TableDisplay from './table-display'
 import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
+import { resolveIpGeolocation } from '@/lib/geoip.server'
+import type { Route } from './+types/form-submission'
 
-export const loader = createTableLoader('form-submission')
+const baseLoader = createTableLoader('form-submission')
+
+const flagEmojiForCountryCode = (countryCode: string | null) => {
+  if (!countryCode) return ''
+  const normalized = countryCode.trim().toUpperCase()
+  if (!/^[A-Z]{2}$/.test(normalized)) return ''
+  return String.fromCodePoint(...Array.from(normalized).map(char => 127397 + char.charCodeAt(0)))
+}
+
+export async function loader(args: Route.LoaderArgs) {
+  const base = await baseLoader(args)
+  const rows = (base.rows ?? []) as Array<Record<string, unknown>>
+  const uniqueIps = Array.from(
+    new Set(rows.map(row => (typeof row.ip_address === 'string' ? row.ip_address.trim() : '')).filter(Boolean))
+  )
+  const geoByIp = new Map<string, Awaited<ReturnType<typeof resolveIpGeolocation>>>()
+
+  await Promise.all(
+    uniqueIps.map(async ip => {
+      const geo = await resolveIpGeolocation(ip)
+      geoByIp.set(ip, geo)
+    })
+  )
+
+  const enrichedRows = rows.map(row => {
+    const ipAddress = typeof row.ip_address === 'string' ? row.ip_address.trim() : ''
+    const geo = ipAddress ? geoByIp.get(ipAddress) ?? null : null
+    const countryCode = geo?.countryCode ?? null
+    const flag = flagEmojiForCountryCode(countryCode)
+    const geoParts = [geo?.city, geo?.region, countryCode].filter(Boolean)
+    const geoSummary = geoParts.length
+      ? `${flag ? `${flag} ` : ''}${geoParts.join(', ')}`
+      : countryCode
+        ? `${flag ? `${flag} ` : ''}${countryCode}`
+        : 'Unknown location'
+
+    const latitude = typeof geo?.latitude === 'number' ? geo.latitude : null
+    const longitude = typeof geo?.longitude === 'number' ? geo.longitude : null
+
+    return {
+      ...row,
+      ip_geo_summary: geoSummary,
+      ip_geo_country: countryCode ?? '-',
+      ip_geo_timezone: geo?.timezone ?? '-',
+      ip_geo_source: geo?.source ?? '-',
+      ip_geo_coordinates:
+        latitude !== null && longitude !== null
+          ? `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`
+          : '-',
+    }
+  })
+
+  const baseColumnMeta = (base.columnMeta ?? {}) as Record<string, unknown>
+
+  return {
+    ...base,
+    rows: enrichedRows,
+    columnMeta: {
+      ...baseColumnMeta,
+      ip_address: {
+        ...(baseColumnMeta.ip_address as Record<string, unknown> ?? {}),
+        hoverCard: {
+          titleField: 'ip_geo_summary',
+          titleFallback: 'Unknown location',
+          fields: [
+            { label: 'Country', field: 'ip_geo_country', fallback: '-' },
+            { label: 'Timezone', field: 'ip_geo_timezone', fallback: '-' },
+            { label: 'Coordinates', field: 'ip_geo_coordinates', fallback: '-' },
+            { label: 'Provider', field: 'ip_geo_source', fallback: '-' },
+          ],
+        },
+      },
+    },
+  }
+}
+
 export const action = createTableAction('form-submission')
 
 export default function FormSubmissionsTablePage() {

--- a/web/app/routes/manage/login-event.tsx
+++ b/web/app/routes/manage/login-event.tsx
@@ -1,7 +1,83 @@
 import TableDisplay from './table-display'
 import { createTableLoader } from './table-loader'
+import { resolveIpGeolocation } from '@/lib/geoip.server'
+import type { Route } from './+types/login-event'
 
-export const loader = createTableLoader('login-event')
+const baseLoader = createTableLoader('login-event')
+
+const flagEmojiForCountryCode = (countryCode: string | null) => {
+  if (!countryCode) return ''
+  const normalized = countryCode.trim().toUpperCase()
+  if (!/^[A-Z]{2}$/.test(normalized)) return ''
+  return String.fromCodePoint(...Array.from(normalized).map(char => 127397 + char.charCodeAt(0)))
+}
+
+export async function loader(args: Route.LoaderArgs) {
+  const base = await baseLoader(args)
+  const rows = (base.rows ?? []) as Array<Record<string, unknown>>
+  const uniqueIps = Array.from(
+    new Set(rows.map(row => (typeof row.ip_address === 'string' ? row.ip_address.trim() : '')).filter(Boolean))
+  )
+  const geoByIp = new Map<string, Awaited<ReturnType<typeof resolveIpGeolocation>>>()
+
+  await Promise.all(
+    uniqueIps.map(async ip => {
+      const geo = await resolveIpGeolocation(ip)
+      geoByIp.set(ip, geo)
+    })
+  )
+
+  const enrichedRows = rows.map(row => {
+    const ipAddress = typeof row.ip_address === 'string' ? row.ip_address.trim() : ''
+    const geo = ipAddress ? geoByIp.get(ipAddress) ?? null : null
+    const countryCode = geo?.countryCode ?? null
+    const flag = flagEmojiForCountryCode(countryCode)
+    const geoParts = [geo?.city, geo?.region, countryCode].filter(Boolean)
+    const geoSummary = geoParts.length
+      ? `${flag ? `${flag} ` : ''}${geoParts.join(', ')}`
+      : countryCode
+        ? `${flag ? `${flag} ` : ''}${countryCode}`
+        : 'Unknown location'
+
+    const latitude = typeof geo?.latitude === 'number' ? geo.latitude : null
+    const longitude = typeof geo?.longitude === 'number' ? geo.longitude : null
+
+    return {
+      ...row,
+      ip_geo_summary: geoSummary,
+      ip_geo_country: countryCode ?? '-',
+      ip_geo_timezone: geo?.timezone ?? '-',
+      ip_geo_source: geo?.source ?? '-',
+      ip_geo_coordinates:
+        latitude !== null && longitude !== null
+          ? `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`
+          : '-',
+    }
+  })
+
+  const baseColumnMeta = (base.columnMeta ?? {}) as Record<string, unknown>
+
+  return {
+    ...base,
+    rows: enrichedRows,
+    columnMeta: {
+      ...baseColumnMeta,
+      ip_address: {
+        ...(baseColumnMeta.ip_address as Record<string, unknown> ?? {}),
+        hoverCard: {
+          titleField: 'ip_geo_summary',
+          titleFallback: 'Unknown location',
+          fields: [
+            { label: 'Country', field: 'ip_geo_country', fallback: '-' },
+            { label: 'Timezone', field: 'ip_geo_timezone', fallback: '-' },
+            { label: 'Coordinates', field: 'ip_geo_coordinates', fallback: '-' },
+            { label: 'Provider', field: 'ip_geo_source', fallback: '-' },
+          ],
+        },
+      },
+    },
+  }
+}
 
 export default function LoginEventTablePage() {
   return <TableDisplay />

--- a/web/app/routes/manage/person.discrepancies.tsx
+++ b/web/app/routes/manage/person.discrepancies.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useOutletContext } from 'react-router'
+import { Link, useLocation, useOutletContext } from 'react-router'
 
 import type { Json } from '@/lib/database.types'
 
@@ -20,6 +20,8 @@ const severityClassName = (severity: string) => {
 export default function ManagePersonDiscrepanciesPage() {
   const { suspiciousSignals, familyProfiles } = useOutletContext<PersonLoaderData>()
   const profileById = useMemo(() => new Map(familyProfiles.map(profile => [profile.id, profile])), [familyProfiles])
+  const location = useLocation()
+  const returnTo = `${location.pathname}${location.search}`
 
   const openSignals = suspiciousSignals.filter(signal => signal.status === 'open')
   const closedSignals = suspiciousSignals.filter(signal => signal.status !== 'open')
@@ -61,7 +63,21 @@ export default function ManagePersonDiscrepanciesPage() {
                             .filter(Boolean)
                             .join(', ')
                           return (
-                            <li key={`${signal.id}-${idx}`}>• {label}: {address || '-'}</li>
+                            <li key={`${signal.id}-${idx}`}>
+                              • {profileId ? (
+                                <Link
+                                  to={{
+                                    pathname: '/manage/person',
+                                    search: new URLSearchParams({ profileId, returnTo }).toString(),
+                                  }}
+                                  className="underline decoration-dotted underline-offset-2 hover:text-primary"
+                                >
+                                  {label}
+                                </Link>
+                              ) : (
+                                label
+                              )}: {address || '-'}
+                            </li>
                           )
                         })}
                       </ul>
@@ -126,7 +142,21 @@ export default function ManagePersonDiscrepanciesPage() {
                               .filter(Boolean)
                               .join(', ')
                             return (
-                              <li key={`${signal.id}-cross-${idx}`}>• {label}: {address || '-'}</li>
+                              <li key={`${signal.id}-cross-${idx}`}>
+                                • {profileId ? (
+                                  <Link
+                                    to={{
+                                      pathname: '/manage/person',
+                                      search: new URLSearchParams({ profileId, returnTo }).toString(),
+                                    }}
+                                    className="underline decoration-dotted underline-offset-2 hover:text-primary"
+                                  >
+                                    {label}
+                                  </Link>
+                                ) : (
+                                  label
+                                )}: {address || '-'}
+                              </li>
                             )
                           }
                         )}

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -56,6 +56,8 @@ type WorkshopEnrollmentEnrichment = {
   profile_hover_name: string
   profile_hover_email: string
   profile_hover_parent_email: string
+  profile_hover_latest_ip: string
+  profile_hover_latest_ip_geo: string
 }
 
 type WorkshopEnrollmentEnrichmentResponse = {
@@ -492,6 +494,8 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
           profile_hover_name: 'N/A',
           profile_hover_email: 'N/A',
           profile_hover_parent_email: 'N/A',
+          profile_hover_latest_ip: 'N/A',
+          profile_hover_latest_ip_geo: 'N/A',
         }
 
         const resolvedByProfileId = requestProfileIds.reduce<Record<string, WorkshopEnrollmentEnrichment>>(

--- a/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
+++ b/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
@@ -1,4 +1,5 @@
 import { adminClient } from '@/lib/supabase/adminClient'
+import { resolveIpGeolocation } from '@/lib/geoip.server'
 
 const GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE = 'gift_card_store_preference'
 const PRIOR_PARTICIPATION_QUESTION_CODE = 'onboarding_prior_participation'
@@ -53,6 +54,26 @@ export type WorkshopEnrollmentEnrichment = {
   profile_hover_name: string
   profile_hover_email: string
   profile_hover_parent_email: string
+  profile_hover_latest_ip: string
+  profile_hover_latest_ip_geo: string
+}
+
+const flagEmojiForCountryCode = (countryCode: string | null) => {
+  if (!countryCode) return ''
+  const normalized = countryCode.trim().toUpperCase()
+  if (!/^[A-Z]{2}$/.test(normalized)) return ''
+  return String.fromCodePoint(...Array.from(normalized).map(char => 127397 + char.charCodeAt(0)))
+}
+
+const parsePrimaryIp = (ipAddress: unknown, forwardedFor: unknown) => {
+  if (typeof ipAddress === 'string' && ipAddress.trim()) return ipAddress.trim()
+  if (typeof forwardedFor !== 'string' || !forwardedFor.trim()) return null
+  return (
+    forwardedFor
+      .split(',')
+      .map(part => part.trim())
+      .find(Boolean) ?? null
+  )
 }
 
 const normalizeRiding = (value: unknown) =>
@@ -202,6 +223,22 @@ export async function loadWorkshopEnrollmentEnrichment(profileIds: string[]) {
     return byProfileId
   }
 
+  const latestSubmissionByProfileId = new Map<string, { occurredAt: string; ip: string }>()
+  for (const profileChunk of chunkArray(profileScope, IN_CLAUSE_BATCH_SIZE)) {
+    const { data: submissions } = await (adminClient.from('form_submission' as any) as any)
+      .select('profile_id, submitted_at, ip_address, forwarded_for')
+      .in('profile_id', profileChunk)
+      .order('submitted_at', { ascending: false })
+
+    for (const submission of submissions ?? []) {
+      const profileId = typeof submission.profile_id === 'string' ? submission.profile_id : ''
+      const occurredAt = typeof submission.submitted_at === 'string' ? submission.submitted_at : ''
+      const ip = parsePrimaryIp(submission.ip_address, submission.forwarded_for)
+      if (!profileId || !occurredAt || !ip || latestSubmissionByProfileId.has(profileId)) continue
+      latestSubmissionByProfileId.set(profileId, { occurredAt, ip })
+    }
+  }
+
   const { data: discrepancyRowsRaw } = await (adminClient.from('suspicious_signal') as any)
     .select('id, family_profile_ids, signal_type, severity, summary, priority_score, created_at')
     .eq('status', 'open')
@@ -232,6 +269,53 @@ export async function loadWorkshopEnrollmentEnrichment(profileIds: string[]) {
       profileIdsByUserId.set(profile.user_id, existing)
     }
   }
+
+  const userIds = Array.from(profileIdsByUserId.keys())
+  const latestLoginByUserId = new Map<string, { occurredAt: string; ip: string }>()
+  for (const userChunk of chunkArray(userIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { data: loginEvents } = await (adminClient.from('login_event' as any) as any)
+      .select('user_id, event_at, ip_address, forwarded_for')
+      .in('user_id', userChunk)
+      .order('event_at', { ascending: false })
+
+    for (const event of loginEvents ?? []) {
+      const userId = typeof event.user_id === 'string' ? event.user_id : ''
+      const occurredAt = typeof event.event_at === 'string' ? event.event_at : ''
+      const ip = parsePrimaryIp(event.ip_address, event.forwarded_for)
+      if (!userId || !occurredAt || !ip || latestLoginByUserId.has(userId)) continue
+      latestLoginByUserId.set(userId, { occurredAt, ip })
+    }
+  }
+
+  const latestIpByProfileId = new Map<string, { occurredAt: string; ip: string }>()
+  for (const profileId of profileScope) {
+    const profile = profileById.get(profileId)
+    const submissionCandidate = latestSubmissionByProfileId.get(profileId) ?? null
+    const loginCandidate =
+      profile?.user_id && latestLoginByUserId.get(profile.user_id)
+        ? latestLoginByUserId.get(profile.user_id)!
+        : null
+
+    if (submissionCandidate && loginCandidate) {
+      latestIpByProfileId.set(
+        profileId,
+        submissionCandidate.occurredAt >= loginCandidate.occurredAt ? submissionCandidate : loginCandidate
+      )
+    } else if (submissionCandidate) {
+      latestIpByProfileId.set(profileId, submissionCandidate)
+    } else if (loginCandidate) {
+      latestIpByProfileId.set(profileId, loginCandidate)
+    }
+  }
+
+  const uniqueLatestIps = Array.from(new Set(Array.from(latestIpByProfileId.values()).map(entry => entry.ip)))
+  const geoByIp = new Map<string, Awaited<ReturnType<typeof resolveIpGeolocation>>>()
+  await Promise.all(
+    uniqueLatestIps.map(async ip => {
+      const geo = await resolveIpGeolocation(ip)
+      geoByIp.set(ip, geo)
+    })
+  )
 
   const visited = new Set<string>()
   for (const rootProfileId of profileScope) {
@@ -560,6 +644,28 @@ export async function loadWorkshopEnrollmentEnrichment(profileIds: string[]) {
       }
     })()
 
+    const latestIpInfo = (() => {
+      for (const candidateProfileId of candidateProfileIds) {
+        const latest = latestIpByProfileId.get(candidateProfileId)
+        if (!latest) continue
+        const geo = geoByIp.get(latest.ip) ?? null
+        const countryCode = geo?.countryCode ?? null
+        const flag = flagEmojiForCountryCode(countryCode)
+        const geoParts = [geo?.city, geo?.region, countryCode].filter(Boolean)
+        const geoLabel = geoParts.length
+          ? `${flag ? `${flag} ` : ''}${geoParts.join(', ')}`
+          : countryCode
+            ? `${flag ? `${flag} ` : ''}${countryCode}`
+            : 'Unknown location'
+        return {
+          ip: latest.ip,
+          geo: geoLabel,
+        }
+      }
+
+      return { ip: '', geo: '' }
+    })()
+
     byProfileId[profileId] = {
       riding_display: ridingDisplay,
       giftcard_display: giftcardDisplay,
@@ -569,6 +675,8 @@ export async function loadWorkshopEnrollmentEnrichment(profileIds: string[]) {
       profile_hover_name: profileHoverName,
       profile_hover_email: profileHoverEmail,
       profile_hover_parent_email: profileHoverParentEmail,
+      profile_hover_latest_ip: latestIpInfo.ip,
+      profile_hover_latest_ip_geo: latestIpInfo.geo,
     }
   }
 

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -141,6 +141,8 @@ export async function loader(args: Route.LoaderArgs) {
       profile_hover_name: '',
       profile_hover_email: '',
       profile_hover_parent_email: '',
+      profile_hover_latest_ip: '',
+      profile_hover_latest_ip_geo: '',
     }
 
     if (!profileSignals.length) {
@@ -258,6 +260,8 @@ export async function loader(args: Route.LoaderArgs) {
           fields: [
             { label: 'Email', field: 'profile_hover_email', fallback: 'N/A' },
             { label: 'Parent Email', field: 'profile_hover_parent_email', fallback: 'N/A' },
+            { label: 'Latest IP', field: 'profile_hover_latest_ip', fallback: 'N/A' },
+            { label: 'Latest IP Geo', field: 'profile_hover_latest_ip_geo', fallback: 'N/A' },
             { label: 'Top Discrepancy', field: 'profile_hover_top_discrepancy' },
             { label: 'More Open', field: 'profile_hover_more_discrepancies' },
           ],


### PR DESCRIPTION
## What\n- add IP geolocation hover details for `ip_address` columns in form submissions and login events\n- enrich workshop enrollment profile hover cards with latest IP + geolocation summary\n- make discrepancy profile labels clickable in address evidence sections\n\n## Why\n- improve suspicious activity triage by exposing geolocation context inline\n- make it faster to navigate from discrepancy evidence to the related person record\n\n## Validation\n- npm run typecheck