### PR TITLE
Fix district analytics with family riding fallback

### DIFF
--- a/web/app/routes/manage/federal-electoral-district.enrichment.ts
+++ b/web/app/routes/manage/federal-electoral-district.enrichment.ts
@@ -3,6 +3,18 @@ import { requireAuth } from '@/lib/auth.server'
 import { createClient } from '@/lib/supabase/server'
 import { isRoleAtLeast } from '@/lib/roles'
 
+type FamilyEdgeRow = {
+  guardian_profile_id: string
+  child_profile_id: string
+  primary_child: boolean
+}
+
+type ProfileRidingRow = {
+  id: string
+  role: Database['public']['Enums']['app_role'] | null
+  federal_electoral_district_name: string | null
+}
+
 const statusBucketFor = (status: Database['public']['Enums']['workshop_enrollment_status']) => {
   if (status === 'approved') return 'accepted'
   if (status === 'pending') return 'pending'
@@ -19,14 +31,6 @@ const canonicalRiding = (value: string) =>
     .replace(/\s+/g, ' ')
     .toLowerCase()
 
-const ridingNameVariants = (value: string) => {
-  const trimmed = value.trim()
-  const variants = new Set<string>([trimmed])
-  variants.add(trimmed.replace(/[—–−]/g, '-'))
-  variants.add(trimmed.replace(/-/g, '—'))
-  return Array.from(variants)
-}
-
 const chunk = <T,>(items: T[], size: number) => {
   if (!items.length || size <= 0) return [] as T[][]
   const batches: T[][] = []
@@ -34,6 +38,31 @@ const chunk = <T,>(items: T[], size: number) => {
     batches.push(items.slice(i, i + size))
   }
   return batches
+}
+
+const pushFamilyLink = (
+  map: Map<string, Array<{ profileId: string; primary: boolean }>>,
+  key: string,
+  profileId: string,
+  primary: boolean
+) => {
+  const entries = map.get(key) ?? []
+  if (entries.some(entry => entry.profileId === profileId)) return
+  entries.push({ profileId, primary })
+  entries.sort((left, right) => Number(right.primary) - Number(left.primary) || left.profileId.localeCompare(right.profileId))
+  map.set(key, entries)
+}
+
+const firstRidingFromLinks = (
+  links: Array<{ profileId: string; primary: boolean }> | undefined,
+  ridingByProfileId: Map<string, string>
+) => {
+  if (!links?.length) return null
+  for (const link of links) {
+    const riding = ridingByProfileId.get(link.profileId)
+    if (riding) return riding
+  }
+  return null
 }
 
 export async function loader({ request }: { request: Request }) {
@@ -91,11 +120,11 @@ export async function loader({ request }: { request: Request }) {
     return Response.json({ byRiding }, { headers: auth.headers })
   }
 
-  const profileRows: Array<{ id: string; federal_electoral_district_name: string | null }> = []
+  const profileRows: ProfileRidingRow[] = []
   for (const profileChunk of chunk(profileIds, 500)) {
     const { data, error } = await supabase
       .from('profile')
-      .select('id, federal_electoral_district_name')
+      .select('id, role, federal_electoral_district_name')
       .in('id', profileChunk)
 
     if (error) {
@@ -103,70 +132,94 @@ export async function loader({ request }: { request: Request }) {
       return Response.json({ byRiding }, { headers: auth.headers })
     }
 
-    profileRows.push(...((data ?? []) as Array<{ id: string; federal_electoral_district_name: string | null }>))
+    profileRows.push(...((data ?? []) as ProfileRidingRow[]))
   }
 
-  const lookupRidingNames = Array.from(
-    new Set(
-      ridingNames.flatMap(riding => ridingNameVariants(riding)).map(canonicalRiding)
-    )
-  )
-  const lookupRidingNameSet = new Set(lookupRidingNames)
-
-  const matchingProfileIds = new Set(
+  const profileById = new Map(profileRows.map(row => [row.id, row]))
+  const ridingByProfileId = new Map(
     profileRows
-      .filter(row => {
-        if (!row.federal_electoral_district_name) return false
-        return lookupRidingNameSet.has(canonicalRiding(row.federal_electoral_district_name))
-      })
-      .map(row => row.id)
-  )
-
-  if (!matchingProfileIds.size) {
-    return Response.json({ byRiding }, { headers: auth.headers })
-  }
-
-  const scopedEnrollmentRows = (enrollmentRows ?? []).filter(enrollment => {
-    if (typeof enrollment.profile_id !== 'string') return false
-    return matchingProfileIds.has(enrollment.profile_id)
-  })
-
-  const scopedProfileIds = Array.from(
-    new Set(
-      scopedEnrollmentRows
-        .map(enrollment => enrollment.profile_id)
-    .filter((profileId): profileId is string => typeof profileId === 'string' && Boolean(profileId))
-    )
-  )
-  const scopedProfileIdSet = new Set(scopedProfileIds)
-
-  if (!scopedProfileIds.length) {
-    return Response.json({ byRiding }, { headers: auth.headers })
-  }
-
-  const requestedRidingByProfileId = new Map(
-    profileRows
-      .filter(row => scopedProfileIdSet.has(row.id) && typeof row.federal_electoral_district_name === 'string')
-      .map(row => {
-        const ridingName = row.federal_electoral_district_name ?? ''
-        const requested = requestedRidingByCanonical.get(canonicalRiding(ridingName))
-        return [row.id, requested ?? null]
-      })
+      .map(row => [row.id, typeof row.federal_electoral_district_name === 'string' ? row.federal_electoral_district_name.trim() : ''] as const)
       .filter((entry): entry is [string, string] => Boolean(entry[1]))
   )
 
-  for (const enrollment of scopedEnrollmentRows) {
+  const childrenByGuardian = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  const guardiansByChild = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  const relatedProfileIds = new Set<string>()
+
+  for (const profileChunk of chunk(profileIds, 200)) {
+    const { data: edges, error: edgesError } = await supabase
+      .from('person_guardian_child')
+      .select('guardian_profile_id, child_profile_id, primary_child')
+      .or(`guardian_profile_id.in.(${profileChunk.join(',')}),child_profile_id.in.(${profileChunk.join(',')})`)
+
+    if (edgesError) {
+      console.error('[federal-electoral-district] failed to load family edges', edgesError)
+      return Response.json({ byRiding }, { headers: auth.headers })
+    }
+
+    for (const edge of (edges ?? []) as FamilyEdgeRow[]) {
+      pushFamilyLink(childrenByGuardian, edge.guardian_profile_id, edge.child_profile_id, edge.primary_child)
+      pushFamilyLink(guardiansByChild, edge.child_profile_id, edge.guardian_profile_id, edge.primary_child)
+      relatedProfileIds.add(edge.guardian_profile_id)
+      relatedProfileIds.add(edge.child_profile_id)
+    }
+  }
+
+  const missingRelatedProfileIds = Array.from(relatedProfileIds).filter(profileId => !profileById.has(profileId))
+  for (const relatedChunk of chunk(missingRelatedProfileIds, 500)) {
+    const { data: relatedProfiles, error: relatedProfilesError } = await supabase
+      .from('profile')
+      .select('id, federal_electoral_district_name')
+      .in('id', relatedChunk)
+
+    if (relatedProfilesError) {
+      console.error('[federal-electoral-district] failed to load related profile ridings', relatedProfilesError)
+      return Response.json({ byRiding }, { headers: auth.headers })
+    }
+
+    for (const related of relatedProfiles ?? []) {
+      const relatedId = typeof related.id === 'string' ? related.id : ''
+      const relatedRiding =
+        typeof related.federal_electoral_district_name === 'string'
+          ? related.federal_electoral_district_name.trim()
+          : ''
+      if (!relatedId || !relatedRiding) continue
+      ridingByProfileId.set(relatedId, relatedRiding)
+    }
+  }
+
+  for (const enrollment of enrollmentRows ?? []) {
     const profileId = typeof enrollment.profile_id === 'string' ? enrollment.profile_id : ''
     if (!profileId) continue
 
-    const riding = requestedRidingByProfileId.get(profileId)
-    if (!riding) continue
+    const enrolledProfile = profileById.get(profileId)
+    const enrolledRole = enrolledProfile?.role
+
+    const enrolledRiding = ridingByProfileId.get(profileId) ?? null
+    const primaryChildRiding = firstRidingFromLinks(childrenByGuardian.get(profileId), ridingByProfileId)
+    const primaryGuardianRiding = firstRidingFromLinks(guardiansByChild.get(profileId), ridingByProfileId)
+    const anyFamilyRiding =
+      firstRidingFromLinks(childrenByGuardian.get(profileId), ridingByProfileId) ??
+      firstRidingFromLinks(guardiansByChild.get(profileId), ridingByProfileId)
+
+    const effectiveRiding =
+      enrolledRiding ??
+      (enrolledRole === 'guardian' ? primaryChildRiding : null) ??
+      (enrolledRole === 'student' ? primaryGuardianRiding : null) ??
+      primaryChildRiding ??
+      primaryGuardianRiding ??
+      anyFamilyRiding
+
+    if (!effectiveRiding) continue
+
+    const requestedRiding = requestedRidingByCanonical.get(canonicalRiding(effectiveRiding))
+    if (!requestedRiding) continue
 
     const status = enrollment.status as Database['public']['Enums']['workshop_enrollment_status']
     const bucket = statusBucketFor(status)
     if (!bucket) continue
 
-    byRiding[riding][bucket] += 1
+    byRiding[requestedRiding][bucket] += 1
   }
 
   return Response.json({ byRiding }, { headers: auth.headers })

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -680,7 +680,7 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
     table: 'federal_electoral_district',
     select: 'code, name, whitelist, meal_kit, updated_at',
     columns: ['code', 'name', 'whitelist', 'meal_kit', 'updated_at'],
-    order: 'code',
+    order: 'name',
     editor: {
       primaryKey: ['name'],
       allowInsert: true,


### PR DESCRIPTION
## What
- update federal electoral district enrichment counts to use effective family riding fallback
- include primary child/guardian riding fallback when enrolled profile riding is missing
- keep requested riding matching canonicalized and status-bucketed
- sort federal electoral district table alphabetically by riding name

## Why
- direct enrolled-profile riding was frequently null, causing all-zero analytics counts
- family-aware riding resolution aligns analytics with enrollment context

## Validation
- npm run typecheck