### PR TITLE
Fix zoom endpoint URL normalization

### DIFF
--- a/web/app/lib/zoom-jobs/endpoint.server.ts
+++ b/web/app/lib/zoom-jobs/endpoint.server.ts
@@ -1,0 +1,22 @@
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
+const hasScheme = (value: string) => /^https?:\/\//i.test(value)
+
+const shouldDefaultToHttp = (value: string) => {
+  const lower = value.toLowerCase()
+  return lower.includes('.internal') || lower.startsWith('localhost') || lower.startsWith('127.0.0.1')
+}
+
+export const normalizeZoomApiEndpoint = (rawEndpoint: string) => {
+  const endpoint = rawEndpoint.trim()
+  if (!endpoint) {
+    throw new Error('Missing ZOOM_API_ENDPOINT')
+  }
+
+  if (hasScheme(endpoint)) {
+    return trimTrailingSlash(endpoint)
+  }
+
+  const scheme = shouldDefaultToHttp(endpoint) ? 'http://' : 'https://'
+  return trimTrailingSlash(`${scheme}${endpoint}`)
+}

--- a/web/app/lib/zoom-jobs/zoom-api.client.server.ts
+++ b/web/app/lib/zoom-jobs/zoom-api.client.server.ts
@@ -1,3 +1,5 @@
+import { normalizeZoomApiEndpoint } from '@/lib/zoom-jobs/endpoint.server'
+
 type ZoomRegistrantRequest = {
   first_name: string
   last_name: string
@@ -18,14 +20,11 @@ type ZoomCreateMeetingResponse = {
   join_url: string
 }
 
-const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
-
 const getConfig = () => {
   const endpoint = (process.env.ZOOM_API_ENDPOINT ?? '').trim()
   const apiKey = (process.env.ZOOM_API_KEY ?? '').trim()
-  if (!endpoint) throw new Error('Missing ZOOM_API_ENDPOINT')
   if (!apiKey) throw new Error('Missing ZOOM_API_KEY')
-  return { endpoint: trimTrailingSlash(endpoint), apiKey }
+  return { endpoint: normalizeZoomApiEndpoint(endpoint), apiKey }
 }
 
 const parsePayload = async (response: Response) => {

--- a/web/app/routes/manage/zoom-connect-test.tsx
+++ b/web/app/routes/manage/zoom-connect-test.tsx
@@ -3,6 +3,7 @@ import { Form, useActionData, useNavigation } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
 import { isRoleAtLeast } from '@/lib/roles'
+import { normalizeZoomApiEndpoint } from '@/lib/zoom-jobs/endpoint.server'
 
 import type { Route } from './+types/zoom-connect-test'
 
@@ -19,8 +20,6 @@ type ActionData =
       payload?: unknown
     }
 
-const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
-
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!isRoleAtLeast(auth.claims.role, 'staff')) {
@@ -35,17 +34,24 @@ export async function action({ request }: Route.ActionArgs): Promise<ActionData>
     return { ok: false, error: 'Unauthorized' }
   }
 
-  const endpoint = (process.env.ZOOM_API_ENDPOINT ?? '').trim()
+  const endpointRaw = (process.env.ZOOM_API_ENDPOINT ?? '').trim()
   const apiKey = (process.env.ZOOM_API_KEY ?? '').trim()
 
-  if (!endpoint) {
-    return { ok: false, error: 'Missing ZOOM_API_ENDPOINT.' }
-  }
   if (!apiKey) {
     return { ok: false, error: 'Missing ZOOM_API_KEY.' }
   }
 
-  const targetUrl = `${trimTrailingSlash(endpoint)}/zoom/connect`
+  let endpoint: string
+  try {
+    endpoint = normalizeZoomApiEndpoint(endpointRaw)
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : 'Missing ZOOM_API_ENDPOINT.',
+    }
+  }
+
+  const targetUrl = `${endpoint}/zoom/connect`
 
   try {
     const response = await fetch(targetUrl, {


### PR DESCRIPTION
## What
- normalize ZOOM_API_ENDPOINT before server fetch calls
- auto-add scheme when endpoint is provided as a bare host
- use http:// for internal/local hosts and https:// otherwise

## Why
Fixes production error: Failed to parse URL from zoom-api.railway.internal/zoom/connect.

## Verification
- npm run typecheck (web)