### PR TITLE
Add workshop geo column and prod seed workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ _**
 /build/
 /web/test-results/
 /web/playwright-report/
+
+# Local production snapshot seed dumps (PII/sensitive)
+/supabase/seeds/prod-data/*.sql

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -62,7 +62,15 @@ schema_paths = []
 enabled = true
 # Specifies an ordered list of seed files to load during db reset.
 # Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+#
+# Default local developer mode (app bootstrap + deterministic dummy fixtures):
 sql_paths = ["./seeds/app-data/*.sql", "./seeds/dummy-data/*.sql"]
+#
+# Production snapshot mode (bootstrap + local prod dump, no dummy fixtures):
+# sql_paths = ["./seeds/app-data/*.sql", "./seeds/prod-data/*.sql"]
+#
+# Dummy-only mode (for fixture-only smoke runs):
+# sql_paths = ["./seeds/dummy-data/*.sql"]
 
 [db.network_restrictions]
 # Enable management of network restrictions.

--- a/supabase/seeds/app-data/07_semester-surveys.sql
+++ b/supabase/seeds/app-data/07_semester-surveys.sql
@@ -7,9 +7,7 @@ with semester_forms as (
     false,
     '{}'::app_role[]
   from public.semester s
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 )
 select count(*) from semester_forms;
@@ -21,9 +19,7 @@ with semester_forms as (
     false,
     '{}'::app_role[]
   from public.semester s
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 )
 select count(*) from semester_forms;
@@ -110,10 +106,7 @@ select * from (
     ('post_feedback_recipes_future', 'Are there any recipes or foods your family would like to learn to make in the future?', 'text'::form_question_type, '[]'::jsonb),
     ('post_feedback_other_comments', 'Do you have any other comments or feedback for the summerlunch+ program or team members?', 'text'::form_question_type, '[]'::jsonb)
 ) as seeded(question_code, prompt, "type", options)
-on conflict (question_code) do update
-  set prompt = excluded.prompt,
-      "type" = excluded."type",
-      options = excluded.options;
+on conflict (question_code) do nothing;
 
 with pre_forms as (
   select id from public.form where name like 'Pre-Semester Survey - %'
@@ -151,10 +144,7 @@ insert into public.form_question_map (
 select f.id, q.question_code, q.position, q.metadata, null::jsonb
 from pre_forms f
 cross join pre_questions q
-on conflict (form_id, question_code) do update
-  set position = excluded.position,
-      metadata = excluded.metadata,
-      visibility_condition = excluded.visibility_condition;
+on conflict (form_id, question_code) do nothing;
 
 with kind_labels as (
   select
@@ -218,9 +208,7 @@ insert into public.semester_form_requirement (semester_id, form_id, kind, is_req
 select s.id, f.id, (select pre_kind from kind_labels)::public.semester_survey_kind, true, true
 from public.semester s
 join public.form f on f.name = format('Pre-Semester Survey - %s', s.id)
-on conflict (semester_id, form_id, kind) do update
-  set is_required = excluded.is_required,
-      is_active = excluded.is_active;
+on conflict (semester_id, form_id, kind) do nothing;
 
 with kind_labels as (
   select
@@ -238,9 +226,7 @@ insert into public.semester_form_requirement (semester_id, form_id, kind, is_req
 select s.id, f.id, (select post_kind from kind_labels)::public.semester_survey_kind, true, true
 from public.semester s
 join public.form f on f.name = format('Post-Semester Survey - %s', s.id)
-on conflict (semester_id, form_id, kind) do update
-  set is_required = excluded.is_required,
-      is_active = excluded.is_active;
+on conflict (semester_id, form_id, kind) do nothing;
 
 with post_forms as (
   select id from public.form where name like 'Post-Semester Survey - %'
@@ -292,7 +278,4 @@ insert into public.form_question_map (
 select f.id, q.question_code, q.position, q.metadata, null::jsonb
 from post_forms f
 cross join post_questions q
-on conflict (form_id, question_code) do update
-  set position = excluded.position,
-      metadata = excluded.metadata,
-      visibility_condition = excluded.visibility_condition;
+on conflict (form_id, question_code) do nothing;

--- a/supabase/seeds/app-data/federal-electoral-districts.sql
+++ b/supabase/seeds/app-data/federal-electoral-districts.sql
@@ -345,5 +345,4 @@ values
   (60001, 'Yukon'),
   (61001, 'Northwest Territories'),
   (62001, 'Nunavut')
-on conflict (code) do update
-  set name = excluded.name;
+on conflict (code) do nothing;

--- a/supabase/seeds/app-data/onboarding-form.sql
+++ b/supabase/seeds/app-data/onboarding-form.sql
@@ -3,9 +3,7 @@
 with form_row as (
   insert into public.form (name, is_required, auto_assign)
   values ('Onboarding Survey', true, array['unassigned']::app_role[])
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 )
 insert into public.form_question (question_code, prompt, "type", options)
@@ -14,10 +12,7 @@ union all
 select 'onboarding_prior_participation', 'Have you been apart of summerlunch+ before?', 'single_choice'::form_question_type, '["yes","no"]'::jsonb
 union all
 select 'onboarding_partner_program', 'Partner-Program', 'text'::form_question_type, '[]'::jsonb
-on conflict (question_code) do update
-  set prompt = excluded.prompt,
-      "type" = excluded."type",
-      options = excluded.options;
+on conflict (question_code) do nothing;
 
 with form_row as (
   select id from public.form where name = 'Onboarding Survey'
@@ -28,8 +23,7 @@ union all
 select id, 'onboarding_prior_participation', 2 from form_row
 union all
 select id, 'onboarding_partner_program', 3 from form_row
-on conflict (form_id, question_code) do update
-  set position = excluded.position;
+on conflict (form_id, question_code) do nothing;
 
 insert into public.form_assignment (form_id, user_id, assigned_by)
 select fr.id, ur.user_id, null

--- a/supabase/seeds/app-data/sign-up-forms.sql
+++ b/supabase/seeds/app-data/sign-up-forms.sql
@@ -7,9 +7,7 @@ with profile_form as (
     true,
     array['guardian','student','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), guardian_details_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -18,9 +16,7 @@ with profile_form as (
     true,
     array['student','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), child_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -29,9 +25,7 @@ with profile_form as (
     true,
     array['guardian','student','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), address_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -40,9 +34,7 @@ with profile_form as (
     true,
     array['guardian','student','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), child_email_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -51,9 +43,7 @@ with profile_form as (
     true,
     array['guardian','student','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), additional_guardian_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -62,9 +52,7 @@ with profile_form as (
     false,
     array['guardian','student','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), household_counts_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -73,9 +61,7 @@ with profile_form as (
     true,
     array['guardian','student','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), partner_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -84,9 +70,7 @@ with profile_form as (
     true,
     array['guardian','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 ), guardian_form as (
   insert into public.form (name, is_required, auto_assign)
@@ -95,9 +79,7 @@ with profile_form as (
     true,
     array['guardian','unassigned']::app_role[]
   )
-  on conflict (name) do update
-    set is_required = excluded.is_required,
-        auto_assign = excluded.auto_assign
+  on conflict (name) do nothing
   returning id
 )
 insert into public.form_question (question_code, prompt, "type", options)
@@ -197,10 +179,7 @@ union all
 select 'guardian_consent_questionnaire', 'I agree to participate in the pre- and post-program questionnaires.', 'checkbox'::form_question_type, '[]'::jsonb
 union all
 select 'guardian_consent_interview', 'May summerlunch+ contact you for an interview after the program has finished?', 'single_choice'::form_question_type, '["Yes","No"]'::jsonb
-on conflict (question_code) do update
-  set prompt = excluded.prompt,
-      "type" = excluded."type",
-      options = excluded.options;
+on conflict (question_code) do nothing;
 
 with profile_form as (
   select id from public.form where name = 'Profile Information'
@@ -292,10 +271,7 @@ union all
 select id, 'guardian_consent_questionnaire', 10, '{}'::jsonb, null::jsonb from guardian_form
 union all
 select id, 'guardian_consent_interview', 11, '{}'::jsonb, null::jsonb from guardian_form
-on conflict (form_id, question_code) do update
-  set position = excluded.position,
-      metadata = excluded.metadata,
-      visibility_condition = excluded.visibility_condition;
+on conflict (form_id, question_code) do nothing;
 
 insert into public.sign_up_flow (form_id, slug, step_order, roles)
 select id, 'profile_information', 1, array['guardian','student']::app_role[]
@@ -325,10 +301,7 @@ union all
 select id, 'guardian_consent', 9, array['guardian']::app_role[]
 from public.form
 where name = 'Guardian Consent'
-on conflict (form_id) do update
-  set slug = excluded.slug,
-      step_order = excluded.step_order,
-      roles = excluded.roles;
+on conflict (form_id) do nothing;
 
 update public.sign_up_flow sf
 set step_order = 8

--- a/supabase/seeds/dummy-data/zzz_cross-table-scenarios.sql
+++ b/supabase/seeds/dummy-data/zzz_cross-table-scenarios.sql
@@ -20,8 +20,8 @@ with selected_forms as (
     (
       select id
       from public.form
-      where name = 'Pre-Semester Survey - bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
-      order by id desc
+      where name like 'Pre-Semester Survey - %'
+      order by name asc
       limit 1
     ) as pre_survey_form_id
 ), submission_rows as (

--- a/supabase/seeds/prod-data/README.md
+++ b/supabase/seeds/prod-data/README.md
@@ -1,0 +1,39 @@
+# Production Snapshot Seed Folder
+
+Use this folder for local, uncommitted production data snapshots.
+
+## Important
+
+- SQL dumps in this folder are gitignored via `.gitignore`.
+- Do not commit production snapshot data.
+
+## Recommended dump scope
+
+- Keep snapshot SQL **data-only**.
+- Avoid schema/DDL in dumps. Schema should continue to come from `supabase/migrations/*`.
+
+## Keep only runtime data here
+
+When preparing a prod dump for this folder, remove data that is already maintained by:
+
+- migrations (`supabase/migrations/*`), and
+- app bootstrap seeds (`supabase/seeds/app-data/*`).
+
+In practice, remove rows for static/bootstrap tables such as:
+
+- `role_permission`
+- `form`
+- `form_question`
+- `form_question_map`
+- `semester_form_requirement`
+- `federal_electoral_district`
+- storage bootstrap rows/policies created by app-data
+
+The prod snapshot should focus on operational/runtime tables (profiles, enrollments, submissions, events, messages, discrepancies, etc.).
+
+## Selecting seed mode
+
+Switch `db.seed.sql_paths` in `supabase/config.toml`:
+
+- app + dummy: `./seeds/app-data/*.sql`, `./seeds/dummy-data/*.sql`
+- app + prod snapshot: `./seeds/app-data/*.sql`, `./seeds/prod-data/*.sql`

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -49,6 +49,7 @@ type HoverCardConfig = {
 
 type WorkshopEnrollmentEnrichment = {
   riding_display: string
+  geo_locations_display: string
   giftcard_display: string
   prior_participation_display: string
   profile_hover_top_discrepancy: string
@@ -700,6 +701,7 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
         const payload = (await response.json()) as WorkshopEnrollmentEnrichmentResponse
         const fallbackEnrichment: WorkshopEnrollmentEnrichment = {
           riding_display: '',
+          geo_locations_display: 'N/A',
           giftcard_display: 'N/A',
           prior_participation_display: 'N/A',
           profile_hover_top_discrepancy: '',

--- a/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
+++ b/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
@@ -47,6 +47,7 @@ type OpenDiscrepancyRow = {
 
 export type WorkshopEnrollmentEnrichment = {
   riding_display: string
+  geo_locations_display: string
   giftcard_display: string
   prior_participation_display: string
   profile_hover_top_discrepancy: string
@@ -74,6 +75,17 @@ const parsePrimaryIp = (ipAddress: unknown, forwardedFor: unknown) => {
       .map(part => part.trim())
       .find(Boolean) ?? null
   )
+}
+
+const formatGeoLabel = (geo: Awaited<ReturnType<typeof resolveIpGeolocation>> | null) => {
+  const countryCode = geo?.countryCode ?? null
+  const flag = flagEmojiForCountryCode(countryCode)
+  const geoParts = [geo?.city, geo?.region, countryCode].filter(Boolean)
+  return geoParts.length
+    ? `${flag ? `${flag} ` : ''}${geoParts.join(', ')}`
+    : countryCode
+      ? `${flag ? `${flag} ` : ''}${countryCode}`
+      : 'Unknown location'
 }
 
 const normalizeRiding = (value: unknown) =>
@@ -649,25 +661,34 @@ export async function loadWorkshopEnrollmentEnrichment(profileIds: string[]) {
         const latest = latestIpByProfileId.get(candidateProfileId)
         if (!latest) continue
         const geo = geoByIp.get(latest.ip) ?? null
-        const countryCode = geo?.countryCode ?? null
-        const flag = flagEmojiForCountryCode(countryCode)
-        const geoParts = [geo?.city, geo?.region, countryCode].filter(Boolean)
-        const geoLabel = geoParts.length
-          ? `${flag ? `${flag} ` : ''}${geoParts.join(', ')}`
-          : countryCode
-            ? `${flag ? `${flag} ` : ''}${countryCode}`
-            : 'Unknown location'
         return {
           ip: latest.ip,
-          geo: geoLabel,
+          geo: formatGeoLabel(geo),
         }
       }
 
       return { ip: '', geo: '' }
     })()
 
+    const geoLocationsDisplay = (() => {
+      const uniqueLabels: string[] = []
+      for (const candidateProfileId of candidateProfileIds) {
+        const latest = latestIpByProfileId.get(candidateProfileId)
+        if (!latest) continue
+        const label = formatGeoLabel(geoByIp.get(latest.ip) ?? null)
+        if (!uniqueLabels.includes(label)) {
+          uniqueLabels.push(label)
+        }
+      }
+
+      if (!uniqueLabels.length) return 'N/A'
+      if (uniqueLabels.length <= 2) return uniqueLabels.join(' | ')
+      return `${uniqueLabels.slice(0, 2).join(' | ')} +${uniqueLabels.length - 2} more`
+    })()
+
     byProfileId[profileId] = {
       riding_display: ridingDisplay,
+      geo_locations_display: geoLocationsDisplay,
       giftcard_display: giftcardDisplay,
       prior_participation_display: priorParticipationDisplay,
       profile_hover_top_discrepancy: discrepancyInfo.top,

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -134,6 +134,7 @@ export async function loader(args: Route.LoaderArgs) {
       ...row,
       enrolled_capacity: capacity === null ? `${approved}/-` : `${approved}/${capacity}`,
       riding_display: '...',
+      geo_locations_display: '...',
       giftcard_display: '...',
       prior_participation_display: '...',
       profile_hover_top_discrepancy: '',
@@ -199,15 +200,34 @@ export async function loader(args: Route.LoaderArgs) {
   }
 
   if (!columns.includes('giftcard_display')) {
+    const geoLocationsIndex = columns.indexOf('geo_locations_display')
+    if (geoLocationsIndex >= 0) {
+      columns = [...columns.slice(0, geoLocationsIndex + 1), 'giftcard_display', ...columns.slice(geoLocationsIndex + 1)]
+    } else {
+      const ridingIndex = columns.indexOf('riding_display')
+      if (ridingIndex >= 0) {
+        columns = [...columns.slice(0, ridingIndex + 1), 'giftcard_display', ...columns.slice(ridingIndex + 1)]
+      } else {
+        const profileIndex = columns.indexOf('profile_display')
+        if (profileIndex >= 0) {
+          columns = [...columns.slice(0, profileIndex + 1), 'giftcard_display', ...columns.slice(profileIndex + 1)]
+        } else {
+          columns = [...columns, 'giftcard_display']
+        }
+      }
+    }
+  }
+
+  if (!columns.includes('geo_locations_display')) {
     const ridingIndex = columns.indexOf('riding_display')
     if (ridingIndex >= 0) {
-      columns = [...columns.slice(0, ridingIndex + 1), 'giftcard_display', ...columns.slice(ridingIndex + 1)]
+      columns = [...columns.slice(0, ridingIndex + 1), 'geo_locations_display', ...columns.slice(ridingIndex + 1)]
     } else {
       const profileIndex = columns.indexOf('profile_display')
       if (profileIndex >= 0) {
-        columns = [...columns.slice(0, profileIndex + 1), 'giftcard_display', ...columns.slice(profileIndex + 1)]
+        columns = [...columns.slice(0, profileIndex + 1), 'geo_locations_display', ...columns.slice(profileIndex + 1)]
       } else {
-        columns = [...columns, 'giftcard_display']
+        columns = [...columns, 'geo_locations_display']
       }
     }
   }
@@ -272,6 +292,9 @@ export async function loader(args: Route.LoaderArgs) {
       },
       riding_display: {
         label: 'riding',
+      },
+      geo_locations_display: {
+        label: 'geo locations',
       },
       giftcard_display: {
         label: 'giftcard',


### PR DESCRIPTION
## What
- add lazy-loaded geo locations enrichment field on workshop enrollments
- compute geo location labels from latest candidate profile IP evidence
- wire the new workshop enrollment column and fallback typing in table enrichment
- add supabase/seeds/prod-data workflow for local production snapshots
- gitignore SQL dumps under supabase/seeds/prod-data
- add seed mode switch guidance in supabase/config.toml
- make app bootstrap seed scripts insert-only to avoid overwriting existing snapshot rows
- update dummy cross-table seed to select pre-survey form dynamically

## Why
- expose geo discrepancy context directly in workshop enrollment triage
- allow developers to switch between dummy fixtures and local prod snapshots safely
- prevent bootstrap seeds from mutating imported production snapshot data

## Validation
- npm run typecheck