### PR TITLE
Refine enrollment flow, invite recovery, and manage person editors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,48 @@
 # AGENTS.md
 
 ## Repo boundaries
-- Main product lives in `web/` (React Router v7 SSR + Vite + TypeScript + Supabase); run Node commands from `web/`.
-- Root `package.json` has shared dependencies only; no root scripts.
-- `zoom-api/` is a separate Python FastAPI service with its own workflow (`zoom-api/CLAUDE.md`).
+- Main product is `web/` (React Router v7 SSR + Vite + TypeScript + Supabase); run app Node commands in `web/`.
+- Root `package.json` has dependencies only (no scripts); do not assume root-level app tasks.
+- `zoom-api/` is a separate Python FastAPI service; follow `zoom-api/CLAUDE.md` for work in that subtree.
 
 ## App wiring that is easy to miss
-- Routes are declared manually in `web/app/routes.ts`; adding a route file alone is not enough.
-- Auth/onboarding guard entrypoints are `web/app/root.tsx` and `web/app/lib/auth.server.ts`.
-- `~/` and `@/` both map to `web/app/*` (`web/tsconfig.json`).
-- `createClient()` in `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; forward `headers` on redirects/responses or auth cookies break.
+- Routes are declared manually in `web/app/routes.ts`; creating a route file without registration still 404s.
+- Auth/onboarding guard logic is split between `web/app/root.tsx` and `web/app/lib/auth.server.ts`.
+- `~/` and `@/` both alias to `web/app/*` (`web/tsconfig.json`).
+- `createClient()` in `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; always forward `headers` on redirect/response writes or auth cookies break.
 - Do not edit generated router types in `web/.react-router/types/`.
 
 ## Local setup and env
-- Initial setup from repo root: `cp web/.env.template web/.env.local`.
-- Start Supabase from repo root: `supabase start --debug`; then `supabase status -o json` and copy values into `web/.env.local`.
-- Playwright/dev default URL is `http://localhost:5173`.
-- `ONBOARDING_MODE` defaults to `role` unless set to `permission` (`web/app/lib/auth.server.ts`).
-- Keep `SUPABASE_SECRET_KEY` server-only (never expose from loaders/client code).
+- Bootstrap local env from repo root: `cp web/.env.template web/.env.local`.
+- Start Supabase from repo root: `supabase start --debug`, then copy `supabase status -o json` values into `web/.env.local`.
+- `web/.env.template` defaults `ONBOARDING_MODE=role`; only `permission` enables permission-gated onboarding behavior.
+- Keep `SUPABASE_SECRET_KEY` server-only (for example `web/app/lib/supabase/adminClient.ts`), never exposed from loaders/client code.
+- `supabase/config.toml` seeds app + sanitized prod snapshot by default (`./seeds/prod-data/*-sanitized.sql`), not dummy fixtures.
 
 ## Commands and focused verification
-- Install deps: `npm ci` (in `web/`).
-- Dev: `npm run dev`.
-- Typecheck (also regenerates route types): `npm run typecheck`.
-- Build smoke: `npm run build && npm run start`.
-- Full Playwright run: `npm run test`.
+- Install deps in app workspace: `npm ci` (run in `web/`).
+- Dev server: `npm run dev`.
+- Typecheck + route type generation: `npm run typecheck`.
+- Build smoke test: `npm run build && npm run start`.
+- Full test run: `npm run test`.
 - Focused e2e: `npm run test:e2e -- tests/e2e/guardian-signup-enroll.spec.ts --grep "..."`.
-- Unit subset: `npm run test:unit` (targets `web/tests/unit`).
+- Unit subset uses Playwright too: `npm run test:unit`.
 
-## Test and CI quirks
-- If `PLAYWRIGHT_BASE_URL` is unset, Playwright starts `npm run dev -- --port 5173` automatically (`web/playwright.config.ts`).
-- Admin e2e helpers require service-role env (`SUPABASE_URL` + `SUPABASE_SECRET_KEY`) from process env or `web/.env.local`; related tests skip without them.
-- CI (`.github/workflows/tests.yml`) runs: `npm ci` -> Playwright browser install -> `supabase start --debug` -> write `web/.env.local` from `supabase status` -> `npm run test`.
+## Test quirks
+- If `PLAYWRIGHT_BASE_URL` is unset, Playwright auto-starts `npm run dev -- --port 5173` (`web/playwright.config.ts`).
+- Admin e2e helpers require `SUPABASE_URL` + `SUPABASE_SECRET_KEY` (process env or `web/.env.local`); those tests skip when missing.
 
 ## Database and auth conventions
-- Source of truth is declarative SQL in `supabase/schemas/`; do not hand-edit existing `supabase/migrations/*`.
-- Schema change flow (repo root): edit `supabase/schemas/*` -> `supabase db diff -f <name>` -> `supabase migration up`.
-- After schema changes, regenerate types:
+- Treat declarative SQL in `supabase/schemas/` as source of truth; do not hand-edit existing `supabase/migrations/*`.
+- Schema flow (repo root): edit `supabase/schemas/*` -> `supabase db diff -f <name>` -> `supabase migration up`.
+- After schema changes, regenerate DB types:
   `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
-- New features/tables must include `app_permissions`, `role_permission` seed updates, and RLS policies in the same change.
-- Treat JWT claims / `public.user_roles` as auth truth; `auth.users.raw_user_meta_data.role` can drift.
+- New features/tables must ship with `app_permissions`, `role_permission` seed updates, and RLS policy updates in the same change.
+- Treat JWT claims and `public.user_roles` as auth truth; `auth.users.raw_user_meta_data.role` can drift.
 
 ## Known failure modes
-- Correct signup details route is `/auth/sign-up-details` (hyphenated); `/auth/signup-details` 404s.
-- Keep onboarding completion checks aligned between `enforceOnboardingGuard` and `web/app/routes/auth/sign-up-details.tsx` to avoid redirect loops.
-- In manage loaders, prefer `public.profile` lookups by `user_id` over `auth.users` for email/name display fields.
-- Batch large Supabase `.in(...)` lookup lists to avoid production fetch/gateway failures.
-- Email templates are configured in `supabase/config.toml` and stored in `supabase/templates/*.html`.
+- Correct signup details route is `/auth/sign-up-details`; `/auth/signup-details` is wrong.
+- Keep onboarding completion logic aligned between `enforceOnboardingGuard` and `web/app/routes/auth/sign-up-details.tsx` to avoid redirect loops.
+- In manage loaders, prefer `public.profile` lookups by `user_id` over `auth.users` for display fields.
+- Batch large Supabase `.in(...)` lookup lists to avoid gateway/fetch failures on production-sized data.
+- Auth email templates are configured in `supabase/config.toml` and loaded from `supabase/templates/*.html`.

--- a/supabase/migrations/20260627120000_enforce_family_enrollment_guard.sql
+++ b/supabase/migrations/20260627120000_enforce_family_enrollment_guard.sql
@@ -1,0 +1,102 @@
+-- Enforce cap/waitlist guardrails for family self-enrollment path.
+-- Staff status updates remain intentionally unrestricted.
+
+drop function if exists public.request_family_workshop_enrollment(uuid, uuid, uuid[], uuid);
+
+create or replace function public.request_family_workshop_enrollment(
+  p_workshop_id uuid,
+  p_profile_id uuid,
+  p_family_profile_ids uuid[]
+)
+returns table (
+  ok boolean,
+  enrollment_id uuid,
+  enrollment_status public.workshop_enrollment_status,
+  error_code text,
+  error_message text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_workshop public.workshop%rowtype;
+  v_now timestamptz := now();
+  v_existing_enrollment_id uuid;
+  v_approved_count integer;
+  v_waitlisted_count integer;
+  v_status public.workshop_enrollment_status;
+  v_inserted_id uuid;
+begin
+  if p_workshop_id is null or p_profile_id is null then
+    return query
+      select false, null::uuid, null::public.workshop_enrollment_status, 'invalid_input', 'Missing workshop or profile id';
+    return;
+  end if;
+
+  select *
+  into v_workshop
+  from public.workshop
+  where id = p_workshop_id
+  for update;
+
+  if not found then
+    return query
+      select false, null::uuid, null::public.workshop_enrollment_status, 'workshop_not_found', 'Workshop not found';
+    return;
+  end if;
+
+  if (
+    (v_workshop.enrollment_open_at is not null and v_now < v_workshop.enrollment_open_at)
+    or (v_workshop.enrollment_close_at is not null and v_now > v_workshop.enrollment_close_at)
+  ) then
+    return query
+      select false, null::uuid, null::public.workshop_enrollment_status, 'enrollment_closed', 'Enrollment is closed for this workshop';
+    return;
+  end if;
+
+  select we.id
+  into v_existing_enrollment_id
+  from public.workshop_enrollment we
+  where we.semester_id = v_workshop.semester_id
+    and we.profile_id = any(coalesce(p_family_profile_ids, array[]::uuid[]))
+  limit 1;
+
+  if v_existing_enrollment_id is not null then
+    return query
+      select false, null::uuid, null::public.workshop_enrollment_status, 'family_already_enrolled', 'Your family is already enrolled in one workshop for this semester.';
+    return;
+  end if;
+
+  select count(*)::integer
+  into v_approved_count
+  from public.workshop_enrollment
+  where workshop_id = p_workshop_id
+    and status = 'approved';
+
+  select count(*)::integer
+  into v_waitlisted_count
+  from public.workshop_enrollment
+  where workshop_id = p_workshop_id
+    and status = 'waitlisted';
+
+  if v_approved_count < greatest(coalesce(v_workshop.capacity, 0), 0) then
+    v_status := 'pending';
+  elsif v_waitlisted_count < greatest(coalesce(v_workshop.wait_list_capacity, 0), 0) then
+    v_status := 'waitlisted';
+  else
+    return query
+      select false, null::uuid, null::public.workshop_enrollment_status, 'workshop_full', 'This workshop and its waitlist are full';
+    return;
+  end if;
+
+  insert into public.workshop_enrollment (workshop_id, profile_id, status)
+  values (p_workshop_id, p_profile_id, v_status)
+  returning id into v_inserted_id;
+
+  return query select true, v_inserted_id, v_status, null::text, null::text;
+end;
+$$;
+
+revoke all on function public.request_family_workshop_enrollment(uuid, uuid, uuid[]) from public, anon, authenticated;
+grant execute on function public.request_family_workshop_enrollment(uuid, uuid, uuid[]) to service_role, supabase_auth_admin;

--- a/supabase/schemas/03_semesters_cohorts_classes.sql
+++ b/supabase/schemas/03_semesters_cohorts_classes.sql
@@ -214,6 +214,96 @@ begin
 end;
 $$;
 
+create or replace function public.request_family_workshop_enrollment(
+  p_workshop_id uuid,
+  p_profile_id uuid,
+  p_family_profile_ids uuid[]
+)
+returns table (
+  ok boolean,
+  enrollment_id uuid,
+  enrollment_status public.workshop_enrollment_status,
+  error_code text,
+  error_message text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_workshop public.workshop%rowtype;
+  v_now timestamptz := now();
+  v_existing_enrollment_id uuid;
+  v_approved_count integer;
+  v_waitlisted_count integer;
+  v_status public.workshop_enrollment_status;
+  v_inserted_id uuid;
+begin
+  if p_workshop_id is null or p_profile_id is null then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'invalid_input', 'Missing workshop or profile id';
+    return;
+  end if;
+
+  select *
+  into v_workshop
+  from public.workshop
+  where id = p_workshop_id
+  for update;
+
+  if not found then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'workshop_not_found', 'Workshop not found';
+    return;
+  end if;
+
+  if (
+    (v_workshop.enrollment_open_at is not null and v_now < v_workshop.enrollment_open_at)
+    or (v_workshop.enrollment_close_at is not null and v_now > v_workshop.enrollment_close_at)
+  ) then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'enrollment_closed', 'Enrollment is closed for this workshop';
+    return;
+  end if;
+
+  select we.id
+  into v_existing_enrollment_id
+  from public.workshop_enrollment we
+  where we.semester_id = v_workshop.semester_id
+    and we.profile_id = any(coalesce(p_family_profile_ids, array[]::uuid[]))
+  limit 1;
+
+  if v_existing_enrollment_id is not null then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'family_already_enrolled', 'Your family is already enrolled in one workshop for this semester.';
+    return;
+  end if;
+
+  select count(*)::integer
+  into v_approved_count
+  from public.workshop_enrollment
+  where workshop_id = p_workshop_id
+    and status = 'approved';
+
+  select count(*)::integer
+  into v_waitlisted_count
+  from public.workshop_enrollment
+  where workshop_id = p_workshop_id
+    and status = 'waitlisted';
+
+  if v_approved_count < greatest(coalesce(v_workshop.capacity, 0), 0) then
+    v_status := 'pending';
+  elsif v_waitlisted_count < greatest(coalesce(v_workshop.wait_list_capacity, 0), 0) then
+    v_status := 'waitlisted';
+  else
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'workshop_full', 'This workshop and its waitlist are full';
+    return;
+  end if;
+
+  insert into public.workshop_enrollment (workshop_id, profile_id, status)
+  values (p_workshop_id, p_profile_id, v_status)
+  returning id into v_inserted_id;
+
+  return query select true, v_inserted_id, v_status, null::text, null::text;
+end;
+$$;
+
 drop trigger if exists on_workshop_enrollment_set_decision_fields on public.workshop_enrollment;
 create trigger on_workshop_enrollment_set_decision_fields
 before update on public.workshop_enrollment
@@ -447,3 +537,6 @@ grant all on table public.workshop to authenticated;
 grant all on table public.class to authenticated;
 grant all on table public.class_attendance to authenticated;
 grant all on table public.workshop_enrollment to authenticated;
+
+revoke all on function public.request_family_workshop_enrollment(uuid, uuid, uuid[]) from public, anon, authenticated;
+grant execute on function public.request_family_workshop_enrollment(uuid, uuid, uuid[]) to service_role, supabase_auth_admin;

--- a/supabase/seeds/app-data/00-prod-semester-anchor.sql
+++ b/supabase/seeds/app-data/00-prod-semester-anchor.sql
@@ -1,0 +1,28 @@
+-- Anchor the runtime semester used by the production snapshot workshop seeds.
+-- Keep this id and window aligned with supabase/seeds/prod-data/20260624-raw*.sql.
+
+insert into public.semester (
+  id,
+  starts_at,
+  ends_at,
+  enrollment_open_at,
+  enrollment_close_at,
+  name,
+  description
+)
+values (
+  '95b4cdf4-01fa-4c33-9863-506d4f6e91c2',
+  '2026-06-29 04:00:00+00',
+  '2026-08-21 03:59:00+00',
+  '2026-05-15 04:00:00+00',
+  '2026-06-30 03:59:00+00',
+  '26 Summer',
+  null
+)
+on conflict (id) do update
+set starts_at = excluded.starts_at,
+    ends_at = excluded.ends_at,
+    enrollment_open_at = excluded.enrollment_open_at,
+    enrollment_close_at = excluded.enrollment_close_at,
+    name = excluded.name,
+    description = excluded.description;

--- a/web/app/routes/auth/waiting-on-guardian.tsx
+++ b/web/app/routes/auth/waiting-on-guardian.tsx
@@ -119,10 +119,10 @@ const sendGuardianInvite = async ({
     )
 
   if (inviteTableError) {
-    return { error: inviteTableError.message }
+    return { error: inviteTableError.message, inviteeUserId }
   }
 
-  return { error: null }
+  return { error: null, inviteeUserId }
 }
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -257,6 +257,33 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   if (inviteResult.error) {
     return { error: inviteResult.error }
+  }
+
+  if (inviteResult.inviteeUserId) {
+    const { error: roleSeedError } = await adminClient
+      .from('user_roles')
+      .upsert(
+        {
+          user_id: inviteResult.inviteeUserId,
+          role: 'guardian',
+          assigned_by: inviteResult.inviteeUserId,
+        },
+        { onConflict: 'user_id' }
+      )
+
+    if (roleSeedError) {
+      return { error: roleSeedError.message }
+    }
+
+    const { error: profileLinkError } = await adminClient
+      .from('profile')
+      .update({ user_id: inviteResult.inviteeUserId })
+      .eq('id', guardianId)
+      .eq('role', 'guardian')
+
+    if (profileLinkError) {
+      return { error: profileLinkError.message }
+    }
   }
 
   return { ok: true, message: `Invite resent to ${guardianProfile.email}` }

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -56,6 +56,14 @@ type ActionData = {
   error?: string
 }
 
+type EnrollmentRequestResult = {
+  ok: boolean
+  enrollment_id: string | null
+  enrollment_status: 'pending' | 'waitlisted' | 'approved' | 'rejected' | 'revoked' | null
+  error_code: string | null
+  error_message: string | null
+}
+
 const ENROLLMENT_SUCCESS_MESSAGE =
   "Thank you for registering for summerlunch+! We're excited to welcome your family this summer. Your registration has been received and is currently pending approval. Our team will review your information and send you a confirmation email shortly with your program details, class schedule, and next steps."
 
@@ -183,7 +191,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const workshopIds = workshops.map(workshop => workshop.id)
   const [workshopEnrollmentResult, upcomingClassesResult] = await Promise.all([
     workshopIds.length
-      ? supabase
+      ? adminClient
           .from('workshop_enrollment')
           .select('workshop_id, status')
           .in('workshop_id', workshopIds)
@@ -302,26 +310,6 @@ export async function action({ request }: Route.ActionArgs) {
     return { error: 'Workshop not found' } satisfies ActionData
   }
 
-  const nowIso = new Date().toISOString()
-  const enrollmentOpenAt = workshopRow.enrollment_open_at
-  const enrollmentCloseAt = workshopRow.enrollment_close_at
-  const isOpen = (!enrollmentOpenAt || nowIso >= enrollmentOpenAt) && (!enrollmentCloseAt || nowIso <= enrollmentCloseAt)
-  if (!isOpen) {
-    return { error: 'Enrollment is closed for this workshop' } satisfies ActionData
-  }
-
-  const { data: existingEnrollment } = await supabase
-    .from('workshop_enrollment')
-    .select('id')
-    .eq('semester_id', workshopRow.semester_id)
-    .in('profile_id', family.familyProfileIds)
-    .limit(1)
-    .maybeSingle()
-
-  if (existingEnrollment?.id) {
-    return { error: 'Your family is already enrolled in one workshop for this semester.' } satisfies ActionData
-  }
-
   const targetProfileId = getFamilyEnrollmentProfileId(family)
   if (!targetProfileId) {
     return { error: 'Family enrollment profile not found.' } satisfies ActionData
@@ -348,46 +336,27 @@ export async function action({ request }: Route.ActionArgs) {
     return { error: 'Please complete the pre-program survey before enrolling.' } satisfies ActionData
   }
 
-  const { data: workshopEnrollments } = await supabase
-    .from('workshop_enrollment')
-    .select('workshop_id, status')
-    .eq('workshop_id', workshop_id)
-
-  const capacitySnapshot = buildWorkshopCapacityMap(
-    [
-      {
-        id: workshop_id,
-        capacity: workshopRow.capacity,
-        wait_list_capacity: workshopRow.wait_list_capacity,
-      },
-    ],
-    workshopEnrollments ?? []
-  ).get(workshop_id)
-
-  if (!capacitySnapshot) {
-    return { error: 'Unable to evaluate workshop capacity' } satisfies ActionData
-  }
-
-  const enrollmentAction = getWorkshopEnrollmentAction(capacitySnapshot)
-  if (enrollmentAction === 'full') {
-    return { error: 'This workshop and its waitlist are full' } satisfies ActionData
-  }
-
-  const status = enrollmentAction === 'waitlist' ? 'waitlisted' : 'pending'
-
-  const { data: enrollmentRow, error: enrollmentError } = await supabase
-    .from('workshop_enrollment')
-    .insert({
-      workshop_id,
-      profile_id: targetProfileId,
-      status,
+  const { data: enrollmentResult, error: enrollmentRequestError } = await adminClient
+    .rpc('request_family_workshop_enrollment', {
+      p_workshop_id: workshop_id,
+      p_profile_id: targetProfileId,
+      p_family_profile_ids: family.familyProfileIds,
     })
-    .select('id')
     .single()
 
-  if (enrollmentError || !enrollmentRow?.id) {
-    return { error: enrollmentError?.message ?? 'Unable to create enrollment' } satisfies ActionData
+  const enrollmentRequest = enrollmentResult as EnrollmentRequestResult | null
+
+  if (enrollmentRequestError) {
+    return { error: enrollmentRequestError.message ?? 'Unable to create enrollment' } satisfies ActionData
   }
+
+  if (!enrollmentRequest?.ok || !enrollmentRequest.enrollment_id) {
+    return {
+      error: enrollmentRequest?.error_message ?? 'Unable to create enrollment',
+    } satisfies ActionData
+  }
+
+  const enrollmentId = enrollmentRequest.enrollment_id
 
   const { data: familyProfilesData } = await adminClient
     .from('profile')
@@ -424,7 +393,7 @@ export async function action({ request }: Route.ActionArgs) {
     }
   }
 
-  const notificationEventKey = `workshop_enrollment:${enrollmentRow.id}:family_requested:v1`
+  const notificationEventKey = `workshop_enrollment:${enrollmentId}:family_requested:v1`
   setTimeout(() => {
     void Promise.all(
       Array.from(emailByLowercase.entries()).map(async ([normalizedEmail, recipient]) => {
@@ -441,7 +410,7 @@ export async function action({ request }: Route.ActionArgs) {
           recipientUserId: recipient.userId,
           profileId: recipient.profileId,
           familyProfileId: targetProfileId,
-          workshopEnrollmentId: enrollmentRow.id,
+          workshopEnrollmentId: enrollmentId,
         })
       })
     )
@@ -449,14 +418,14 @@ export async function action({ request }: Route.ActionArgs) {
         const failedNotifications = notificationResults.filter(result => result.status === 'failed')
         if (failedNotifications.length > 0) {
           console.error('[enroll] failed to send some family enrollment notifications', {
-            workshopEnrollmentId: enrollmentRow.id,
+            workshopEnrollmentId: enrollmentId,
             failures: failedNotifications,
           })
         }
       })
       .catch(error => {
         console.error('[enroll] notification dispatch failed', {
-          workshopEnrollmentId: enrollmentRow.id,
+          workshopEnrollmentId: enrollmentId,
           error,
         })
       })

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -4,7 +4,7 @@ import { useFetcher, useLocation, useOutletContext } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Combobox } from '@/components/ui/combobox'
 import type { PersonLoaderData } from './person.shared'
-import { formatDate, formatDateTime } from './person.shared'
+import { formatDate, formatDateTime, profileLabel } from './person.shared'
 
 const geoStatusLabel: Record<PersonLoaderData['ipEvidence'][number]['geo_status'], string> = {
   geo_available: 'Geo available',
@@ -18,7 +18,8 @@ const geoStatusLabel: Record<PersonLoaderData['ipEvidence'][number]['geo_status'
 export default function ManagePersonOverviewPage() {
   const { profile, ipEvidence, familyProfiles, primaryChildByGuardian, federalDistrictOptions } = useOutletContext<PersonLoaderData>()
   const location = useLocation()
-  const ridingFetcher = useFetcher<{ error?: string; success?: boolean }>()
+  const selectedRidingFetcher = useFetcher<{ error?: string; success?: boolean }>()
+  const relatedRidingFetcher = useFetcher<{ error?: string; success?: boolean }>()
   const [selectedRiding, setSelectedRiding] = useState(profile.federal_electoral_district_name ?? '')
 
   useEffect(() => {
@@ -51,6 +52,11 @@ export default function ManagePersonOverviewPage() {
         .filter(Boolean)
         .join(', ')
     : ''
+  const [relatedRiding, setRelatedRiding] = useState(relatedProfile?.federal_electoral_district_name ?? '')
+
+  useEffect(() => {
+    setRelatedRiding(relatedProfile?.federal_electoral_district_name ?? '')
+  }, [relatedProfile?.id, relatedProfile?.federal_electoral_district_name])
 
   return (
     <section className="rounded-lg border bg-card p-4">
@@ -59,36 +65,31 @@ export default function ManagePersonOverviewPage() {
         <div className="rounded-md border bg-muted/20 p-3 text-sm">
           <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Selected profile</h3>
           <div className="grid gap-2">
-            <p><span className="font-medium">Profile ID:</span> {profile.id}</p>
-            <p><span className="font-medium">User ID:</span> {profile.user_id ?? '-'}</p>
+            <p><span className="font-medium">Name:</span> {profileLabel(profile)}</p>
             <p><span className="font-medium">Role:</span> {profile.role ?? '-'}</p>
             <p><span className="font-medium">Email:</span> {profile.email ?? '-'}</p>
             <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
             <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
             <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
-            <div className="space-y-2 rounded border bg-background p-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Riding</p>
-              <p>
-                <span className="font-medium">Lookup status:</span> {profile.riding_lookup_status ?? 'not_attempted'}
-                {profile.riding_lookup_error ? ` (${profile.riding_lookup_error})` : ''}
-              </p>
-              <ridingFetcher.Form method="post" action={`/manage/person${location.search}`} className="space-y-2">
+            <div>
+              <selectedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="flex flex-wrap items-center gap-2">
                 <input type="hidden" name="intent" value="update-riding" />
                 <input type="hidden" name="profile_id" value={profile.id} />
                 <input type="hidden" name="riding_name" value={selectedRiding} />
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Riding</span>
                 <Combobox
                   value={selectedRiding}
                   onChange={setSelectedRiding}
                   options={[{ value: '', label: 'Unassigned' }, ...federalDistrictOptions]}
                   placeholder="Select riding"
-                  disabled={ridingFetcher.state !== 'idle'}
+                  disabled={selectedRidingFetcher.state !== 'idle'}
                 />
-                <Button type="submit" size="sm" variant="outline" disabled={ridingFetcher.state !== 'idle'}>
-                  {ridingFetcher.state !== 'idle' ? 'Saving...' : 'Save riding'}
+                <Button type="submit" size="sm" variant="outline" disabled={selectedRidingFetcher.state !== 'idle'}>
+                  {selectedRidingFetcher.state !== 'idle' ? 'Saving...' : 'Save riding'}
                 </Button>
-                {ridingFetcher.data?.error ? <p className="text-xs text-destructive">{ridingFetcher.data.error}</p> : null}
-                {ridingFetcher.data?.success ? <p className="text-xs text-emerald-600">Riding updated.</p> : null}
-              </ridingFetcher.Form>
+                {selectedRidingFetcher.data?.error ? <p className="basis-full text-xs text-destructive">{selectedRidingFetcher.data.error}</p> : null}
+                {selectedRidingFetcher.data?.success ? <p className="basis-full text-xs text-emerald-600">Riding updated.</p> : null}
+              </selectedRidingFetcher.Form>
             </div>
           </div>
         </div>
@@ -96,17 +97,34 @@ export default function ManagePersonOverviewPage() {
         <div className="rounded-md border bg-muted/20 p-3 text-sm">
           <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {profile.role === 'guardian' ? 'Primary child profile' : 'Related guardian profile'}
+            {relatedProfile ? `: ${profileLabel(relatedProfile)}` : ''}
           </h3>
           {relatedProfile ? (
             <div className="grid gap-2">
-              <p><span className="font-medium">Profile ID:</span> {relatedProfile.id}</p>
-              <p><span className="font-medium">User ID:</span> {relatedProfile.user_id ?? '-'}</p>
+              <p><span className="font-medium">Name:</span> {profileLabel(relatedProfile)}</p>
               <p><span className="font-medium">Role:</span> {relatedProfile.role ?? '-'}</p>
               <p><span className="font-medium">Email:</span> {relatedProfile.email ?? '-'}</p>
               <p><span className="font-medium">Phone:</span> {relatedProfile.phone ?? '-'}</p>
               <p><span className="font-medium">DOB:</span> {formatDate(relatedProfile.date_of_birth)}</p>
               <p><span className="font-medium">Address:</span> {relatedAddress || '-'}</p>
-              <p><span className="font-medium">Riding:</span> {relatedProfile.federal_electoral_district_name ?? '-'}</p>
+              <relatedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="flex flex-wrap items-center gap-2">
+                <input type="hidden" name="intent" value="update-riding" />
+                <input type="hidden" name="profile_id" value={relatedProfile.id} />
+                <input type="hidden" name="riding_name" value={relatedRiding} />
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Riding</span>
+                <Combobox
+                  value={relatedRiding}
+                  onChange={setRelatedRiding}
+                  options={[{ value: '', label: 'Unassigned' }, ...federalDistrictOptions]}
+                  placeholder="Select riding"
+                  disabled={relatedRidingFetcher.state !== 'idle'}
+                />
+                <Button type="submit" size="sm" variant="outline" disabled={relatedRidingFetcher.state !== 'idle'}>
+                  {relatedRidingFetcher.state !== 'idle' ? 'Saving...' : 'Save riding'}
+                </Button>
+                {relatedRidingFetcher.data?.error ? <p className="basis-full text-xs text-destructive">{relatedRidingFetcher.data.error}</p> : null}
+                {relatedRidingFetcher.data?.success ? <p className="basis-full text-xs text-emerald-600">Riding updated.</p> : null}
+              </relatedRidingFetcher.Form>
             </div>
           ) : (
             <p className="text-muted-foreground">No related child/guardian profile found.</p>

--- a/web/app/routes/manage/person.tsx
+++ b/web/app/routes/manage/person.tsx
@@ -495,9 +495,6 @@ export async function action({ request }: LoaderFunctionArgs) {
     .from('profile')
     .update({
       federal_electoral_district_name: ridingName,
-      riding_lookup_status: ridingName ? 'matched' : 'skipped',
-      riding_lookup_error: null,
-      riding_lookup_last_attempt_at: new Date().toISOString(),
     })
     .eq('id', profileId)
 

--- a/web/app/routes/sign-up/invite.tsx
+++ b/web/app/routes/sign-up/invite.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { adminClient } from '@/lib/supabase/adminClient'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -78,24 +79,109 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return { error: 'Session unavailable' }
   }
 
+  const authUser = userData.user
+
+  const ensureLinkedProfile = async () => {
+    const { data: directProfile, error: directProfileError } = await supabase
+      .from('profile')
+      .select('id')
+      .eq('user_id', authUser.id)
+      .maybeSingle()
+
+    if (directProfileError) {
+      return { profileId: null, error: directProfileError.message }
+    }
+
+    if (directProfile?.id) {
+      return { profileId: directProfile.id, error: null }
+    }
+
+    const normalizedEmail = authUser.email?.trim().toLowerCase()
+    if (!normalizedEmail) {
+      return { profileId: null, error: 'Unable to find your profile. Please contact support.' }
+    }
+
+    const { data: inviteRoleRow } = inviteId
+      ? await adminClient.from('invites').select('role').eq('id', inviteId).maybeSingle()
+      : { data: null }
+    const inviteRole = inviteRoleRow?.role
+
+    const profileLookup = adminClient
+      .from('profile')
+      .select('id, user_id, role')
+      .eq('email', normalizedEmail)
+      .limit(1)
+
+    const { data: profileByEmail, error: profileByEmailError } =
+      inviteRole === 'guardian' || inviteRole === 'student'
+        ? await profileLookup.eq('role', inviteRole).maybeSingle()
+        : await profileLookup.maybeSingle()
+
+    if (profileByEmailError || !profileByEmail?.id) {
+      return {
+        profileId: null,
+        error: profileByEmailError?.message ?? 'Unable to find your profile. Please contact support.',
+      }
+    }
+
+    if (profileByEmail.user_id && profileByEmail.user_id !== authUser.id) {
+      return { profileId: null, error: 'This invite is already linked to another account.' }
+    }
+
+    const { error: roleSeedError } = await adminClient
+      .from('user_roles')
+      .upsert(
+        {
+          user_id: authUser.id,
+          role: profileByEmail.role,
+          assigned_by: authUser.id,
+        },
+        { onConflict: 'user_id' }
+      )
+
+    if (roleSeedError) {
+      return { profileId: null, error: roleSeedError.message }
+    }
+
+    const { error: relinkError } = await adminClient
+      .from('profile')
+      .update({ user_id: authUser.id })
+      .eq('id', profileByEmail.id)
+
+    if (relinkError) {
+      return { profileId: null, error: relinkError.message }
+    }
+
+    return { profileId: profileByEmail.id, error: null }
+  }
+
+  const { profileId, error: ensureProfileError } = await ensureLinkedProfile()
+  if (ensureProfileError || !profileId) {
+    return { error: ensureProfileError ?? 'Unable to prepare your profile. Please contact support.' }
+  }
+
   const { error: updatePasswordError } = await supabase.auth.updateUser({ password })
   if (updatePasswordError) {
     return { error: updatePasswordError.message }
   }
 
-  await supabase
+  const { error: passwordSetError } = await adminClient
     .from('profile')
     .update({ password_set: true })
-    .eq('user_id', userData.user.id)
+    .eq('id', profileId)
 
-  await supabase.rpc('sync_auto_assigned_forms_for_user', { p_user_id: userData.user.id })
+  if (passwordSetError) {
+    return { error: passwordSetError.message }
+  }
+
+  await supabase.rpc('sync_auto_assigned_forms_for_user', { p_user_id: authUser.id })
 
   if (inviteId) {
     await supabase
       .from('invites')
       .update({
         status: 'confirmed',
-        invitee_user_id: userData.user.id,
+        invitee_user_id: authUser.id,
         confirmed_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       })

--- a/web/tests/e2e/helpers/invite-links.ts
+++ b/web/tests/e2e/helpers/invite-links.ts
@@ -1,0 +1,41 @@
+import { getAdminSupabaseClient } from './admin-account'
+
+export const generateInviteLinkForEmail = async ({
+  email,
+  origin,
+  role,
+}: {
+  email: string
+  origin: string
+  role: 'guardian' | 'student'
+}) => {
+  const adminSupabase = getAdminSupabaseClient()
+  const redirectTo = `${origin}/auth/sign-up-details?role=${role}`
+  const { data, error } = await adminSupabase.auth.admin.generateLink({
+    type: 'invite',
+    email,
+    options: {
+      redirectTo,
+      data: { role },
+    },
+  })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const linkData = data as
+    | {
+        action_link?: string
+        properties?: { action_link?: string }
+      }
+    | null
+
+  const actionLink = linkData?.properties?.action_link ?? linkData?.action_link ?? null
+
+  if (!actionLink || typeof actionLink !== 'string') {
+    throw new Error('Invite link was not returned by Supabase generateLink')
+  }
+
+  return actionLink
+}

--- a/web/tests/e2e/student-resend-guardian-invite.spec.ts
+++ b/web/tests/e2e/student-resend-guardian-invite.spec.ts
@@ -1,0 +1,322 @@
+import { expect, test } from '@playwright/test'
+
+import { generateInviteLinkForEmail } from './helpers/invite-links'
+import { getAdminSupabaseClient, hasAdminServiceEnv } from './helpers/admin-account'
+
+const uniqueSuffix = () => {
+  const now = new Date()
+  return `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}${String(now.getMilliseconds()).padStart(3, '0')}`
+}
+
+const fillRequiredFields = async (page: import('@playwright/test').Page) => {
+  const form = page.locator('form').first()
+
+  const requiredTextInputs = form.locator(
+    'input[required]:not([type="hidden"]):not([type="radio"]):not([type="checkbox"])'
+  )
+
+  const inputCount = await requiredTextInputs.count()
+  for (let index = 0; index < inputCount; index += 1) {
+    const input = requiredTextInputs.nth(index)
+    const currentValue = await input.inputValue()
+    if (currentValue.trim()) continue
+
+    const inputType = (await input.getAttribute('type')) ?? 'text'
+    const inputName = ((await input.getAttribute('name')) ?? '').toLowerCase()
+
+    if (inputType === 'date') {
+      await input.fill('2012-05-10')
+      continue
+    }
+
+    if (inputType === 'number') {
+      await input.fill('2')
+      continue
+    }
+
+    if (inputType === 'email') {
+      await input.fill(`autofill+${uniqueSuffix()}@gmail.com`)
+      continue
+    }
+
+    if (inputName.includes('postcode') || inputName.includes('postal')) {
+      await input.fill('K1A 0B1')
+      continue
+    }
+
+    await input.fill('Auto value')
+  }
+
+  const requiredSelectNames = await form
+    .locator('select[required]')
+    .evaluateAll(selects =>
+      Array.from(new Set(selects.map(select => select.getAttribute('name')).filter((name): name is string => Boolean(name))))
+    )
+
+  for (const name of requiredSelectNames) {
+    const select = form.locator(`select[name="${name}"]`).first()
+    if (!(await select.isVisible())) continue
+    if (!(await select.isEnabled())) continue
+
+    const value = await select.inputValue()
+    if (value) continue
+
+    const options = await select.locator('option').all()
+    for (const option of options) {
+      const optionValue = (await option.getAttribute('value')) ?? ''
+      const disabled = (await option.getAttribute('disabled')) !== null
+      if (!optionValue || disabled) continue
+      await select.selectOption(optionValue)
+      break
+    }
+  }
+
+  const checkboxNames = await form
+    .locator('input[type="checkbox"][name^="question_"], input[type="checkbox"][required]')
+    .evaluateAll(inputs =>
+      Array.from(new Set(inputs.map(input => input.getAttribute('name')).filter((name): name is string => Boolean(name))))
+    )
+
+  for (const name of checkboxNames) {
+    const checkbox = form.locator(`input[type="checkbox"][name="${name}"]`).first()
+    if (!(await checkbox.isVisible())) continue
+    if (!(await checkbox.isEnabled())) continue
+    await checkbox.check()
+  }
+
+  const radioNames = await form
+    .locator('input[type="radio"][required]')
+    .evaluateAll(inputs =>
+      Array.from(new Set(inputs.map(input => input.getAttribute('name')).filter((name): name is string => Boolean(name))))
+    )
+
+  for (const name of radioNames) {
+    const checked = await form.locator(`input[type="radio"][name="${name}"]:checked`).count()
+    if (checked > 0) continue
+    await form.locator(`input[type="radio"][name="${name}"]`).first().check()
+  }
+}
+
+const countMissingRequiredFields = async (page: import('@playwright/test').Page) => {
+  const form = page.locator('form').first()
+  return form.evaluate(formEl => {
+    const getVisible = (element: HTMLElement) => {
+      const style = window.getComputedStyle(element)
+      return style.display !== 'none' && style.visibility !== 'hidden' && element.offsetParent !== null
+    }
+
+    let missing = 0
+
+    const requiredInputs = Array.from(
+      formEl.querySelectorAll<HTMLInputElement>('input[required]:not([type="hidden"])')
+    ).filter(input => !input.disabled && getVisible(input))
+
+    const handledRadioNames = new Set<string>()
+
+    for (const input of requiredInputs) {
+      if (input.type === 'radio') {
+        if (!input.name || handledRadioNames.has(input.name)) continue
+        handledRadioNames.add(input.name)
+        const checked = formEl.querySelector(`input[type="radio"][name="${CSS.escape(input.name)}"]:checked`)
+        if (!checked) missing += 1
+        continue
+      }
+
+      if (input.type === 'checkbox') {
+        if (!input.checked) missing += 1
+        continue
+      }
+
+      if (!input.value.trim()) missing += 1
+    }
+
+    const requiredSelects = Array.from(formEl.querySelectorAll<HTMLSelectElement>('select[required]')).filter(
+      select => !select.disabled && getVisible(select)
+    )
+
+    for (const select of requiredSelects) {
+      if (!select.value) missing += 1
+    }
+
+    return missing
+  })
+}
+
+const submitStepWithRetry = async (page: import('@playwright/test').Page, maxAttempts = 3) => {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    await fillRequiredFields(page)
+
+    const missingBeforeSubmit = await countMissingRequiredFields(page)
+    if (missingBeforeSubmit > 0) {
+      await page.waitForTimeout(400)
+      continue
+    }
+
+    const submitButton = page.locator('form button[type="submit"]').first()
+    if ((await submitButton.count()) === 0) {
+      await page.waitForTimeout(400)
+      continue
+    }
+
+    await expect(submitButton).toBeEnabled({ timeout: 10000 })
+    await submitButton.click()
+    await page.waitForTimeout(500)
+
+    const errorPrompt = page.locator('p.text-red-500').first()
+    if ((await errorPrompt.count()) === 0 || !(await errorPrompt.isVisible())) {
+      return
+    }
+  }
+
+  throw new Error('Form could not be submitted cleanly after retries')
+}
+
+const findAuthUserByEmail = async (email: string) => {
+  const adminSupabase = getAdminSupabaseClient()
+  let pageNumber = 1
+
+  while (true) {
+    const { data, error } = await adminSupabase.auth.admin.listUsers({ page: pageNumber, perPage: 200 })
+    if (error) throw new Error(error.message)
+
+    const users = data?.users ?? []
+    const found = users.find(user => (user.email ?? '').toLowerCase() === email.toLowerCase())
+    if (found) return found
+
+    if (users.length < 200) break
+    pageNumber += 1
+  }
+
+  return null
+}
+
+test.describe.serial('student resend guardian invite', () => {
+  test.skip(!hasAdminServiceEnv(), 'Requires SUPABASE_URL and SUPABASE_SECRET_KEY for admin setup')
+
+  test('resend invite works after student re-login and guardian can complete password setup', async ({ page }) => {
+    const suffix = uniqueSuffix()
+    const studentEmail = `e2e.student.${suffix}@gmail.com`
+    const studentPassword = 'Password123456!'
+    const guardianPassword = 'Password123456!'
+    const origin = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173'
+    const adminSupabase = getAdminSupabaseClient()
+
+    await page.goto('/sign-up')
+    await page.getByRole('button', { name: 'I am a Student' }).click()
+    await page.getByLabel('Gmail').fill(studentEmail)
+    await page.getByLabel('Password', { exact: true }).fill(studentPassword)
+    await page.getByLabel('Repeat Password').fill(studentPassword)
+    await page.getByLabel(/I have read and agree to the/i).check()
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    await expect(page).toHaveURL(/\/auth\/sign-up-details/)
+
+    for (let step = 0; step < 25; step += 1) {
+      if (page.url().includes('/auth/waiting-on-guardian')) break
+
+      const saveAndContinue = page.getByRole('button', { name: /Save and continue|Saving\.\.\./ })
+      await Promise.race([
+        page.waitForURL(/\/auth\/waiting-on-guardian/, { timeout: 10000 }),
+        saveAndContinue.first().waitFor({ state: 'visible', timeout: 10000 }),
+      ])
+
+      if (page.url().includes('/auth/waiting-on-guardian')) break
+
+      if ((await page.locator('input[name="question_child_has_email"][value="No"]').count()) > 0) {
+        await page.locator('input[name="question_child_has_email"][value="No"]').check()
+      }
+
+      if ((await page.locator('input[name="additional_guardian_choice"][value="no"]').count()) > 0) {
+        await page.locator('input[name="additional_guardian_choice"][value="no"]').check()
+      }
+
+      await submitStepWithRetry(page)
+      await page.waitForLoadState('networkidle')
+    }
+
+    await expect(page).toHaveURL(/\/auth\/waiting-on-guardian/)
+
+    const studentUser = await findAuthUserByEmail(studentEmail)
+    if (!studentUser?.id) {
+      throw new Error('Unable to find created student auth user')
+    }
+
+    await expect
+      .poll(
+        async () => {
+          const { data } = await adminSupabase
+            .from('invites')
+            .select('invitee_email')
+            .eq('inviter_user_id', studentUser.id)
+            .eq('role', 'guardian')
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .maybeSingle()
+
+          return Boolean(data?.invitee_email)
+        },
+        { timeout: 15000 }
+      )
+      .toBeTruthy()
+
+    const { data: guardianInviteRow, error: guardianInviteError } = await adminSupabase
+      .from('invites')
+      .select('invitee_email')
+      .eq('inviter_user_id', studentUser.id)
+      .eq('role', 'guardian')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (guardianInviteError || !guardianInviteRow?.invitee_email) {
+      throw new Error(guardianInviteError?.message ?? 'Unable to find guardian invite email')
+    }
+
+    const guardianEmail = guardianInviteRow.invitee_email
+
+    await page.goto('/logout')
+    await page.goto('/login')
+    await page.getByLabel('Email').fill(studentEmail)
+    await page.getByLabel('Password').fill(studentPassword)
+    await page.getByRole('button', { name: 'Login' }).click()
+
+    await expect(page).toHaveURL(/\/auth\/waiting-on-guardian/)
+
+    await page.getByRole('button', { name: 'Resend invite' }).first().click()
+    await expect(page.getByText(`Invite resent to ${guardianEmail}`)).toBeVisible()
+
+    const inviteLink = await generateInviteLinkForEmail({
+      email: guardianEmail,
+      origin,
+      role: 'guardian',
+    })
+
+    await page.goto(inviteLink)
+    await expect(page).toHaveURL(/\/sign-up\/invite/)
+
+    await page.getByLabel('Password', { exact: true }).fill(guardianPassword)
+    await page.getByLabel('Repeat Password').fill(guardianPassword)
+    await page.getByRole('button', { name: 'Set password' }).click()
+
+    await expect(page).toHaveURL(/\/auth\/sign-up-details|\/home|\/my-forms/)
+
+    const guardianUser = await findAuthUserByEmail(guardianEmail)
+    if (!guardianUser?.id) {
+      throw new Error('Unable to find invited guardian auth user')
+    }
+
+    const { data: guardianProfile, error: guardianProfileError } = await adminSupabase
+      .from('profile')
+      .select('user_id, password_set')
+      .eq('email', guardianEmail)
+      .eq('role', 'guardian')
+      .maybeSingle()
+
+    if (guardianProfileError) {
+      throw new Error(guardianProfileError.message)
+    }
+
+    expect(guardianProfile?.user_id).toBe(guardianUser.id)
+    expect(guardianProfile?.password_set).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What this PR changes\n- adds family enrollment guardrails and supporting DB/schema updates\n- fixes guardian invite resend flow and adds e2e coverage for student resend flows\n- refines manage person riding editors and related UX updates\n- adds prod semester anchor seed so local seeded data aligns with prod workshop semester references\n\n## Verification\n- e2e coverage added for invite resend scenario\n- schema + seed changes included together for enrollment guardrails