### PR TITLE
Load district analytics in page loader

### DIFF
--- a/web/app/routes/manage/federal-electoral-district.tsx
+++ b/web/app/routes/manage/federal-electoral-district.tsx
@@ -1,25 +1,260 @@
 import TableDisplay from './table-display'
 import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
+import { createClient } from '@/lib/supabase/server'
+import type { Database } from '@/lib/database.types'
 
 import type { Route } from './+types/federal-electoral-district'
 
 const baseLoader = createTableLoader('federal-electoral-district')
 
+type EnrollmentRow = {
+  profile_id: string | null
+  status: Database['public']['Enums']['workshop_enrollment_status']
+}
+
+type ProfileRidingRow = {
+  id: string
+  role: Database['public']['Enums']['app_role'] | null
+  federal_electoral_district_name: string | null
+}
+
+type FamilyEdgeRow = {
+  guardian_profile_id: string
+  child_profile_id: string
+  primary_child: boolean
+}
+
+type RidingCounts = {
+  total: number
+  accepted: number
+  pending: number
+  waitlisted: number
+  declined: number
+}
+
+const chunk = <T,>(items: T[], size: number) => {
+  if (!items.length || size <= 0) return [] as T[][]
+  const batches: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size))
+  }
+  return batches
+}
+
+const canonicalRiding = (value: string) =>
+  value
+    .normalize('NFKC')
+    .trim()
+    .replace(/[—–−]/g, '-')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+
+const statusBucketFor = (status: Database['public']['Enums']['workshop_enrollment_status']) => {
+  if (status === 'approved') return 'accepted'
+  if (status === 'pending') return 'pending'
+  if (status === 'waitlisted') return 'waitlisted'
+  if (status === 'rejected' || status === 'revoked') return 'declined'
+  return null
+}
+
+const emptyCounts = (): RidingCounts => ({
+  total: 0,
+  accepted: 0,
+  pending: 0,
+  waitlisted: 0,
+  declined: 0,
+})
+
+const pushFamilyLink = (
+  map: Map<string, Array<{ profileId: string; primary: boolean }>>,
+  key: string,
+  profileId: string,
+  primary: boolean
+) => {
+  const entries = map.get(key) ?? []
+  if (entries.some(entry => entry.profileId === profileId)) return
+  entries.push({ profileId, primary })
+  entries.sort((left, right) => Number(right.primary) - Number(left.primary) || left.profileId.localeCompare(right.profileId))
+  map.set(key, entries)
+}
+
+const firstRidingFromLinks = (
+  links: Array<{ profileId: string; primary: boolean }> | undefined,
+  ridingByProfileId: Map<string, string>
+) => {
+  if (!links?.length) return null
+  for (const link of links) {
+    const riding = ridingByProfileId.get(link.profileId)
+    if (riding) return riding
+  }
+  return null
+}
+
 export async function loader(args: Route.LoaderArgs) {
   const base = await baseLoader(args)
+  const { supabase } = createClient(args.request)
+
+  const baseRows = (base.rows ?? []) as Array<Record<string, unknown>>
+  const ridingNames = Array.from(
+    new Set(
+      baseRows
+        .map(row => (typeof row.name === 'string' ? row.name.trim() : ''))
+        .filter(Boolean)
+    )
+  )
+
+  const requestedRidingByCanonical = new Map(ridingNames.map(riding => [canonicalRiding(riding), riding]))
+  const byRiding = ridingNames.reduce<Record<string, RidingCounts>>((acc, riding) => {
+    acc[riding] = emptyCounts()
+    return acc
+  }, {})
+
+  const { data: enrollmentRowsRaw, error: enrollmentError } = await supabase
+    .from('workshop_enrollment')
+    .select('profile_id, status')
+    .not('profile_id', 'is', null)
+
+  if (enrollmentError) {
+    throw new Response(enrollmentError.message, { status: 500 })
+  }
+
+  const enrollmentRows = (enrollmentRowsRaw ?? []) as EnrollmentRow[]
+  const profileIds = Array.from(
+    new Set(
+      enrollmentRows
+        .map(row => row.profile_id)
+        .filter((profileId): profileId is string => typeof profileId === 'string' && Boolean(profileId))
+    )
+  )
+
+  const profileRows: ProfileRidingRow[] = []
+  for (const profileChunk of chunk(profileIds, 500)) {
+    const { data, error } = await supabase
+      .from('profile')
+      .select('id, role, federal_electoral_district_name')
+      .in('id', profileChunk)
+
+    if (error) {
+      throw new Response(error.message, { status: 500 })
+    }
+
+    profileRows.push(...((data ?? []) as ProfileRidingRow[]))
+  }
+
+  const profileById = new Map(profileRows.map(row => [row.id, row]))
+  const ridingByProfileId = new Map(
+    profileRows
+      .map(row => [row.id, typeof row.federal_electoral_district_name === 'string' ? row.federal_electoral_district_name.trim() : ''] as const)
+      .filter((entry): entry is [string, string] => Boolean(entry[1]))
+  )
+
+  const childrenByGuardian = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  const guardiansByChild = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  const familyEdgeKeys = new Set<string>()
+
+  for (const profileChunk of chunk(profileIds, 200)) {
+    const [{ data: guardianEdges, error: guardianEdgesError }, { data: childEdges, error: childEdgesError }] =
+      await Promise.all([
+        supabase
+          .from('person_guardian_child')
+          .select('guardian_profile_id, child_profile_id, primary_child')
+          .in('guardian_profile_id', profileChunk),
+        supabase
+          .from('person_guardian_child')
+          .select('guardian_profile_id, child_profile_id, primary_child')
+          .in('child_profile_id', profileChunk),
+      ])
+
+    if (guardianEdgesError) throw new Response(guardianEdgesError.message, { status: 500 })
+    if (childEdgesError) throw new Response(childEdgesError.message, { status: 500 })
+
+    for (const edge of [...(guardianEdges ?? []), ...(childEdges ?? [])] as FamilyEdgeRow[]) {
+      const edgeKey = `${edge.guardian_profile_id}:${edge.child_profile_id}`
+      if (familyEdgeKeys.has(edgeKey)) continue
+      familyEdgeKeys.add(edgeKey)
+      pushFamilyLink(childrenByGuardian, edge.guardian_profile_id, edge.child_profile_id, edge.primary_child)
+      pushFamilyLink(guardiansByChild, edge.child_profile_id, edge.guardian_profile_id, edge.primary_child)
+    }
+  }
+
+  const relatedProfileIds = Array.from(
+    new Set(
+      Array.from(familyEdgeKeys).flatMap(edgeKey => edgeKey.split(':')).filter(profileId => !profileById.has(profileId))
+    )
+  )
+
+  for (const relatedChunk of chunk(relatedProfileIds, 500)) {
+    const { data: relatedProfiles, error: relatedProfilesError } = await supabase
+      .from('profile')
+      .select('id, federal_electoral_district_name')
+      .in('id', relatedChunk)
+
+    if (relatedProfilesError) {
+      throw new Response(relatedProfilesError.message, { status: 500 })
+    }
+
+    for (const related of relatedProfiles ?? []) {
+      const relatedId = typeof related.id === 'string' ? related.id : ''
+      const relatedRiding =
+        typeof related.federal_electoral_district_name === 'string'
+          ? related.federal_electoral_district_name.trim()
+          : ''
+      if (!relatedId || !relatedRiding) continue
+      ridingByProfileId.set(relatedId, relatedRiding)
+    }
+  }
+
+  for (const enrollment of enrollmentRows) {
+    const profileId = typeof enrollment.profile_id === 'string' ? enrollment.profile_id : ''
+    if (!profileId) continue
+
+    const enrolledProfile = profileById.get(profileId)
+    const enrolledRole = enrolledProfile?.role
+
+    const enrolledRiding = ridingByProfileId.get(profileId) ?? null
+    const primaryChildRiding = firstRidingFromLinks(childrenByGuardian.get(profileId), ridingByProfileId)
+    const primaryGuardianRiding = firstRidingFromLinks(guardiansByChild.get(profileId), ridingByProfileId)
+    const anyFamilyRiding =
+      firstRidingFromLinks(childrenByGuardian.get(profileId), ridingByProfileId) ??
+      firstRidingFromLinks(guardiansByChild.get(profileId), ridingByProfileId)
+
+    const effectiveRiding =
+      enrolledRiding ??
+      (enrolledRole === 'guardian' ? primaryChildRiding : null) ??
+      (enrolledRole === 'student' ? primaryGuardianRiding : null) ??
+      primaryChildRiding ??
+      primaryGuardianRiding ??
+      anyFamilyRiding
+
+    if (!effectiveRiding) continue
+
+    const requestedRiding = requestedRidingByCanonical.get(canonicalRiding(effectiveRiding))
+    if (!requestedRiding) continue
+
+    const bucket = statusBucketFor(enrollment.status)
+    if (!bucket) continue
+
+    byRiding[requestedRiding].total += 1
+    byRiding[requestedRiding][bucket] += 1
+  }
+
   const columns = base.columns.includes('accepted')
     ? base.columns
     : ['code', 'name', 'total', 'accepted', 'pending', 'waitlisted', 'declined', ...base.columns.filter(column => !['code', 'name'].includes(column))]
 
-  const rows = (base.rows ?? []).map(row => ({
+  const rows = baseRows.map(row => {
+    const ridingName = typeof row.name === 'string' ? row.name.trim() : ''
+    const counts = ridingName ? byRiding[ridingName] ?? emptyCounts() : emptyCounts()
+    return {
     ...row,
-    total: '...',
-    accepted: '...',
-    pending: '...',
-    waitlisted: '...',
-    declined: '...',
-  }))
+    total: counts.total,
+    accepted: counts.accepted,
+    pending: counts.pending,
+    waitlisted: counts.waitlisted,
+    declined: counts.declined,
+  }
+  })
 
   return {
     ...base,

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -65,18 +65,6 @@ type WorkshopEnrollmentEnrichmentResponse = {
   byProfileId: Record<string, WorkshopEnrollmentEnrichment>
 }
 
-type FederalElectoralDistrictEnrichment = {
-  total: number
-  accepted: number
-  pending: number
-  waitlisted: number
-  declined: number
-}
-
-type FederalElectoralDistrictEnrichmentResponse = {
-  byRiding: Record<string, FederalElectoralDistrictEnrichment>
-}
-
 type LoaderData = {
   columns: string[]
   rows: Record<string, unknown>[]
@@ -451,16 +439,13 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
   const [editingRowKey, setEditingRowKey] = useState<string | null>(null)
   const [editValues, setEditValues] = useState<Record<string, string>>({})
   const [enrichmentByProfileId, setEnrichmentByProfileId] = useState<Record<string, WorkshopEnrollmentEnrichment>>({})
-  const [enrichmentByRiding, setEnrichmentByRiding] = useState<Record<string, FederalElectoralDistrictEnrichment>>({})
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({})
   const [columnMinWidths, setColumnMinWidths] = useState<Record<string, number>>({})
   const [resizeState, setResizeState] = useState<ResizeState | null>(null)
   const loadingEnrichmentProfileIdsRef = useRef<Set<string>>(new Set())
-  const loadingEnrichmentRidingNamesRef = useRef<Set<string>>(new Set())
   const filterButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const filterPopoverRef = useRef<HTMLDivElement | null>(null)
   const isWorkshopEnrollmentTable = tableName === 'class-enrollment'
-  const isFederalElectoralDistrictTable = tableName === 'federal-electoral-district'
 
   useEffect(() => {
     const nextSort = searchParams.get('sort')
@@ -616,17 +601,9 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
         }
       }
 
-      if (isFederalElectoralDistrictTable) {
-        const ridingName = typeof row.name === 'string' ? row.name.trim() : ''
-        const enrichment = ridingName ? enrichmentByRiding[ridingName] : null
-        if (enrichment) {
-          nextRow = { ...nextRow, ...enrichment }
-        }
-      }
-
       return nextRow
     })
-  }, [enrichmentByProfileId, enrichmentByRiding, isFederalElectoralDistrictTable, isWorkshopEnrollmentTable, rows])
+  }, [enrichmentByProfileId, isWorkshopEnrollmentTable, rows])
 
   const derivedRows = useMemo(() => {
     let adjustedRows = rowsWithEnrichment.filter(row => rowMatchesFilters(row, filters))
@@ -739,72 +716,6 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
       abortController.abort()
     }
   }, [enrichmentByProfileId, isWorkshopEnrollmentTable, paginatedRows])
