### PR TITLE
Move export enrichment to async runner

### DIFF
--- a/web/app/lib/exports/runner.server.ts
+++ b/web/app/lib/exports/runner.server.ts
@@ -10,6 +10,7 @@ import {
   EXPORT_STORAGE_BUCKET,
   EXPORT_TYPE_WORKSHOP_ENROLLMENT_CSV,
 } from './types'
+import { materializeWorkshopEnrollmentExportRows } from './workshop-enrollment-export-row.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 
 const buildStoragePath = ({ requestedBy, jobId }: { requestedBy: string; jobId: string }) =>
@@ -27,8 +28,14 @@ export const processNextExportJob = async () => {
     }
 
     const rows = await listExportJobRows({ jobId: job.id })
-    const csvRows = rows.map(row => row.row_data)
     const columns = Array.isArray(job.column_order) ? job.column_order : []
+    const csvRows =
+      job.export_type === EXPORT_TYPE_WORKSHOP_ENROLLMENT_CSV
+        ? await materializeWorkshopEnrollmentExportRows({
+            rows: rows.map(row => row.row_data),
+            columns,
+          })
+        : rows.map(row => row.row_data)
     const csv = buildCsv({ columns, rows: csvRows })
     const bytes = new TextEncoder().encode(csv)
     const storagePath = buildStoragePath({ requestedBy: job.requested_by, jobId: job.id })

