### PR TITLE
Add totals to district analytics enrichment

### DIFF
--- a/web/app/routes/manage/federal-electoral-district.enrichment.ts
+++ b/web/app/routes/manage/federal-electoral-district.enrichment.ts
@@ -86,9 +86,9 @@ export async function loader({ request }: { request: Request }) {
     return Response.json({ byRiding: {} }, { headers: auth.headers })
   }
 
-  const byRiding = ridingNames.reduce<Record<string, { accepted: number; pending: number; waitlisted: number; declined: number }>>(
+  const byRiding = ridingNames.reduce<Record<string, { total: number; accepted: number; pending: number; waitlisted: number; declined: number }>>(
     (acc, riding) => {
-      acc[riding] = { accepted: 0, pending: 0, waitlisted: 0, declined: 0 }
+      acc[riding] = { total: 0, accepted: 0, pending: 0, waitlisted: 0, declined: 0 }
       return acc
     },
     {}
@@ -219,6 +219,7 @@ export async function loader({ request }: { request: Request }) {
     const bucket = statusBucketFor(status)
     if (!bucket) continue
 
+    byRiding[requestedRiding].total += 1
     byRiding[requestedRiding][bucket] += 1
   }
 

--- a/web/app/routes/manage/federal-electoral-district.tsx
+++ b/web/app/routes/manage/federal-electoral-district.tsx
@@ -10,10 +10,11 @@ export async function loader(args: Route.LoaderArgs) {
   const base = await baseLoader(args)
   const columns = base.columns.includes('accepted')
     ? base.columns
-    : ['code', 'name', 'accepted', 'pending', 'waitlisted', 'declined', ...base.columns.filter(column => !['code', 'name'].includes(column))]
+    : ['code', 'name', 'total', 'accepted', 'pending', 'waitlisted', 'declined', ...base.columns.filter(column => !['code', 'name'].includes(column))]
 
   const rows = (base.rows ?? []).map(row => ({
     ...row,
+    total: '...',
     accepted: '...',
     pending: '...',
     waitlisted: '...',
@@ -26,6 +27,7 @@ export async function loader(args: Route.LoaderArgs) {
     rows,
     columnMeta: {
       ...(base.columnMeta ?? {}),
+      total: { label: 'total', numeric: true },
       accepted: { label: 'accepted', numeric: true },
       pending: { label: 'pending', numeric: true },
       waitlisted: { label: 'waitlisted', numeric: true },

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -66,6 +66,7 @@ type WorkshopEnrollmentEnrichmentResponse = {
 }
 
 type FederalElectoralDistrictEnrichment = {
+  total: number
   accepted: number
   pending: number
   waitlisted: number
@@ -772,6 +773,7 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
         if (!response.ok) return
         const payload = (await response.json()) as FederalElectoralDistrictEnrichmentResponse
         const fallbackEnrichment: FederalElectoralDistrictEnrichment = {
+          total: 0,
           accepted: 0,
           pending: 0,
           waitlisted: 0,


### PR DESCRIPTION
## What
- add a total metric to federal electoral district enrichment responses
- include a total column in the district analytics table
- wire total fallback typing in table enrichment state

## Why
- district analytics should show total enrollments alongside status buckets

## Validation
- npm run typecheck