### PR TITLE
Add ZLR redirect route and local scheduler make tooling

### DIFF
--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -1,0 +1,38 @@
+IMAGE_NAME ?= summerlunchplus-scheduler-local
+CONTAINER_NAME ?= summerlunchplus-scheduler-cron
+ENV_FILE ?= .env.local
+
+.PHONY: check-env build cron cron-bg down logs status smoke-zoom smoke-export smoke-cleanup smoke-all
+
+check-env:
+	@test -f "$(ENV_FILE)" || (echo "Missing $(ENV_FILE). Create it from .env.template." && exit 1)
+
+build: check-env
+	docker build -t $(IMAGE_NAME) .
+
+cron: build
+	docker run --rm --name $(CONTAINER_NAME) --env-file $(ENV_FILE) $(IMAGE_NAME)
+
+cron-bg: build
+	-docker rm -f $(CONTAINER_NAME)
+	docker run -d --name $(CONTAINER_NAME) --env-file $(ENV_FILE) $(IMAGE_NAME)
+
+down:
+	-docker stop $(CONTAINER_NAME)
+
+logs:
+	docker logs -f $(CONTAINER_NAME)
+
+status:
+	docker ps --filter "name=$(CONTAINER_NAME)"
+
+smoke-zoom: build
+	docker run --rm --env-file $(ENV_FILE) $(IMAGE_NAME) /bin/bash /app/scripts/zoom-jobs.sh
+
+smoke-export: build
+	docker run --rm --env-file $(ENV_FILE) $(IMAGE_NAME) /bin/bash /app/scripts/export-jobs.sh
+
+smoke-cleanup: build
+	docker run --rm --env-file $(ENV_FILE) $(IMAGE_NAME) /bin/bash /app/scripts/export-cleanup.sh
+
+smoke-all: smoke-zoom smoke-export smoke-cleanup

--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -13,6 +13,24 @@ This service runs cron schedules and triggers internal job routes on the `web` s
 - `APP_BASE_URL` - base URL of the web service, for example `https://summerlunchplus.up.railway.app`
 - `INTERNAL_RUNNER_SECRET` - must match `web` service `INTERNAL_RUNNER_SECRET`
 
+## Local run
+
+From `scheduler/`:
+
+1. Copy `.env.template` to `.env.local` and set values.
+2. Run cron in foreground:
+
+   ```bash
+   make cron
+   ```
+
+Useful local commands:
+
+- `make cron-bg` - run scheduler container in background
+- `make logs` - follow background cron logs
+- `make down` - stop background container
+- `make smoke-all` - run all three jobs once immediately
+
 ## Schedule source of truth
 
 Schedules are declared in `scheduler/crontab`.

