### PR TITLE
Keep profile display and newest-first enrollments

### DIFF
--- a/web/app/lib/exports/runner.server.ts
+++ b/web/app/lib/exports/runner.server.ts
@@ -28,7 +28,7 @@ const normalizeWorkshopExportColumns = (columns: string[]) => {
   }
 
   return columns.flatMap(column =>
-    column === 'profile_display' ? [...WORKSHOP_PROFILE_SPLIT_COLUMNS] : [column]
+    column === 'profile_display' ? ['profile_display', ...WORKSHOP_PROFILE_SPLIT_COLUMNS] : [column]
   )
 }
 

--- a/web/app/lib/exports/workshop-enrollment-query.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-query.server.ts
@@ -143,7 +143,7 @@ export async function loadWorkshopEnrollmentData(request: Request) {
       return statusDiff
     }
 
-    const timeDiff = toTime(left.requested_at) - toTime(right.requested_at)
+    const timeDiff = toTime(right.requested_at) - toTime(left.requested_at)
     if (timeDiff !== 0) {
       return timeDiff
     }

--- a/web/app/lib/exports/workshop-enrollment-snapshot.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-snapshot.server.ts
@@ -91,7 +91,7 @@ export const buildWorkshopEnrollmentSnapshot = async ({
   }
 
   const exportColumns = baseColumns.flatMap(column =>
-    column === 'profile_display' ? [...PROFILE_SPLIT_COLUMNS] : [column]
+    column === 'profile_display' ? ['profile_display', ...PROFILE_SPLIT_COLUMNS] : [column]
   )
 
   const snapshotRows = filteredRows.map(row => ({ ...row }))


### PR DESCRIPTION
## What
- keep profile_display in workshop enrollment export output
- keep student and guardian split columns alongside profile_display
- switch workshop enrollment default ordering to newest requested_at first
- apply legacy runner column normalization without dropping profile_display

## Why
- exports should preserve existing profile_display while adding expanded identity fields
- enrollments table should be reverse chronological by default

## Validation
- npm run typecheck
- npm run build