### PR TITLE
Improve export runner trigger reliability

### DIFF
--- a/web/app/lib/exports/dispatch.server.ts
+++ b/web/app/lib/exports/dispatch.server.ts
@@ -10,26 +10,57 @@ const internalEndpointFor = (request: Request, pathname: string) => {
   return url.toString()
 }
 
+export type InternalTriggerResult = {
+  attempted: boolean
+  ok: boolean
+  status?: number
+  reason?: 'missing-secret' | 'network-error'
+}
+
 export const triggerExportRunner = async ({ request }: { request: Request }) => {
   const secret = internalSecretForRunner()
-  if (!secret) return
+  if (!secret) {
+    return { attempted: false, ok: false, reason: 'missing-secret' } satisfies InternalTriggerResult
+  }
 
-  await fetch(internalEndpointFor(request, '/internal/export-jobs/run'), {
-    method: 'POST',
-    headers: {
-      [INTERNAL_RUNNER_HEADER]: secret,
-    },
-  })
+  try {
+    const response = await fetch(internalEndpointFor(request, '/internal/export-jobs/run'), {
+      method: 'POST',
+      headers: {
+        [INTERNAL_RUNNER_HEADER]: secret,
+      },
+    })
+
+    return {
+      attempted: true,
+      ok: response.ok,
+      status: response.status,
+    } satisfies InternalTriggerResult
+  } catch {
+    return { attempted: true, ok: false, reason: 'network-error' } satisfies InternalTriggerResult
+  }
 }
 
 export const triggerExportCleanup = async ({ request }: { request: Request }) => {
   const secret = internalSecretForRunner()
-  if (!secret) return
+  if (!secret) {
+    return { attempted: false, ok: false, reason: 'missing-secret' } satisfies InternalTriggerResult
+  }
 
-  await fetch(internalEndpointFor(request, '/internal/export-jobs/cleanup'), {
-    method: 'POST',
-    headers: {
-      [INTERNAL_RUNNER_HEADER]: secret,
-    },
-  })
+  try {
+    const response = await fetch(internalEndpointFor(request, '/internal/export-jobs/cleanup'), {
+      method: 'POST',
+      headers: {
+        [INTERNAL_RUNNER_HEADER]: secret,
+      },
+    })
+
+    return {
+      attempted: true,
+      ok: response.ok,
+      status: response.status,
+    } satisfies InternalTriggerResult
+  } catch {
+    return { attempted: true, ok: false, reason: 'network-error' } satisfies InternalTriggerResult
+  }
 }

--- a/web/app/routes/manage/exports.tsx
+++ b/web/app/routes/manage/exports.tsx
@@ -21,6 +21,7 @@ import type { Route } from './+types/exports'
 type ActionData = {
   error?: string
   success?: string
+  warning?: string
 }
 
 const isActiveStatus = (status: string) => status === 'queued' || status === 'running'
@@ -85,9 +86,19 @@ export async function action({ request }: Route.ActionArgs) {
       rows: snapshot.rows,
     })
 
-    void triggerExportRunner({ request }).catch(error => {
-      console.error('[exports] immediate process trigger failed', { jobId: job.id, error })
-    })
+    const triggerResult = await triggerExportRunner({ request })
+    if (!triggerResult.ok) {
+      const warning =
+        triggerResult.reason === 'missing-secret'
+          ? 'Export queued, but immediate processing is disabled because EXPORT_RUNNER_SECRET is not configured. Configure the secret and scheduler, or run /internal/export-jobs/run manually.'
+          : `Export queued, but immediate processing trigger failed${typeof triggerResult.status === 'number' ? ` (HTTP ${triggerResult.status})` : ''}. The scheduler can still pick this up.`
+
+      console.error('[exports] immediate process trigger failed', { jobId: job.id, triggerResult })
+      return {
+        success: `Export queued (${snapshot.rows.length} rows).`,
+        warning,
+      } satisfies ActionData
+    }
 
     return { success: `Export queued (${snapshot.rows.length} rows).` } satisfies ActionData
   }
@@ -101,9 +112,15 @@ export async function action({ request }: Route.ActionArgs) {
     }
 
     await setExportJobStatus({ supabase, jobId, status: 'queued' })
-    void triggerExportRunner({ request }).catch(error => {
-      console.error('[exports] retry trigger failed', { jobId, error })
-    })
+    const triggerResult = await triggerExportRunner({ request })
+    if (!triggerResult.ok) {
+      const warning =
+        triggerResult.reason === 'missing-secret'
+          ? 'Export re-queued, but immediate processing is disabled because EXPORT_RUNNER_SECRET is not configured.'
+          : `Export re-queued, but immediate processing trigger failed${typeof triggerResult.status === 'number' ? ` (HTTP ${triggerResult.status})` : ''}.`
+      console.error('[exports] retry trigger failed', { jobId, triggerResult })
+      return { success: 'Export re-queued.', warning } satisfies ActionData
+    }
     return { success: 'Export re-queued.' } satisfies ActionData
   }
 
@@ -157,6 +174,11 @@ export default function ManageExportsPage() {
       {actionData?.success ? (
         <p className="rounded border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
           {actionData.success}
+        </p>
+      ) : null}
+      {actionData?.warning ? (
+        <p className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {actionData.warning}
         </p>
       ) : null}
 


### PR DESCRIPTION
## What
- await immediate export runner trigger instead of fire-and-forget
- return structured trigger result metadata from dispatch helpers
- surface warning messages in manage exports when immediate trigger fails
- preserve queued/re-queued success while explaining fallback behavior

## Why
- queued exports could appear stuck when immediate trigger did not execute or failed silently
- operators need clear UI feedback when EXPORT_RUNNER_SECRET is missing or trigger calls fail

## Validation
- npm run typecheck
- npm run build