--- a/web/app/lib/exports/workshop-enrollment-export-row.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-export-row.server.ts
@@ -1,0 +1,186 @@
+import { adminClient } from '@/lib/supabase/adminClient'
+import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
+
+import { getCellValue } from './table-filtering.server'
+
+const PROFILE_SPLIT_COLUMNS = new Set([
+  'student_firstname',
+  'student_lastname',
+  'student_email',
+  'guardian_firstname',
+  'guardian_lastname',
+  'guardian_email',
+])
+
+type ProfileRow = {
+  id: string
+  role: string | null
+  firstname: string | null
+  surname: string | null
+  email: string | null
+}
+
+type GuardianChildEdge = {
+  guardian_profile_id: string
+  child_profile_id: string
+  primary_child: boolean
+}
+
+const normalizeText = (value: unknown) => (typeof value === 'string' ? value.trim() : '')
+
+const chunkArray = <T,>(items: T[], size: number): T[][] => {
+  if (!items.length || size <= 0) return []
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+const pickPreferred = (items: Array<{ profileId: string; primary: boolean }>) => {
+  if (!items.length) return null
+  const sorted = [...items].sort((left, right) => {
+    const primaryDiff = Number(right.primary) - Number(left.primary)
+    if (primaryDiff !== 0) return primaryDiff
+    return left.profileId.localeCompare(right.profileId)
+  })
+  return sorted[0]?.profileId ?? null
+}
+
+const fallbackWorkshopEnrollmentEnrichment = {
+  riding_display: '',
+  geo_locations_display: 'N/A',
+  giftcard_display: 'N/A',
+  prior_participation_display: 'N/A',
+  profile_hover_top_discrepancy: '',
+  profile_hover_more_discrepancies: '',
+  profile_hover_name: 'N/A',
+  profile_hover_email: 'N/A',
+  profile_hover_parent_email: 'N/A',
+  profile_hover_latest_ip: 'N/A',
+  profile_hover_latest_ip_geo: 'N/A',
+}
+
+const buildProfileSplitData = async (enrollmentProfileIds: string[]) => {
+  const splitByProfileId = new Map<string, Record<string, string>>()
+  if (!enrollmentProfileIds.length) {
+    return splitByProfileId
+  }
+
+  const edgeRows: GuardianChildEdge[] = []
+  for (const chunk of chunkArray(enrollmentProfileIds, 100)) {
+    const { data, error } = await adminClient
+      .from('person_guardian_child')
+      .select('guardian_profile_id, child_profile_id, primary_child')
+      .or(`guardian_profile_id.in.(${chunk.join(',')}),child_profile_id.in.(${chunk.join(',')})`)
+
+    if (error) {
+      throw new Error(`Unable to load guardian relationships: ${error.message}`)
+    }
+    edgeRows.push(...((data ?? []) as GuardianChildEdge[]))
+  }
+
+  const allRelatedIds = new Set<string>(enrollmentProfileIds)
+  const guardiansByChild = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+  const childrenByGuardian = new Map<string, Array<{ profileId: string; primary: boolean }>>()
+
+  for (const edge of edgeRows) {
+    allRelatedIds.add(edge.guardian_profile_id)
+    allRelatedIds.add(edge.child_profile_id)
+
+    const guardians = guardiansByChild.get(edge.child_profile_id) ?? []
+    guardians.push({ profileId: edge.guardian_profile_id, primary: edge.primary_child })
+    guardiansByChild.set(edge.child_profile_id, guardians)
+
+    const children = childrenByGuardian.get(edge.guardian_profile_id) ?? []
+    children.push({ profileId: edge.child_profile_id, primary: edge.primary_child })
+    childrenByGuardian.set(edge.guardian_profile_id, children)
+  }
+
+  const profileRows: ProfileRow[] = []
+  for (const chunk of chunkArray(Array.from(allRelatedIds), 250)) {
+    const { data, error } = await adminClient
+      .from('profile')
+      .select('id, role, firstname, surname, email')
+      .in('id', chunk)
+
+    if (error) {
+      throw new Error(`Unable to load export profile details: ${error.message}`)
+    }
+    profileRows.push(...((data ?? []) as ProfileRow[]))
+  }
+
+  const profileById = new Map(profileRows.map(profile => [profile.id, profile]))
+
+  for (const enrollmentProfileId of enrollmentProfileIds) {
+    const enrollmentProfile = profileById.get(enrollmentProfileId)
+    const enrollmentRole = normalizeText(enrollmentProfile?.role).toLowerCase()
+
+    let studentProfileId: string | null = null
+    let guardianProfileId: string | null = null
+
+    if (enrollmentRole === 'student') {
+      studentProfileId = enrollmentProfileId
+      guardianProfileId = pickPreferred(guardiansByChild.get(enrollmentProfileId) ?? [])
+    } else if (enrollmentRole === 'guardian') {
+      guardianProfileId = enrollmentProfileId
+      studentProfileId = pickPreferred(childrenByGuardian.get(enrollmentProfileId) ?? [])
+    } else {
+      studentProfileId =
+        pickPreferred(childrenByGuardian.get(enrollmentProfileId) ?? []) ??
+        (enrollmentProfile ? enrollmentProfileId : null)
+      guardianProfileId =
+        (studentProfileId ? pickPreferred(guardiansByChild.get(studentProfileId) ?? []) : null) ??
+        pickPreferred(guardiansByChild.get(enrollmentProfileId) ?? [])
+    }
+
+    const studentProfile = studentProfileId ? profileById.get(studentProfileId) : null
+    const guardianProfile = guardianProfileId ? profileById.get(guardianProfileId) : null
+
+    splitByProfileId.set(enrollmentProfileId, {
+      student_firstname: normalizeText(studentProfile?.firstname),
+      student_lastname: normalizeText(studentProfile?.surname),
+      student_email: normalizeText(studentProfile?.email),
+      guardian_firstname: normalizeText(guardianProfile?.firstname),
+      guardian_lastname: normalizeText(guardianProfile?.surname),
+      guardian_email: normalizeText(guardianProfile?.email),
+    })
+  }
+
+  return splitByProfileId
+}
+
+export const materializeWorkshopEnrollmentExportRows = async ({
+  rows,
+  columns,
+}: {
+  rows: Array<Record<string, unknown>>
+  columns: string[]
+}) => {
+  const profileIds = Array.from(new Set(rows.map(row => normalizeText(row.profile_id)).filter(Boolean)))
+  const enrichmentByProfileId = profileIds.length
+    ? await loadWorkshopEnrollmentEnrichment(profileIds)
+    : {}
+  const splitByProfileId = await buildProfileSplitData(profileIds)
+
+  return rows.map(row => {
+    const profileId = normalizeText(row.profile_id)
+    const enrichment = profileId
+      ? (enrichmentByProfileId[profileId] ?? fallbackWorkshopEnrollmentEnrichment)
+      : fallbackWorkshopEnrollmentEnrichment
+    const split = profileId ? splitByProfileId.get(profileId) ?? null : null
+    const enrichedRow = {
+      ...row,
+      ...enrichment,
+    }
+
+    return columns.reduce<Record<string, unknown>>((acc, column) => {
+      if (PROFILE_SPLIT_COLUMNS.has(column)) {
+        acc[column] = split?.[column] ?? ''
+        return acc
+      }
+      acc[column] = getCellValue(column, enrichedRow, 'class-enrollment')
+      return acc
+    }, {})
+  })
+}

--- a/web/app/lib/exports/workshop-enrollment-snapshot.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-snapshot.server.ts
@@ -1,8 +1,7 @@
 import { loadWorkshopEnrollmentData } from '@/lib/exports/workshop-enrollment-query.server'
-import { adminClient } from '@/lib/supabase/adminClient'
 import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
 
-import { applyFiltersAndSort, getCellValue, parseFiltersFromSearchParams } from './table-filtering.server'
+import { applyFiltersAndSort, parseFiltersFromSearchParams } from './table-filtering.server'
 import { EXPORT_MAX_ROWS } from './types'
 
 const PROFILE_SPLIT_COLUMNS = [
@@ -14,40 +13,14 @@ const PROFILE_SPLIT_COLUMNS = [
   'guardian_email',
 ] as const
 
-type ProfileRow = {
-  id: string
-  role: string | null
-  firstname: string | null
-  surname: string | null
-  email: string | null
-}
-
-type GuardianChildEdge = {
-  guardian_profile_id: string
-  child_profile_id: string
-  primary_child: boolean
-}
+const GENERATED_WORKSHOP_COLUMNS = new Set([
+  'riding_display',
+  'geo_locations_display',
+  'giftcard_display',
+  'prior_participation_display',
+])
 
 const normalizeText = (value: unknown) => (typeof value === 'string' ? value.trim() : '')
-
-const chunkArray = <T,>(items: T[], size: number): T[][] => {
-  if (!items.length || size <= 0) return []
-  const chunks: T[][] = []
-  for (let index = 0; index < items.length; index += size) {
-    chunks.push(items.slice(index, index + size))
-  }
-  return chunks
-}
-
-const pickPreferred = (items: Array<{ profileId: string; primary: boolean }>) => {
-  if (!items.length) return null
-  const sorted = [...items].sort((left, right) => {
-    const primaryDiff = Number(right.primary) - Number(left.primary)
-    if (primaryDiff !== 0) return primaryDiff
-    return left.profileId.localeCompare(right.profileId)
-  })
-  return sorted[0]?.profileId ?? null
-}
 
 const fallbackWorkshopEnrollmentEnrichment = {
   riding_display: '',
@@ -63,103 +36,6 @@ const fallbackWorkshopEnrollmentEnrichment = {
   profile_hover_latest_ip_geo: 'N/A',
 }
 
-const buildProfileSplitData = async ({
-  rows,
-}: {
-  rows: Array<Record<string, unknown>>
-}) => {
-  const enrollmentProfileIds = Array.from(
-    new Set(rows.map(row => normalizeText(row.profile_id)).filter(Boolean))
-  )
-
-  const splitByProfileId = new Map<string, Record<string, string>>()
-  if (!enrollmentProfileIds.length) {
-    return splitByProfileId
-  }
-
-  const edgeRows: GuardianChildEdge[] = []
-  for (const chunk of chunkArray(enrollmentProfileIds, 250)) {
-    const { data, error } = await adminClient
-      .from('person_guardian_child')
-      .select('guardian_profile_id, child_profile_id, primary_child')
-      .or(`guardian_profile_id.in.(${chunk.join(',')}),child_profile_id.in.(${chunk.join(',')})`)
-
-    if (error) {
-      throw new Error(`Unable to load guardian relationships: ${error.message}`)
-    }
-    edgeRows.push(...((data ?? []) as GuardianChildEdge[]))
-  }
-
-  const allRelatedIds = new Set<string>(enrollmentProfileIds)
-  const guardiansByChild = new Map<string, Array<{ profileId: string; primary: boolean }>>()
-  const childrenByGuardian = new Map<string, Array<{ profileId: string; primary: boolean }>>()
-
-  for (const edge of edgeRows) {
-    allRelatedIds.add(edge.guardian_profile_id)
-    allRelatedIds.add(edge.child_profile_id)
-
-    const guardians = guardiansByChild.get(edge.child_profile_id) ?? []
-    guardians.push({ profileId: edge.guardian_profile_id, primary: edge.primary_child })
-    guardiansByChild.set(edge.child_profile_id, guardians)
-
-    const children = childrenByGuardian.get(edge.guardian_profile_id) ?? []
-    children.push({ profileId: edge.child_profile_id, primary: edge.primary_child })
-    childrenByGuardian.set(edge.guardian_profile_id, children)
-  }
-
-  const profileRows: ProfileRow[] = []
-  for (const chunk of chunkArray(Array.from(allRelatedIds), 250)) {
-    const { data, error } = await adminClient
-      .from('profile')
-      .select('id, role, firstname, surname, email')
-      .in('id', chunk)
-
-    if (error) {
-      throw new Error(`Unable to load export profile details: ${error.message}`)
-    }
-    profileRows.push(...((data ?? []) as ProfileRow[]))
-  }
-
-  const profileById = new Map(profileRows.map(profile => [profile.id, profile]))
-
-  for (const enrollmentProfileId of enrollmentProfileIds) {
-    const enrollmentProfile = profileById.get(enrollmentProfileId)
-    const enrollmentRole = normalizeText(enrollmentProfile?.role).toLowerCase()
-
-    let studentProfileId: string | null = null
-    let guardianProfileId: string | null = null
-
-    if (enrollmentRole === 'student') {
-      studentProfileId = enrollmentProfileId
-      guardianProfileId = pickPreferred(guardiansByChild.get(enrollmentProfileId) ?? [])
-    } else if (enrollmentRole === 'guardian') {
-      guardianProfileId = enrollmentProfileId
-      studentProfileId = pickPreferred(childrenByGuardian.get(enrollmentProfileId) ?? [])
-    } else {
-      studentProfileId =
-        pickPreferred(childrenByGuardian.get(enrollmentProfileId) ?? []) ??
-        (enrollmentProfile ? enrollmentProfileId : null)
-      guardianProfileId =
-        (studentProfileId ? pickPreferred(guardiansByChild.get(studentProfileId) ?? []) : null) ??
-        pickPreferred(guardiansByChild.get(enrollmentProfileId) ?? [])
-    }
-
-    const studentProfile = studentProfileId ? profileById.get(studentProfileId) : null
-    const guardianProfile = guardianProfileId ? profileById.get(guardianProfileId) : null
-
-    splitByProfileId.set(enrollmentProfileId, {
-      student_firstname: normalizeText(studentProfile?.firstname),
-      student_lastname: normalizeText(studentProfile?.surname),
-      student_email: normalizeText(studentProfile?.email),
-      guardian_firstname: normalizeText(guardianProfile?.firstname),
-      guardian_lastname: normalizeText(guardianProfile?.surname),
-      guardian_email: normalizeText(guardianProfile?.email),
-    })
-  }
-
-  return splitByProfileId
-}
-
 export const buildWorkshopEnrollmentSnapshot = async ({
   request,
 }: {
@@ -168,38 +44,41 @@ export const buildWorkshopEnrollmentSnapshot = async ({
   const tableData = await loadWorkshopEnrollmentData(request)
   const baseColumns = (tableData.columns ?? []) as string[]
   const baseRows = (tableData.rows ?? []) as Array<Record<string, unknown>>
-
-  const enrichmentProfileIds = Array.from(
-    new Set(baseRows.map(row => normalizeText(row.profile_id)).filter(Boolean))
-  )
-  const enrichmentByProfileId = enrichmentProfileIds.length
-    ? await loadWorkshopEnrollmentEnrichment(enrichmentProfileIds)
-    : {}
-
-  const enrichedRows = baseRows.map(row => {
-    const profileId = normalizeText(row.profile_id)
-    const enrichment = profileId
-      ? (enrichmentByProfileId[profileId] ?? fallbackWorkshopEnrollmentEnrichment)
-      : fallbackWorkshopEnrollmentEnrichment
-    return {
-      ...row,
-      ...enrichment,
-    }
-  })
-
-  const profileSplitByProfileId = await buildProfileSplitData({ rows: enrichedRows })
-
-  const exportColumns = baseColumns.flatMap(column =>
-    column === 'profile_display' ? [...PROFILE_SPLIT_COLUMNS] : [column]
-  )
   const url = new URL(request.url)
   const sortColumn = url.searchParams.get('sort')
   const sortDirRaw = url.searchParams.get('dir')
   const sortDir = sortDirRaw === 'asc' || sortDirRaw === 'desc' ? sortDirRaw : null
   const filters = parseFiltersFromSearchParams(url.searchParams, baseColumns)
 
+  const filterColumns = Object.keys(filters)
+  const needsGeneratedValues =
+    (sortColumn !== null && GENERATED_WORKSHOP_COLUMNS.has(sortColumn)) ||
+    filterColumns.some(column => GENERATED_WORKSHOP_COLUMNS.has(column))
+
+  const rowsForFiltering = needsGeneratedValues
+    ? await (async () => {
+        const enrichmentProfileIds = Array.from(
+          new Set(baseRows.map(row => normalizeText(row.profile_id)).filter(Boolean))
+        )
+        const enrichmentByProfileId = enrichmentProfileIds.length
+          ? await loadWorkshopEnrollmentEnrichment(enrichmentProfileIds)
+          : {}
+
+        return baseRows.map(row => {
+          const profileId = normalizeText(row.profile_id)
+          const enrichment = profileId
+            ? (enrichmentByProfileId[profileId] ?? fallbackWorkshopEnrollmentEnrichment)
+            : fallbackWorkshopEnrollmentEnrichment
+          return {
+            ...row,
+            ...enrichment,
+          }
+        })
+      })()
+    : baseRows
+
   const filteredRows = applyFiltersAndSort({
-    rows: enrichedRows,
+    rows: rowsForFiltering,
     columns: baseColumns,
     filters,
     sortColumn,
@@ -211,19 +90,11 @@ export const buildWorkshopEnrollmentSnapshot = async ({
     throw new Error(`Export limit exceeded (${filteredRows.length} rows > ${EXPORT_MAX_ROWS}).`)
   }
 
-  const snapshotRows = filteredRows.map(row => {
-    const profileId = normalizeText(row.profile_id)
-    const split = profileSplitByProfileId.get(profileId) ?? null
+  const exportColumns = baseColumns.flatMap(column =>
+    column === 'profile_display' ? [...PROFILE_SPLIT_COLUMNS] : [column]
+  )
 
-    return exportColumns.reduce<Record<string, unknown>>((acc, column) => {
-      if (column in (split ?? {})) {
-        acc[column] = split?.[column] ?? ''
-        return acc
-      }
-      acc[column] = getCellValue(column, row, 'class-enrollment')
-      return acc
-    }, {})
-  })
+  const snapshotRows = filteredRows.map(row => ({ ...row }))
 
   return {
     columns: exportColumns,


### PR DESCRIPTION
## What
- move workshop enrollment export row materialization into runner-time processing
- keep queue-time snapshot lightweight while preserving generated-column filter/sort behavior
- add dedicated export row materializer for enrichment and student/guardian split columns

## Why
- export queue action regressed into blocking behavior and occasional 500s
- heavy enrichment and profile splitting should happen asynchronously in the export runner

## Validation
- npm run typecheck
- npm run build