--- a/web/app/lib/zoom-jobs/provision.server.ts
+++ b/web/app/lib/zoom-jobs/provision.server.ts
@@ -1,7 +1,6 @@
-import { createHash, randomBytes } from 'node:crypto'
-
 import { adminClient } from '@/lib/supabase/adminClient'
 import { zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
+import { hashZlrToken, newZlrToken } from '@/lib/zoom-jobs/zlr-token.server'
 
 type ClassRow = {
   id: string
@@ -56,10 +55,6 @@ const toDisplayName = (profile: ProfileRow) => {
   const last = (profile.surname ?? '').trim()
   return [first, last].filter(Boolean).join(' ').trim()
 }
-
-const randomToken = () => randomBytes(24).toString('base64url')
-
-const sha256 = (value: string) => createHash('sha256').update(value).digest('hex')
 
 const buildTopic = (classRow: ClassRow) => {
   const workshopName = classRow.workshop?.description?.trim() || 'SummerLunch+ Class'
@@ -247,7 +242,7 @@ const ensureRegistrantsForClass = async ({
       email,
     })
 
-    const tokenHash = sha256(randomToken())
+    const tokenHash = hashZlrToken(newZlrToken())
     const { error: upsertError } = await adminClient.from('class_zoom_registrant').upsert(
       {
         class_id: classRow.id,

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -1,17 +1,12 @@
-import { createHash, randomBytes } from 'node:crypto'
-
 import { sendTransactionalEmail } from '@/lib/email/send-email.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { getClassesInWindow, provisionClassById } from '@/lib/zoom-jobs/provision.server'
 import { zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
+import { hashZlrToken, newZlrToken } from '@/lib/zoom-jobs/zlr-token.server'
 
 const toIso = (date: Date) => date.toISOString()
 
 const addMinutes = (date: Date, minutes: number) => new Date(date.getTime() + minutes * 60_000)
-
-const hashToken = (token: string) => createHash('sha256').update(token).digest('hex')
-
-const newToken = () => randomBytes(24).toString('base64url')
 
 const normalizeEmail = (value: string | null) => (value ?? '').trim().toLowerCase()
 
@@ -108,8 +103,8 @@ const send2hReminders = async ({ now, appOrigin }: { now: Date; appOrigin: strin
         continue
       }
 
-      const token = newToken()
-      const tokenHash = hashToken(token)
+      const token = newZlrToken()
+      const tokenHash = hashZlrToken(token)
       const expiresAt = addMinutes(new Date(classRow.starts_at), 240).toISOString()
 
       const { error: tokenUpdateError } = await adminClient

--- a/web/app/lib/zoom-jobs/zlr-token.server.ts
+++ b/web/app/lib/zoom-jobs/zlr-token.server.ts
@@ -1,0 +1,5 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+export const hashZlrToken = (token: string) => createHash('sha256').update(token).digest('hex')
+
+export const newZlrToken = () => randomBytes(24).toString('base64url')

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -32,6 +32,7 @@ export default [
   route("protected", "routes/protected.tsx"),
   route("auth/confirm", "routes/auth/confirm.tsx"),
   route("auth/error", "routes/auth/error.tsx"),
+  route("zlr/:token", "routes/zlr.$token.ts"),
   route("internal/export-jobs/run", "routes/internal/export-jobs.run.ts"),
   route("internal/export-jobs/cleanup", "routes/internal/export-jobs.cleanup.ts"),
   route("internal/zoom-jobs/run", "routes/internal/zoom-jobs.run.ts"),

--- a/web/app/routes/zlr.$token.ts
+++ b/web/app/routes/zlr.$token.ts
@@ -1,0 +1,82 @@
+import { redirect, type LoaderFunctionArgs } from 'react-router'
+
+import { extractRequestMetadata } from '@/lib/request-metadata.server'
+import { adminClient } from '@/lib/supabase/adminClient'
+import { hashZlrToken } from '@/lib/zoom-jobs/zlr-token.server'
+
+const noStoreHeaders = {
+  'cache-control': 'no-store',
+}
+
+const invalidLink = () =>
+  new Response('This Zoom link is invalid or expired. Please request a new class reminder email.', {
+    status: 404,
+    headers: noStoreHeaders,
+  })
+
+const unavailableLink = () =>
+  new Response('This Zoom link is no longer available. Please contact support if you need help joining.', {
+    status: 410,
+    headers: noStoreHeaders,
+  })
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const token = (params.token ?? '').trim()
+  if (!token) return invalidLink()
+
+  const tokenHash = hashZlrToken(token)
+  const { data: registrant, error: registrantError } = await adminClient
+    .from('class_zoom_registrant')
+    .select('id, profile_id, class_id, zoom_join_url, zlr_expires_at')
+    .eq('zlr_token_hash', tokenHash)
+    .maybeSingle()
+
+  if (registrantError) {
+    console.error('[zlr] lookup failed', { tokenHashPrefix: tokenHash.slice(0, 12), error: registrantError.message })
+    return new Response('Unable to process this Zoom link right now.', { status: 500, headers: noStoreHeaders })
+  }
+
+  if (!registrant) {
+    return invalidLink()
+  }
+
+  const requestMetadata = extractRequestMetadata(request)
+  const clickMetadata = {
+    classId: registrant.class_id,
+    tokenHashPrefix: tokenHash.slice(0, 12),
+    ipSelected: requestMetadata.ipSelected,
+    ipSelectedSource: requestMetadata.ipSelectedSource,
+    ipChain: requestMetadata.ipChain,
+    forwardedFor: requestMetadata.forwardedFor,
+    referer: requestMetadata.referer,
+    origin: requestMetadata.origin,
+  }
+
+  const { error: clickError } = await adminClient.from('zlr_click_event').insert({
+    class_zoom_registrant_id: registrant.id,
+    profile_id: registrant.profile_id,
+    ip_address: requestMetadata.ipAddress,
+    user_agent: requestMetadata.userAgent,
+    metadata: clickMetadata,
+  })
+
+  if (clickError) {
+    console.error('[zlr] click insert failed', {
+      registrantId: registrant.id,
+      classId: registrant.class_id,
+      error: clickError.message,
+    })
+  }
+
+  const expiresAt = registrant.zlr_expires_at ? new Date(registrant.zlr_expires_at) : null
+  if (expiresAt && Number.isFinite(expiresAt.getTime()) && Date.now() > expiresAt.getTime()) {
+    return unavailableLink()
+  }
+
+  const joinUrl = (registrant.zoom_join_url ?? '').trim()
+  if (!joinUrl) {
+    return unavailableLink()
+  }
+
+  return redirect(joinUrl)
+}


### PR DESCRIPTION
## What
- add /zlr/:token redirect route with token hash lookup and expiry checks
- record click events for ZLR link opens with request metadata
- centralize ZLR token hash/generation helper
- add scheduler Makefile targets for local cron and smoke runs
- document local scheduler usage in README

## Verification
- npm run typecheck (web)
- make -n cron and make -n smoke-all (scheduler)