### PR TITLE
Add uploaded and accepted class attendance statuses

### DIFF
--- a/supabase/migrations/20260623120000_class_attendance_picture_submission_status.sql
+++ b/supabase/migrations/20260623120000_class_attendance_picture_submission_status.sql
@@ -1,0 +1,20 @@
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_enum
+    where enumtypid = 'public.class_attendance_status'::regtype
+      and enumlabel = 'uploaded'
+  ) then
+    alter type public.class_attendance_status add value 'uploaded';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_enum
+    where enumtypid = 'public.class_attendance_status'::regtype
+      and enumlabel = 'accepted'
+  ) then
+    alter type public.class_attendance_status add value 'accepted';
+  end if;
+end $$;

--- a/supabase/schemas/03_semesters_cohorts_classes.sql
+++ b/supabase/schemas/03_semesters_cohorts_classes.sql
@@ -11,7 +11,9 @@ create type public.workshop_enrollment_status as enum (
 create type public.class_attendance_status as enum (
   'unknown',
   'present',
-  'absent'
+  'absent',
+  'uploaded',
+  'accepted'
 );
 
 create table public.semester (

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -1410,7 +1410,7 @@ export type Database = {
         | "instructor"
         | "student"
         | "guardian"
-      class_attendance_status: "unknown" | "present" | "absent"
+      class_attendance_status: "unknown" | "present" | "absent" | "uploaded" | "accepted"
       email_draft_channel: "transactional" | "auth"
       email_draft_status: "draft" | "published" | "archived"
       email_message_status: "queued" | "sent" | "failed" | "skipped"
@@ -1626,7 +1626,7 @@ export const Constants = {
         "student",
         "guardian",
       ],
-      class_attendance_status: ["unknown", "present", "absent"],
+      class_attendance_status: ["unknown", "present", "absent", "uploaded", "accepted"],
       email_draft_channel: ["transactional", "auth"],
       email_draft_status: ["draft", "published", "archived"],
       email_message_status: ["queued", "sent", "failed", "skipped"],
@@ -1662,4 +1662,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -60,7 +60,7 @@ type ClassRow = {
 type AttendanceRow = {
   class_id: string
   profile_id: string
-  status: 'unknown' | 'present' | 'absent' | null
+  status: 'unknown' | 'present' | 'absent' | 'uploaded' | 'accepted' | null
 }
 
 type LoaderData = {

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -1,4 +1,5 @@
 import { requireAuth } from '@/lib/auth.server'
+import { Constants, type Database } from '@/lib/database.types'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
 import type { Route } from './+types/class-attendance'
@@ -40,6 +41,10 @@ export async function action({ request }: Route.ActionArgs) {
 
   if (intent === 'update-status') {
     const status = (formData.get('status') as string | null) ?? null
+    const allowedStatuses = Constants.public.Enums.class_attendance_status as readonly Database['public']['Enums']['class_attendance_status'][]
+    if (status && !allowedStatuses.includes(status as Database['public']['Enums']['class_attendance_status'])) {
+      return new Response('Invalid status', { status: 400, headers: auth.headers })
+    }
     updates.status = status || null
   }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -1369,6 +1369,8 @@ export default function TableDisplay({ headerActions, data }: TableDisplayProps 
                               <option value="unknown">unknown</option>
                               <option value="present">present</option>
                               <option value="absent">absent</option>
+                              <option value="uploaded">uploaded</option>
+                              <option value="accepted">accepted</option>
                             </select>
                           </td>
                         )


### PR DESCRIPTION
## What
- add 'uploaded' and 'accepted' to class_attendance_status in declarative schema
- add forward migration to append both enum values safely
- update generated DB types/constants for the new enum values
- update attendance UI/status typing and validate submitted status values server-side

## Validation
- npm run typecheck