### PR TITLE
Process triggered export by job id

### DIFF
--- a/web/app/lib/exports/repository.server.ts
+++ b/web/app/lib/exports/repository.server.ts
@@ -136,6 +136,26 @@ export const claimNextExportJob = async () => {
   return data[0] as ExportJobRecord
 }
 
+export const claimExportJobById = async ({ jobId }: { jobId: string }) => {
+  const { data, error } = await (adminClient.from('export_job' as any) as any)
+    .update({
+      status: 'running',
+      started_at: new Date().toISOString(),
+      error_message: null,
+    })
+    .eq('id', jobId)
+    .eq('status', 'queued')
+    .select('*')
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') return null
+    throw new Error(error.message)
+  }
+
+  return (data ?? null) as ExportJobRecord | null
+}
+
 export const listExportJobRows = async ({ jobId }: { jobId: string }) => {
   const { data, error } = await (adminClient.from('export_job_row' as any) as any)
     .select('row_index, row_data')

--- a/web/app/lib/exports/runner.server.ts
+++ b/web/app/lib/exports/runner.server.ts
@@ -1,5 +1,6 @@
 import { buildCsv } from './csv.server'
 import {
+  claimExportJobById,
   claimNextExportJob,
   completeExportJob,
   failExportJob,
@@ -40,6 +41,25 @@ export const processNextExportJob = async () => {
   if (!job) {
     return { processed: false as const }
   }
+
+  return processClaimedExportJob(job)
+}
+
+export const processExportJobById = async ({ jobId }: { jobId: string }) => {
+  const job = await claimExportJobById({ jobId })
+  if (!job) {
+    return { processed: false as const }
+  }
+
+  return processClaimedExportJob(job)
+}
+
+const processClaimedExportJob = async (job: {
+  id: string
+  export_type: string
+  column_order: string[] | null
+  requested_by: string
+}) => {
 
   try {
     if (job.export_type !== EXPORT_TYPE_WORKSHOP_ENROLLMENT_CSV) {

--- a/web/app/routes/manage/exports.tsx
+++ b/web/app/routes/manage/exports.tsx
@@ -4,7 +4,7 @@ import { Form, redirect, useActionData, useLoaderData, useNavigation, useRevalid
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
 import { triggerExportRunner } from '@/lib/exports/dispatch.server'
-import { processNextExportJob } from '@/lib/exports/runner.server'
+import { processExportJobById } from '@/lib/exports/runner.server'
 import {
   createExportJob,
   getExportJobById,
@@ -33,7 +33,7 @@ const triggerExportRunnerWithFallback = async ({ request, jobId }: { request: Re
     return { warning: undefined as string | undefined }
   }
 
-  const fallbackResult = await processNextExportJob()
+  const fallbackResult = await processExportJobById({ jobId })
   if (fallbackResult.processed && fallbackResult.jobId === jobId) {
     console.warn('[exports] immediate trigger failed, local fallback processed queued job', {
       jobId,


### PR DESCRIPTION
## What
- add claimExportJobById repository helper to atomically claim a specific queued export job
- add processExportJobById runner path using shared claimed-job processing logic
- update manage exports fallback trigger to process the current job id instead of next queued job

## Why
- creating a new export could trigger older queued jobs while leaving the just-queued job untouched
- fallback behavior should prioritize the initiating job for deterministic user flow

## Validation
- npm run typecheck
- npm run build