### PR TITLE
Improve riding visibility and manual correction flows

### DIFF
--- a/web/app/lib/exports/workshop-enrollment-query.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-query.server.ts
@@ -24,8 +24,11 @@ const toTime = (value: unknown) => {
 
 export async function loadWorkshopEnrollmentData(request: Request) {
   const auth = await requireAuth(request)
-  const base = await baseLoader({ request } as LoaderFunctionArgs)
   const canManageEnrollments = isRoleAtLeast(auth.claims.role, 'admin')
+  const base = await baseLoader(
+    { request } as LoaderFunctionArgs,
+    { includeForeignKeyOptions: canManageEnrollments }
+  )
 
   const rows = (base.rows ?? []) as Array<Record<string, unknown>>
   const workshopIds = Array.from(

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -1,5 +1,8 @@
-import { useOutletContext } from 'react-router'
+import { useEffect, useState } from 'react'
+import { useFetcher, useLocation, useOutletContext } from 'react-router'
 
+import { Button } from '@/components/ui/button'
+import { Combobox } from '@/components/ui/combobox'
 import type { PersonLoaderData } from './person.shared'
 import { formatDate, formatDateTime } from './person.shared'
 
@@ -13,7 +16,15 @@ const geoStatusLabel: Record<PersonLoaderData['ipEvidence'][number]['geo_status'
 }
 
 export default function ManagePersonOverviewPage() {
-  const { profile, ipEvidence, familyProfiles, primaryChildByGuardian } = useOutletContext<PersonLoaderData>()
+  const { profile, ipEvidence, familyProfiles, primaryChildByGuardian, federalDistrictOptions } = useOutletContext<PersonLoaderData>()
+  const location = useLocation()
+  const ridingFetcher = useFetcher<{ error?: string; success?: boolean }>()
+  const [selectedRiding, setSelectedRiding] = useState(profile.federal_electoral_district_name ?? '')
+
+  useEffect(() => {
+    setSelectedRiding(profile.federal_electoral_district_name ?? '')
+  }, [profile.federal_electoral_district_name, profile.id])
+
   const familyProfileById = new Map(familyProfiles.map(item => [item.id, item]))
 
   const relatedProfile = (() => {
@@ -55,6 +66,30 @@ export default function ManagePersonOverviewPage() {
             <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
             <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
             <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
+            <div className="space-y-2 rounded border bg-background p-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Riding</p>
+              <p>
+                <span className="font-medium">Lookup status:</span> {profile.riding_lookup_status ?? 'not_attempted'}
+                {profile.riding_lookup_error ? ` (${profile.riding_lookup_error})` : ''}
+              </p>
+              <ridingFetcher.Form method="post" action={`/manage/person${location.search}`} className="space-y-2">
+                <input type="hidden" name="intent" value="update-riding" />
+                <input type="hidden" name="profile_id" value={profile.id} />
+                <input type="hidden" name="riding_name" value={selectedRiding} />
+                <Combobox
+                  value={selectedRiding}
+                  onChange={setSelectedRiding}
+                  options={[{ value: '', label: 'Unassigned' }, ...federalDistrictOptions]}
+                  placeholder="Select riding"
+                  disabled={ridingFetcher.state !== 'idle'}
+                />
+                <Button type="submit" size="sm" variant="outline" disabled={ridingFetcher.state !== 'idle'}>
+                  {ridingFetcher.state !== 'idle' ? 'Saving...' : 'Save riding'}
+                </Button>
+                {ridingFetcher.data?.error ? <p className="text-xs text-destructive">{ridingFetcher.data.error}</p> : null}
+                {ridingFetcher.data?.success ? <p className="text-xs text-emerald-600">Riding updated.</p> : null}
+              </ridingFetcher.Form>
+            </div>
           </div>
         </div>
 
@@ -71,6 +106,7 @@ export default function ManagePersonOverviewPage() {
               <p><span className="font-medium">Phone:</span> {relatedProfile.phone ?? '-'}</p>
               <p><span className="font-medium">DOB:</span> {formatDate(relatedProfile.date_of_birth)}</p>
               <p><span className="font-medium">Address:</span> {relatedAddress || '-'}</p>
+              <p><span className="font-medium">Riding:</span> {relatedProfile.federal_electoral_district_name ?? '-'}</p>
             </div>
           ) : (
             <p className="text-muted-foreground">No related child/guardian profile found.</p>

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -13,19 +13,69 @@ const geoStatusLabel: Record<PersonLoaderData['ipEvidence'][number]['geo_status'
 }
 
 export default function ManagePersonOverviewPage() {
-  const { profile, ipEvidence } = useOutletContext<PersonLoaderData>()
+  const { profile, ipEvidence, familyProfiles, primaryChildByGuardian } = useOutletContext<PersonLoaderData>()
+  const familyProfileById = new Map(familyProfiles.map(item => [item.id, item]))
+
+  const relatedProfile = (() => {
+    if (profile.role === 'guardian') {
+      const childId = primaryChildByGuardian[profile.id]
+      return childId ? familyProfileById.get(childId) ?? null : null
+    }
+
+    if (profile.role === 'student') {
+      const primaryGuardian = familyProfiles.find(
+        member => member.role === 'guardian' && primaryChildByGuardian[member.id] === profile.id
+      )
+      return primaryGuardian ?? familyProfiles.find(member => member.role === 'guardian') ?? null
+    }
+
+    return familyProfiles.find(member => member.id !== profile.id) ?? null
+  })()
+
+  const profileAddress = [profile.street_address, profile.city, profile.province, profile.postcode]
+    .filter(Boolean)
+    .join(', ')
+  const relatedAddress = relatedProfile
+    ? [relatedProfile.street_address, relatedProfile.city, relatedProfile.province, relatedProfile.postcode]
+        .filter(Boolean)
+        .join(', ')
+    : ''
 
   return (
     <section className="rounded-lg border bg-card p-4">
       <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Personal information</h2>
-      <div className="mt-3 grid gap-2 text-sm md:grid-cols-2">
-        <p><span className="font-medium">Profile ID:</span> {profile.id}</p>
-        <p><span className="font-medium">User ID:</span> {profile.user_id ?? '-'}</p>
-        <p><span className="font-medium">Role:</span> {profile.role ?? '-'}</p>
-        <p><span className="font-medium">Email:</span> {profile.email ?? '-'}</p>
-        <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
-        <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
-        <p className="md:col-span-2"><span className="font-medium">Address:</span> {[profile.street_address, profile.city, profile.province, profile.postcode].filter(Boolean).join(', ') || '-'}</p>
+      <div className="mt-3 grid gap-4 md:grid-cols-2">
+        <div className="rounded-md border bg-muted/20 p-3 text-sm">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Selected profile</h3>
+          <div className="grid gap-2">
+            <p><span className="font-medium">Profile ID:</span> {profile.id}</p>
+            <p><span className="font-medium">User ID:</span> {profile.user_id ?? '-'}</p>
+            <p><span className="font-medium">Role:</span> {profile.role ?? '-'}</p>
+            <p><span className="font-medium">Email:</span> {profile.email ?? '-'}</p>
+            <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
+            <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
+            <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
+          </div>
+        </div>
+
+        <div className="rounded-md border bg-muted/20 p-3 text-sm">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {profile.role === 'guardian' ? 'Primary child profile' : 'Related guardian profile'}
+          </h3>
+          {relatedProfile ? (
+            <div className="grid gap-2">
+              <p><span className="font-medium">Profile ID:</span> {relatedProfile.id}</p>
+              <p><span className="font-medium">User ID:</span> {relatedProfile.user_id ?? '-'}</p>
+              <p><span className="font-medium">Role:</span> {relatedProfile.role ?? '-'}</p>
+              <p><span className="font-medium">Email:</span> {relatedProfile.email ?? '-'}</p>
+              <p><span className="font-medium">Phone:</span> {relatedProfile.phone ?? '-'}</p>
+              <p><span className="font-medium">DOB:</span> {formatDate(relatedProfile.date_of_birth)}</p>
+              <p><span className="font-medium">Address:</span> {relatedAddress || '-'}</p>
+            </div>
+          ) : (
+            <p className="text-muted-foreground">No related child/guardian profile found.</p>
+          )}
+        </div>
       </div>
 
       <div className="mt-4 border-t pt-3">

--- a/web/app/routes/manage/person.shared.ts
+++ b/web/app/routes/manage/person.shared.ts
@@ -13,6 +13,10 @@ export type ProfileRow = {
   province: string | null
   postcode: string | null
   date_of_birth: string | null
+  federal_electoral_district_name?: string | null
+  riding_lookup_status?: string | null
+  riding_lookup_last_attempt_at?: string | null
+  riding_lookup_error?: string | null
 }
 
 export type SuspiciousSignalRow = {
@@ -102,6 +106,7 @@ export type PersonLoaderData = {
   }>
   formNameById: Record<string, string>
   suspiciousSignals: SuspiciousSignalRow[]
+  federalDistrictOptions: Array<{ value: string; label: string }>
 }
 
 export const formatDate = (value: string | null) => {

--- a/web/app/routes/manage/person.tsx
+++ b/web/app/routes/manage/person.tsx
@@ -123,7 +123,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const profileQuery = adminClient
     .from('profile')
-    .select('id, user_id, role, firstname, surname, email, phone, street_address, city, province, postcode, date_of_birth')
+    .select(
+      'id, user_id, role, firstname, surname, email, phone, street_address, city, province, postcode, date_of_birth, federal_electoral_district_name, riding_lookup_status, riding_lookup_last_attempt_at, riding_lookup_error'
+    )
 
   const { data: profileRow } = profileIdParam
     ? await profileQuery.eq('id', profileIdParam).maybeSingle()
@@ -295,10 +297,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const familyProfileIds = Array.from(seen)
 
-  const [{ data: familyProfilesRaw }, { data: enrollmentRowsRaw }, { data: suspiciousSignalsRaw }] = await Promise.all([
+  const [{ data: familyProfilesRaw }, { data: enrollmentRowsRaw }, { data: suspiciousSignalsRaw }, { data: districtRowsRaw }] = await Promise.all([
     adminClient
       .from('profile')
-      .select('id, user_id, role, firstname, surname, email, phone, street_address, city, province, postcode, date_of_birth')
+      .select(
+        'id, user_id, role, firstname, surname, email, phone, street_address, city, province, postcode, date_of_birth, federal_electoral_district_name, riding_lookup_status, riding_lookup_last_attempt_at, riding_lookup_error'
+      )
       .in('id', familyProfileIds),
     adminClient
       .from('workshop_enrollment')
@@ -311,6 +315,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       .order('priority_score', { ascending: false })
       .order('created_at', { ascending: false })
       .limit(200),
+    adminClient
+      .from('federal_electoral_district')
+      .select('name')
+      .order('name', { ascending: true }),
   ])
 
   const familyProfiles = (familyProfilesRaw ?? []) as ProfileRow[]
@@ -423,6 +431,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return acc
   }, {})
 
+  const federalDistrictOptions = (districtRowsRaw ?? [])
+    .filter(row => typeof row.name === 'string' && row.name.trim())
+    .map(row => {
+      const name = row.name.trim()
+      return { value: name, label: name }
+    })
+
   return {
     profile: profileRow as ProfileRow,
     activityEvents,
@@ -437,7 +452,60 @@ export async function loader({ request }: LoaderFunctionArgs) {
     classByWorkshop,
     attendanceByClass,
     suspiciousSignals,
+    federalDistrictOptions,
   } satisfies PersonLoaderData
+}
+
+export async function action({ request }: LoaderFunctionArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'staff')) {
+    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const formData = await request.formData()
+  const intent = String(formData.get('intent') ?? '')
+  if (intent !== 'update-riding') {
+    return new Response('Unsupported action', { status: 400, headers: auth.headers })
+  }
+
+  const profileId = String(formData.get('profile_id') ?? '').trim()
+  const ridingNameRaw = String(formData.get('riding_name') ?? '').trim()
+  const ridingName = ridingNameRaw || null
+
+  if (!profileId) {
+    return { error: 'Missing profile id.' }
+  }
+
+  if (ridingName) {
+    const { data: districtRow, error: districtError } = await adminClient
+      .from('federal_electoral_district')
+      .select('name')
+      .eq('name', ridingName)
+      .maybeSingle()
+
+    if (districtError) {
+      return { error: districtError.message }
+    }
+    if (!districtRow?.name) {
+      return { error: 'Selected riding does not exist.' }
+    }
+  }
+
+  const { error: updateError } = await adminClient
+    .from('profile')
+    .update({
+      federal_electoral_district_name: ridingName,
+      riding_lookup_status: ridingName ? 'matched' : 'skipped',
+      riding_lookup_error: null,
+      riding_lookup_last_attempt_at: new Date().toISOString(),
+    })
+    .eq('id', profileId)
+
+  if (updateError) {
+    return { error: updateError.message }
+  }
+
+  return { success: true }
 }
 
 export default function ManagePersonLayoutPage() {

--- a/web/app/routes/manage/riding-lookup.tsx
+++ b/web/app/routes/manage/riding-lookup.tsx
@@ -9,6 +9,7 @@ import type { Route } from './+types/riding-lookup'
 
 type MissingRidingProfile = {
   id: string
+  user_id: string | null
   role: string | null
   firstname: string | null
   surname: string | null
@@ -17,6 +18,15 @@ type MissingRidingProfile = {
   riding_lookup_status: string | null
   riding_lookup_error: string | null
   riding_lookup_last_attempt_at: string | null
+}
+
+type RetryDetail = {
+  profileId: string
+  profileLabel: string
+  postcode: string | null
+  outcome: 'matched' | 'not_found' | 'district_not_seeded' | 'failed' | 'skipped_missing_postcode'
+  reason: string | null
+  attempts: number
 }
 
 type ActionData = {
@@ -28,10 +38,13 @@ type ActionData = {
     failed: number
     districtNotSeeded: number
     skippedMissingPostcode: number
+    details: RetryDetail[]
   }
 }
 
 const normalizePostcode = (value: string) => value.replace(/\s+/g, '').toUpperCase()
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+const RETRYABLE_REASONS = new Set(['rate_limited', 'timeout', 'upstream', 'network'])
 
 const profileLabel = (profile: MissingRidingProfile) => {
   const name = [profile.firstname?.trim(), profile.surname?.trim()].filter(Boolean).join(' ')
@@ -44,7 +57,7 @@ const resolveCandidates = async (limit: number) => {
   const { data, error } = await adminClient
     .from('profile')
     .select(
-      'id, role, firstname, surname, email, postcode, federal_electoral_district_name, riding_lookup_status, riding_lookup_error, riding_lookup_last_attempt_at'
+      'id, user_id, role, firstname, surname, email, postcode, federal_electoral_district_name, riding_lookup_status, riding_lookup_error, riding_lookup_last_attempt_at'
     )
     .is('federal_electoral_district_name', null)
     .order('riding_lookup_last_attempt_at', { ascending: true, nullsFirst: true })
@@ -60,17 +73,46 @@ const resolveCandidates = async (limit: number) => {
 }
 
 const refreshProfileRiding = async (profile: MissingRidingProfile) => {
-  const attemptedAt = new Date().toISOString()
+  if (profile.user_id) {
+    const { error: roleSyncError } = await adminClient
+      .from('user_roles')
+      .upsert(
+        {
+          user_id: profile.user_id,
+          role: profile.role ?? 'unassigned',
+        } as never,
+        { onConflict: 'user_id', ignoreDuplicates: true }
+      )
+
+    if (roleSyncError) {
+      throw new Error(`role_sync_failed:${roleSyncError.message}`)
+    }
+  }
+
+  let attemptedAt = new Date().toISOString()
   const postcode = typeof profile.postcode === 'string' ? normalizePostcode(profile.postcode) : ''
   if (!postcode) {
     await adminClient
       .from('profile')
       .update({ riding_lookup_last_attempt_at: attemptedAt })
       .eq('id', profile.id)
-    return { outcome: 'skipped_missing_postcode' as const }
+    return { outcome: 'skipped_missing_postcode' as const, reason: 'missing_postcode', attempts: 0 }
   }
 
-  const lookup = await ridingLookupProvider.lookupByPostcode(postcode)
+  let lookup = await ridingLookupProvider.lookupByPostcode(postcode)
+  let attempts = 1
+
+  while (
+    lookup.status === 'error' &&
+    RETRYABLE_REASONS.has(lookup.reason) &&
+    attempts < 3
+  ) {
+    await sleep(250 * attempts)
+    lookup = await ridingLookupProvider.lookupByPostcode(postcode)
+    attempts += 1
+  }
+
+  attemptedAt = new Date().toISOString()
 
   if (lookup.status === 'matched') {
     const { data: districtRow } = await (adminClient.from('federal_electoral_district') as any)
@@ -90,7 +132,7 @@ const refreshProfileRiding = async (profile: MissingRidingProfile) => {
         .eq('id', profile.id)
 
       if (error) throw new Error(error.message)
-      return { outcome: 'matched' as const }
+      return { outcome: 'matched' as const, reason: null, attempts }
     }
 
     const { error } = await adminClient
@@ -103,7 +145,7 @@ const refreshProfileRiding = async (profile: MissingRidingProfile) => {
       })
       .eq('id', profile.id)
     if (error) throw new Error(error.message)
-    return { outcome: 'district_not_seeded' as const }
+    return { outcome: 'district_not_seeded' as const, reason: 'district_not_seeded', attempts }
   }
 
   if (lookup.status === 'not_found') {
@@ -117,7 +159,7 @@ const refreshProfileRiding = async (profile: MissingRidingProfile) => {
       })
       .eq('id', profile.id)
     if (error) throw new Error(error.message)
-    return { outcome: 'not_found' as const }
+    return { outcome: 'not_found' as const, reason: 'postcode_not_found', attempts }
   }
 
   const { error } = await adminClient
@@ -129,7 +171,7 @@ const refreshProfileRiding = async (profile: MissingRidingProfile) => {
     })
     .eq('id', profile.id)
   if (error) throw new Error(error.message)
-  return { outcome: 'failed' as const }
+  return { outcome: 'failed' as const, reason: lookup.reason, attempts }
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -141,7 +183,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { data: missingWithPostcodeRaw } = await adminClient
     .from('profile')
     .select(
-      'id, role, firstname, surname, email, postcode, riding_lookup_status, riding_lookup_error, riding_lookup_last_attempt_at'
+      'id, user_id, role, firstname, surname, email, postcode, riding_lookup_status, riding_lookup_error, riding_lookup_last_attempt_at'
     )
     .is('federal_electoral_district_name', null)
     .not('postcode', 'is', null)
@@ -185,7 +227,7 @@ export async function action({ request }: Route.ActionArgs) {
 
     const { data, error } = await adminClient
       .from('profile')
-      .select('id, role, firstname, surname, email, postcode, riding_lookup_status, riding_lookup_error, riding_lookup_last_attempt_at')
+      .select('id, user_id, role, firstname, surname, email, postcode, riding_lookup_status, riding_lookup_error, riding_lookup_last_attempt_at')
       .in('id', profileIds)
 
     if (error) {
@@ -211,6 +253,7 @@ export async function action({ request }: Route.ActionArgs) {
     failed: 0,
     districtNotSeeded: 0,
     skippedMissingPostcode: 0,
+    details: [] as RetryDetail[],
   }
 
   for (const profile of candidates) {
@@ -222,14 +265,34 @@ export async function action({ request }: Route.ActionArgs) {
       else if (refresh.outcome === 'failed') result.failed += 1
       else if (refresh.outcome === 'district_not_seeded') result.districtNotSeeded += 1
       else if (refresh.outcome === 'skipped_missing_postcode') result.skippedMissingPostcode += 1
+
+      result.details.push({
+        profileId: profile.id,
+        profileLabel: profileLabel(profile),
+        postcode: typeof profile.postcode === 'string' && profile.postcode.trim() ? profile.postcode.trim() : null,
+        outcome: refresh.outcome,
+        reason: refresh.reason,
+        attempts: refresh.attempts,
+      })
+
+      await sleep(200)
     } catch (error) {
       result.attempted += 1
       result.failed += 1
+      result.details.push({
+        profileId: profile.id,
+        profileLabel: profileLabel(profile),
+        postcode: typeof profile.postcode === 'string' && profile.postcode.trim() ? profile.postcode.trim() : null,
+        outcome: 'failed',
+        reason: error instanceof Error ? error.message : 'unknown_error',
+        attempts: 1,
+      })
       console.error('[riding lookup] manual retry failed', {
         profileId: profile.id,
         profile: profileLabel(profile),
         error,
       })
+      await sleep(200)
     }
   }
 
@@ -252,35 +315,38 @@ export default function RidingLookupPage() {
         </p>
       </header>
 
-      <section className="rounded-lg border bg-card p-4 space-y-2">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Current queue</h2>
-        <div className="grid gap-2 text-sm md:grid-cols-2">
-          <p><span className="font-medium">Missing riding with postcode:</span> {missingWithPostcode.length}</p>
-          <p><span className="font-medium">Missing riding without postcode:</span> {missingWithoutPostcodeCount}</p>
-        </div>
-      </section>
+      <div className="grid gap-4 md:grid-cols-2">
+        <section className="rounded-lg border bg-card p-4 space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Current queue</h2>
+          <div className="grid gap-2 text-sm">
+            <p><span className="font-medium">Missing riding with postcode:</span> {missingWithPostcode.length}</p>
+            <p><span className="font-medium">Missing riding without postcode:</span> {missingWithoutPostcodeCount}</p>
+          </div>
+        </section>
 
-      <Form method="post" className="rounded-lg border bg-card p-4 space-y-3">
-        <input type="hidden" name="intent" value="retry-batch" />
-        <label className="grid gap-1 text-sm md:max-w-xs">
-          <span className="text-muted-foreground">Retry first N missing profiles (1-300)</span>
-          <input
-            name="max_profiles"
-            type="number"
-            min={1}
-            max={300}
-            defaultValue={50}
-            className="h-10 rounded border border-input bg-background px-3"
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
-        >
-          {isSubmitting ? 'Retrying...' : 'Retry batch'}
-        </button>
-      </Form>
+        <Form method="post" className="rounded-lg border bg-card p-4 space-y-3">
+          <input type="hidden" name="intent" value="retry-batch" />
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Retry batch</h2>
+          <label className="grid gap-1 text-sm md:max-w-xs">
+            <span className="text-muted-foreground">Retry first N missing profiles (1-300)</span>
+            <input
+              name="max_profiles"
+              type="number"
+              min={1}
+              max={300}
+              defaultValue={50}
+              className="h-10 rounded border border-input bg-background px-3"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
+          >
+            {isSubmitting ? 'Retrying...' : 'Retry batch'}
+          </button>
+        </Form>
+      </div>
 
       {missingWithPostcode.length ? (
         <Form method="post" className="rounded-lg border bg-card p-4 space-y-3">
@@ -339,7 +405,7 @@ export default function RidingLookupPage() {
       ) : null}
 
       {actionData?.result ? (
-        <section className="rounded-lg border bg-card p-4 space-y-2 text-sm">
+        <section className="rounded-lg border bg-card p-4 space-y-3 text-sm">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Last retry result</h2>
           <div className="grid gap-2 md:grid-cols-2">
             <p><span className="font-medium">Attempted:</span> {actionData.result.attempted}</p>
@@ -349,6 +415,35 @@ export default function RidingLookupPage() {
             <p><span className="font-medium">Failed:</span> {actionData.result.failed}</p>
             <p><span className="font-medium">Skipped missing postcode:</span> {actionData.result.skippedMissingPostcode}</p>
           </div>
+          {actionData.result.details.length ? (
+            <div className="max-h-72 overflow-auto rounded border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2">Profile</th>
+                    <th className="px-3 py-2">Postcode</th>
+                    <th className="px-3 py-2">Outcome</th>
+                    <th className="px-3 py-2">Reason</th>
+                    <th className="px-3 py-2">Attempts</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {actionData.result.details.map(detail => (
+                    <tr key={detail.profileId} className="border-t">
+                      <td className="px-3 py-2 align-top">
+                        <div className="font-medium">{detail.profileLabel}</div>
+                        <div className="text-xs text-muted-foreground">{detail.profileId}</div>
+                      </td>
+                      <td className="px-3 py-2 align-top">{detail.postcode ?? 'N/A'}</td>
+                      <td className="px-3 py-2 align-top">{detail.outcome}</td>
+                      <td className="px-3 py-2 align-top">{detail.reason ?? 'N/A'}</td>
+                      <td className="px-3 py-2 align-top">{detail.attempts}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
         </section>
       ) : null}
     </div>

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -642,6 +642,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
   const [openFilterCacheEntry, setOpenFilterCacheEntry] = useState<FilterOptionsCacheEntry | null>(null)
   const isWorkshopEnrollmentTable = tableName === 'class-enrollment'
   const isFederalDistrictTable = tableName === 'federal-electoral-district'
+  const debugPerf = searchParams.get('debugPerf') === '1'
 
   useEffect(() => {
     const nextSort = searchParams.get('sort')
@@ -1129,6 +1130,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
     const abortController = new AbortController()
     void (async () => {
+      const startedAt = Date.now()
       try {
         const searchParams = new URLSearchParams()
         requestProfileIds.forEach(profileId => searchParams.append('profileId', profileId))
@@ -1187,6 +1189,14 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
           ...prev,
           ...resolvedByProfileId,
         }))
+        if (debugPerf) {
+          console.info('[table-display] workshop row enrichment loaded', {
+            requestedProfiles: requestProfileIds.length,
+            workshopValues: shouldLoadWorkshopValues,
+            familyContext: shouldLoadFamilyContext,
+            ms: Date.now() - startedAt,
+          })
+        }
       } catch (error) {
         if ((error as Error).name !== 'AbortError') {
           console.error('[table display] enrichment fetch failed', error)
@@ -1343,6 +1353,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
     loadingEnrichmentProfileIdsRef.current.add(profileId)
     void (async () => {
+      const startedAt = Date.now()
       try {
         const query = new URLSearchParams()
         query.append('profileId', profileId)
@@ -1386,6 +1397,12 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
             profile_hover_parent_address: resolved.profile_hover_parent_address,
           },
         }))
+        if (debugPerf) {
+          console.info('[table-display] hover family-context loaded', {
+            profileId,
+            ms: Date.now() - startedAt,
+          })
+        }
       } catch (error) {
         console.error('[table display] family-context hover fetch failed', error)
       } finally {

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -149,6 +149,8 @@ const FILTER_CACHE_TTL_MS = 5 * 60 * 1000
 const FILTER_OPTION_MAX_VISIBLE_LIST = 500
 const FILTER_EMPTY_LABEL = '(empty)'
 const ENABLE_PERSISTED_COLUMN_WIDTHS = false
+const WORKSHOP_ENRICHMENT_BATCH_SIZE = 40
+const WORKSHOP_ENRICHMENT_FILTER_BOOTSTRAP_BATCH_SIZE = 200
 const WORKSHOP_ENRICHMENT_COLUMNS = new Set([
   'riding_display',
   'geo_locations_display',
@@ -266,7 +268,9 @@ const hoverCardDataForCell = (row: Record<string, unknown>, config?: HoverCardCo
   if (!hasListFields && !hasColumns) return null
 
   const titleRaw = config.titleField ? normalizeHoverCardValue(row[config.titleField]) : ''
-  const title = titleRaw || config.titleFallback || ''
+  const profileDisplayFallback =
+    config.titleField === 'profile_hover_name' ? normalizeHoverCardValue(row.profile_display) : ''
+  const title = titleRaw || profileDisplayFallback || config.titleFallback || ''
   const normalizeField = (field: HoverCardField) => {
     const rawValue = normalizeHoverCardValue(row[field.field])
     return {
@@ -1101,7 +1105,10 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
     if (!missingProfileIds.length) return
 
-    const requestProfileIds = missingProfileIds.slice(0, 40)
+    const requestBatchSize = hasActiveEnrichmentBackedFilters
+      ? WORKSHOP_ENRICHMENT_FILTER_BOOTSTRAP_BATCH_SIZE
+      : WORKSHOP_ENRICHMENT_BATCH_SIZE
+    const requestProfileIds = missingProfileIds.slice(0, requestBatchSize)
     requestProfileIds.forEach(profileId => loadingEnrichmentProfileIdsRef.current.add(profileId))
 
     const abortController = new AbortController()

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -155,9 +155,9 @@ const WORKSHOP_ENRICHMENT_COLUMNS = new Set([
   'riding_display',
   'geo_locations_display',
   'giftcard_display',
+  'prior_participation_display',
 ])
 const FAMILY_CONTEXT_COLUMNS = new Set([
-  'prior_participation_display',
   'profile_hover_top_discrepancy',
   'profile_hover_more_discrepancies',
   'profile_hover_name',
@@ -175,6 +175,18 @@ const WORKSHOP_FILTER_ENRICHMENT_COLUMNS = new Set([
   ...Array.from(WORKSHOP_ENRICHMENT_COLUMNS),
   ...Array.from(FAMILY_CONTEXT_COLUMNS),
 ])
+
+const hasHydratedFamilyContext = (enrichment?: WorkshopEnrollmentEnrichment) =>
+  Boolean(
+    enrichment?.profile_hover_name ||
+      enrichment?.profile_hover_parent_name ||
+      enrichment?.profile_hover_email ||
+      enrichment?.profile_hover_parent_email ||
+      enrichment?.profile_hover_student_geo ||
+      enrichment?.profile_hover_parent_geo ||
+      enrichment?.profile_hover_top_discrepancy ||
+      enrichment?.profile_hover_more_discrepancies
+  )
 const DEFAULT_COLUMN_WIDTH = 180
 const DEFAULT_NUMERIC_COLUMN_WIDTH = 120
 const ACTIONS_COLUMN_WIDTH = 120
@@ -1058,6 +1070,10 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     () => Object.keys(filters).some(column => WORKSHOP_FILTER_ENRICHMENT_COLUMNS.has(column)),
     [filters]
   )
+  const hasActiveFamilyContextFilters = useMemo(
+    () => Object.keys(filters).some(column => FAMILY_CONTEXT_COLUMNS.has(column)),
+    [filters]
+  )
   const baseFiltersForEnrichmentFetch = useMemo(() => {
     const next: Record<string, string[]> = {}
     for (const [column, values] of Object.entries(filters)) {
@@ -1083,7 +1099,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
     const shouldLoadWorkshopValues = columns.some(column => WORKSHOP_ENRICHMENT_COLUMNS.has(column))
     const shouldLoadFamilyContext =
-      columns.includes('profile_display') || columns.some(column => FAMILY_CONTEXT_COLUMNS.has(column))
+      hasActiveFamilyContextFilters || Boolean(openFilterColumn && FAMILY_CONTEXT_COLUMNS.has(openFilterColumn))
 
     if (!shouldLoadWorkshopValues && !shouldLoadFamilyContext) return
 
@@ -1187,8 +1203,10 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     baseFiltersForEnrichmentFetch,
     columns,
     enrichmentByProfileId,
+    hasActiveFamilyContextFilters,
     hasActiveEnrichmentBackedFilters,
     isWorkshopEnrollmentTable,
+    openFilterColumn,
     paginatedRows,
     rows,
   ])
@@ -1316,6 +1334,64 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
       setPageSize(nextPageSize)
     }
     syncSearch(filters, sortColumn, sortStage, boundedPage, nextPageSize)
+  }
+
+  const requestFamilyContextForProfile = (profileId: string) => {
+    if (!isWorkshopEnrollmentTable || !profileId) return
+    const existing = enrichmentByProfileId[profileId]
+    if (hasHydratedFamilyContext(existing) || loadingEnrichmentProfileIdsRef.current.has(profileId)) return
+
+    loadingEnrichmentProfileIdsRef.current.add(profileId)
+    void (async () => {
+      try {
+        const query = new URLSearchParams()
+        query.append('profileId', profileId)
+        const response = await fetch(`/manage/family-context/enrichment?${query.toString()}`)
+        if (!response.ok) return
+        const payload = (await response.json()) as FamilyContextEnrichmentResponse
+        const resolved = payload?.byProfileId?.[profileId] ?? {
+          prior_participation_display: 'N/A',
+          profile_hover_top_discrepancy: '',
+          profile_hover_more_discrepancies: '',
+          profile_hover_name: 'N/A',
+          profile_hover_parent_name: 'N/A',
+          profile_hover_email: 'N/A',
+          profile_hover_student_phone: '',
+          profile_hover_parent_email: 'N/A',
+          profile_hover_parent_phone: 'N/A',
+          profile_hover_student_geo: 'N/A',
+          profile_hover_parent_geo: 'N/A',
+          profile_hover_student_submitted_address: 'N/A',
+          profile_hover_parent_address: 'N/A',
+        }
+
+        setEnrichmentByProfileId(prev => ({
+          ...prev,
+          [profileId]: {
+            riding_display: prev[profileId]?.riding_display ?? '',
+            geo_locations_display: prev[profileId]?.geo_locations_display ?? 'N/A',
+            giftcard_display: prev[profileId]?.giftcard_display ?? 'N/A',
+            prior_participation_display: prev[profileId]?.prior_participation_display ?? resolved.prior_participation_display,
+            profile_hover_top_discrepancy: resolved.profile_hover_top_discrepancy,
+            profile_hover_more_discrepancies: resolved.profile_hover_more_discrepancies,
+            profile_hover_name: resolved.profile_hover_name,
+            profile_hover_parent_name: resolved.profile_hover_parent_name,
+            profile_hover_email: resolved.profile_hover_email,
+            profile_hover_student_phone: resolved.profile_hover_student_phone,
+            profile_hover_parent_email: resolved.profile_hover_parent_email,
+            profile_hover_parent_phone: resolved.profile_hover_parent_phone,
+            profile_hover_student_geo: resolved.profile_hover_student_geo,
+            profile_hover_parent_geo: resolved.profile_hover_parent_geo,
+            profile_hover_student_submitted_address: resolved.profile_hover_student_submitted_address,
+            profile_hover_parent_address: resolved.profile_hover_parent_address,
+          },
+        }))
+      } catch (error) {
+        console.error('[table display] family-context hover fetch failed', error)
+      } finally {
+        loadingEnrichmentProfileIdsRef.current.delete(profileId)
+      }
+    })()
   }
 
   const effectiveSelectedValuesForColumn = (column: string, allOptionsForColumn: string[]) => {
@@ -2024,6 +2100,12 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                           onClick={() => {
                             if (!filterable) return
                             appendFilter(column, cellValue)
+                          }}
+                          onMouseEnter={() => {
+                            if (!isWorkshopEnrollment || column !== 'profile_display') return
+                            const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+                            if (!profileId) return
+                            requestFamilyContextForProfile(profileId)
                           }}
                         >
                           {hoverCardData ? (

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -169,6 +169,10 @@ const FAMILY_CONTEXT_COLUMNS = new Set([
   'profile_hover_student_submitted_address',
   'profile_hover_parent_address',
 ])
+const WORKSHOP_FILTER_ENRICHMENT_COLUMNS = new Set([
+  ...Array.from(WORKSHOP_ENRICHMENT_COLUMNS),
+  ...Array.from(FAMILY_CONTEXT_COLUMNS),
+])
 const DEFAULT_COLUMN_WIDTH = 180
 const DEFAULT_NUMERIC_COLUMN_WIDTH = 120
 const ACTIONS_COLUMN_WIDTH = 120
@@ -1046,6 +1050,18 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
   const totalRows = derivedRows.length
   const totalPages = Math.max(1, Math.ceil(totalRows / pageSize))
   const effectivePage = Math.min(page, totalPages)
+  const hasActiveEnrichmentBackedFilters = useMemo(
+    () => Object.keys(filters).some(column => WORKSHOP_FILTER_ENRICHMENT_COLUMNS.has(column)),
+    [filters]
+  )
+  const baseFiltersForEnrichmentFetch = useMemo(() => {
+    const next: Record<string, string[]> = {}
+    for (const [column, values] of Object.entries(filters)) {
+      if (WORKSHOP_FILTER_ENRICHMENT_COLUMNS.has(column)) continue
+      next[column] = values
+    }
+    return next
+  }, [filters])
 
   useEffect(() => {
     if (effectivePage === page) return
@@ -1067,9 +1083,13 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
     if (!shouldLoadWorkshopValues && !shouldLoadFamilyContext) return
 
+    const enrichmentSeedRows = hasActiveEnrichmentBackedFilters
+      ? rows.filter(row => rowMatchesFilters(row, baseFiltersForEnrichmentFetch))
+      : paginatedRows
+
     const missingProfileIds = Array.from(
       new Set(
-        paginatedRows
+        enrichmentSeedRows
           .map(row => (typeof row.profile_id === 'string' ? row.profile_id : ''))
           .filter(profileId =>
             Boolean(profileId) &&
@@ -1156,7 +1176,15 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     return () => {
       abortController.abort()
     }
-  }, [columns, enrichmentByProfileId, isWorkshopEnrollmentTable, paginatedRows])
+  }, [
+    baseFiltersForEnrichmentFetch,
+    columns,
+    enrichmentByProfileId,
+    hasActiveEnrichmentBackedFilters,
+    isWorkshopEnrollmentTable,
+    paginatedRows,
+    rows,
+  ])
 
   useEffect(() => {
     if (!isFederalDistrictTable) return
@@ -1592,6 +1620,19 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
   const openFilterSelectedValues = openFilterColumn
     ? effectiveSelectedValuesForColumn(openFilterColumn, openFilterOptions)
     : []
+  const isOpenFilterApplied = openFilterColumn ? hasOwn(filters, openFilterColumn) : false
+
+  const clearOpenFilter = () => {
+    if (!openFilterColumn) return
+    setFilters(prev => {
+      if (!hasOwn(prev, openFilterColumn)) return prev
+      const next = { ...prev }
+      delete next[openFilterColumn]
+      setPage(1)
+      syncSearch(next, sortColumn, sortStage, 1, pageSize)
+      return next
+    })
+  }
 
   const selectVisibleFilterOptions = () => {
     if (!openFilterColumn) return
@@ -1603,6 +1644,10 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
   const clearVisibleFilterOptions = () => {
     if (!openFilterColumn) return
+    if (!canRenderFilterOptionsList) {
+      clearOpenFilter()
+      return
+    }
     const allOptionsForColumn = openFilterOptions
     const current = effectiveSelectedValuesForColumn(openFilterColumn, allOptionsForColumn)
     const visibleSet = new Set(visibleFilterOptions)
@@ -2151,8 +2196,17 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                 </button>
                 <button
                   type="button"
+                  onClick={clearOpenFilter}
+                  disabled={!isOpenFilterApplied}
+                  aria-label="Clear current filter"
+                  className="rounded border border-input px-2 py-1 hover:bg-muted"
+                >
+                  Clear filter
+                </button>
+                <button
+                  type="button"
                   onClick={clearVisibleFilterOptions}
-                  disabled={!canRenderFilterOptionsList}
+                  disabled={!canRenderFilterOptionsList && !isOpenFilterApplied}
                   aria-label="Clear visible options"
                   className="rounded border border-input px-2 py-1 hover:bg-muted"
                 >

--- a/web/app/routes/manage/table-loader.ts
+++ b/web/app/routes/manage/table-loader.ts
@@ -301,7 +301,10 @@ const foreignKeyOptions = async (
 }
 
 export function createTableLoader(tableName: string) {
-  return async function loader({ request }: LoaderFunctionArgs) {
+  return async function loader(
+    { request }: LoaderFunctionArgs,
+    options?: { includeForeignKeyOptions?: boolean }
+  ) {
     const definition = TABLE_DEFINITIONS[tableName]
     if (!definition) {
       throw new Response('Table not found', { status: 404 })
@@ -429,7 +432,8 @@ export function createTableLoader(tableName: string) {
     }
 
     const editorConfig = definition.editor
-    const fkOptions = editorConfig ? await foreignKeyOptions(supabase, tableName) : {}
+    const includeForeignKeyOptions = options?.includeForeignKeyOptions ?? true
+    const fkOptions = editorConfig && includeForeignKeyOptions ? await foreignKeyOptions(supabase, tableName) : {}
 
     return {
       columns: definition.columns,

--- a/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
+++ b/web/app/routes/manage/workshop-enrollment-enrichment.server.ts
@@ -86,19 +86,19 @@ const normalizeText = (value: unknown) =>
 
 const toRidingStatusLabel = (status: string | null, error: string | null) => {
   if (status === 'matched') {
-    return 'Lookup matched (district missing)'
+    return '0. Lookup matched (district missing)'
   }
   if (status === 'not_found') {
     if (error === 'district_not_seeded') {
-      return 'District not seeded'
+      return '0. District not seeded'
     }
-    return 'Postcode not found'
+    return '0. Postcode not found'
   }
   if (status === 'error') {
-    return `Lookup error${error ? ` (${error})` : ''}`
+    return `0. Lookup error${error ? ` (${error})` : ''}`
   }
   if (status) {
-    return `Lookup ${status}`
+    return `0. Lookup ${status}`
   }
   return null
 }
@@ -577,7 +577,7 @@ export async function loadWorkshopEnrollmentEnrichment(profileIds: string[]) {
       ? toRidingStatusLabel(statusProfile.riding_lookup_status, statusProfile.riding_lookup_error)
       : null
 
-    const ridingDisplay = explicitRiding ?? ridingStatusLabel ?? 'Not looked up'
+    const ridingDisplay = explicitRiding ?? ridingStatusLabel ?? '0. Not looked up'
 
     const candidateProfileIds: string[] = []
     const addCandidate = (candidateId: string | null) => {

--- a/web/tests/e2e/manage-workshop-filter-loading.spec.ts
+++ b/web/tests/e2e/manage-workshop-filter-loading.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  ensureReusableAdminAccount,
+  getAdminSupabaseClient,
+  hasAdminServiceEnv,
+  loginAsAdmin,
+} from './helpers/admin-account'
+
+const seedPriorParticipationAnswer = async () => {
+  const adminSupabase = getAdminSupabaseClient()
+
+  const { data: enrollmentRow, error: enrollmentError } = await adminSupabase
+    .from('workshop_enrollment')
+    .select('profile_id')
+    .not('profile_id', 'is', null)
+    .limit(1)
+    .maybeSingle()
+
+  if (enrollmentError || !enrollmentRow?.profile_id) {
+    throw new Error(enrollmentError?.message ?? 'Unable to find workshop enrollment with profile_id')
+  }
+
+  const { data: formRow, error: formError } = await adminSupabase
+    .from('form')
+    .select('id')
+    .limit(1)
+    .maybeSingle()
+
+  if (formError || !formRow?.id) {
+    throw new Error(formError?.message ?? 'Unable to find form for submission fixture')
+  }
+
+  const { data: submissionRow, error: submissionError } = await adminSupabase
+    .from('form_submission')
+    .insert({
+      form_id: formRow.id,
+      profile_id: enrollmentRow.profile_id,
+      submitted_at: new Date().toISOString(),
+      ip_address: '203.0.113.10',
+      metadata: { source: 'e2e-manage-workshop-filter-loading' },
+    })
+    .select('id')
+    .single()
+
+  if (submissionError || !submissionRow?.id) {
+    throw new Error(submissionError?.message ?? 'Unable to create submission fixture')
+  }
+
+  const { error: answerError } = await adminSupabase.from('form_answer').upsert(
+    {
+      submission_id: submissionRow.id,
+      question_code: 'child_prior_participation',
+      value: 'Yes',
+    },
+    { onConflict: 'submission_id,question_code' }
+  )
+
+  if (answerError) {
+    throw new Error(answerError.message)
+  }
+}
+
+test.describe.serial('manage workshop filter loading behavior', () => {
+  test.skip(!hasAdminServiceEnv(), 'Requires SUPABASE_URL and SUPABASE_SECRET_KEY for admin setup')
+
+  test.beforeAll(async () => {
+    await ensureReusableAdminAccount()
+    await seedPriorParticipationAnswer()
+  })
+
+  test('can clear an applied filter while options are still loading', async ({ page }) => {
+    await page.route('**/manage/workshop-enrollment/enrichment*', async route => {
+      await new Promise(resolve => setTimeout(resolve, 900))
+      await route.continue()
+    })
+
+    await loginAsAdmin(page)
+    await page.goto('/manage/workshop-enrollment?f_prior_participation_display=N/A')
+    await page.getByLabel('Filter prior_participation_display').click()
+
+    await expect(page.getByText('Loading...')).toBeVisible()
+
+    const clearFilterButton = page.getByRole('button', { name: 'Clear current filter' })
+    await expect(clearFilterButton).toBeEnabled()
+    await clearFilterButton.click()
+
+    await expect(page).not.toHaveURL(/f_prior_participation_display=/)
+  })
+
+  test('URL-applied enrichment filter still renders rows and profile hover title', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/manage/workshop-enrollment?f_prior_participation_display=N/A')
+
+    const rows = page.locator('tbody tr')
+    await expect.poll(async () => await rows.count(), { timeout: 15000 }).toBeGreaterThan(0)
+
+    const profileCell = rows.first().locator('td').nth(2)
+    const hoverTrigger = profileCell.locator('div[class*="group/hovercard"]').first()
+    await hoverTrigger.hover()
+
+    const hoverPanel = profileCell.locator('div[class*="group/hovercard"] > div.absolute')
+    await expect(hoverPanel).toBeVisible({ timeout: 5000 })
+
+    const hoverTitle = hoverPanel.locator('p.font-semibold').first()
+    await expect(hoverTitle).toBeVisible()
+    await expect(hoverTitle).not.toHaveText(/^\s*$/)
+  })
+})


### PR DESCRIPTION
## What changed
- show riding lookup status messages in workshop enrollment when district is missing
- prefix unresolved riding statuses with `0.` so they sort to top in filter options
- enhance riding retry page with per-profile attempt details and paced/backoff retries
- move riding editing into the person overview as editable personal info using riding combobox

## Verification
- npm run typecheck (web)