-
-  useEffect(() => {
-    if (!isFederalElectoralDistrictTable) return
-
-    const missingRidingNames = Array.from(
-      new Set(
-        paginatedRows
-          .map(row => (typeof row.name === 'string' ? row.name.trim() : ''))
-          .filter(
-            ridingName =>
-              Boolean(ridingName) &&
-              !enrichmentByRiding[ridingName] &&
-              !loadingEnrichmentRidingNamesRef.current.has(ridingName)
-          )
-      )
-    )
-
-    if (!missingRidingNames.length) return
-
-    const requestRidingNames = missingRidingNames.slice(0, 40)
-    requestRidingNames.forEach(ridingName => loadingEnrichmentRidingNamesRef.current.add(ridingName))
-
-    const abortController = new AbortController()
-    void (async () => {
-      try {
-        const searchParams = new URLSearchParams()
-        requestRidingNames.forEach(ridingName => searchParams.append('riding', ridingName))
-        const response = await fetch(`/manage/federal-electoral-district/enrichment?${searchParams.toString()}`, {
-          signal: abortController.signal,
-        })
-
-        if (!response.ok) return
-        const payload = (await response.json()) as FederalElectoralDistrictEnrichmentResponse
-        const fallbackEnrichment: FederalElectoralDistrictEnrichment = {
-          total: 0,
-          accepted: 0,
-          pending: 0,
-          waitlisted: 0,
-          declined: 0,
-        }
-
-        const resolvedByRiding = requestRidingNames.reduce<Record<string, FederalElectoralDistrictEnrichment>>(
-          (acc, ridingName) => {
-            acc[ridingName] = payload?.byRiding?.[ridingName] ?? fallbackEnrichment
-            return acc
-          },
-          {}
-        )
-
-        setEnrichmentByRiding(prev => ({
-          ...prev,
-          ...resolvedByRiding,
-        }))
-      } catch (error) {
-        if ((error as Error).name !== 'AbortError') {
-          console.error('[table display] federal riding enrichment fetch failed', error)
-        }
-      } finally {
-        requestRidingNames.forEach(ridingName => loadingEnrichmentRidingNamesRef.current.delete(ridingName))
-      }
-    })()
-
-    return () => {
-      abortController.abort()
-    }
-  }, [enrichmentByRiding, isFederalElectoralDistrictTable, paginatedRows])
 
   const updateSort = (column: string) => {
     if (sortColumn !== column) {


### PR DESCRIPTION
## What
- remove per-page lazy enrichment fetch for federal electoral district analytics
- compute district status counts directly in the federal district page loader
- apply family-aware effective riding fallback during aggregation

## Why
- avoid canceled enrichment calls and placeholder/zero drift on initial page render
- ensure analytics data is loaded once with the page and displayed directly

## Validation
- npm run typecheck