### PR TITLE
Harden Zoom cron idempotency, retries, and coverage checks

### DIFF
--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -31,6 +31,19 @@ Useful local commands:
 - `make down` - stop background container
 - `make smoke-all` - run all three jobs once immediately
 
+## Troubleshooting
+
+- Verify env parity first:
+  - `scheduler` has `APP_BASE_URL` and `INTERNAL_RUNNER_SECRET`
+  - `web` has matching `INTERNAL_RUNNER_SECRET`
+- Validate internal routes manually:
+  - `POST /internal/zoom-jobs/run`
+  - `POST /internal/export-jobs/run`
+  - `POST /internal/export-jobs/cleanup`
+- If jobs return `401 Unauthorized`, secrets do not match.
+- If jobs return `5xx`, inspect `web` logs by `runId` (`x-cron-run-id`) and check Zoom API reachability.
+- For Zoom attendance sync delays, a `pending` sync status indicates retryable report lag; the next cron pass will retry.
+
 ## Schedule source of truth
 
 Schedules are declared in `scheduler/crontab`.

--- a/supabase/migrations/20260628213000_zoom_advisory_locks.sql
+++ b/supabase/migrations/20260628213000_zoom_advisory_locks.sql
@@ -1,0 +1,20 @@
+create or replace function public.zoom_try_advisory_lock(p_lock_name text)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select pg_try_advisory_lock(hashtextextended(coalesce(nullif(btrim(p_lock_name), ''), 'zoom:default'), 0));
+$$;
+
+create or replace function public.zoom_advisory_unlock(p_lock_name text)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select pg_advisory_unlock(hashtextextended(coalesce(nullif(btrim(p_lock_name), ''), 'zoom:default'), 0));
+$$;
+
+grant execute on function public.zoom_try_advisory_lock(text) to supabase_auth_admin, service_role;
+grant execute on function public.zoom_advisory_unlock(text) to supabase_auth_admin, service_role;

--- a/supabase/schemas/16_zoom_integration.sql
+++ b/supabase/schemas/16_zoom_integration.sql
@@ -301,6 +301,24 @@ create policy zlr_click_event_auth_admin on public.zlr_click_event
   using (true)
   with check (true);
 
+create or replace function public.zoom_try_advisory_lock(p_lock_name text)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select pg_try_advisory_lock(hashtextextended(coalesce(nullif(btrim(p_lock_name), ''), 'zoom:default'), 0));
+$$;
+
+create or replace function public.zoom_advisory_unlock(p_lock_name text)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select pg_advisory_unlock(hashtextextended(coalesce(nullif(btrim(p_lock_name), ''), 'zoom:default'), 0));
+$$;
+
 grant usage on type public.zoom_meeting_status to authenticated, supabase_auth_admin;
 grant usage on type public.zoom_sync_status to authenticated, supabase_auth_admin;
 
@@ -324,3 +342,6 @@ grant select, insert, update, delete on table public.class_zoom_registrant to au
 grant select, insert, update, delete on table public.class_zoom_participant_sync to authenticated;
 grant select, insert, update, delete on table public.class_zoom_participant to authenticated;
 grant select, insert, update, delete on table public.zlr_click_event to authenticated;
+
+grant execute on function public.zoom_try_advisory_lock(text) to supabase_auth_admin, service_role;
+grant execute on function public.zoom_advisory_unlock(text) to supabase_auth_admin, service_role;

--- a/web/app/lib/zoom-jobs/lock.server.ts
+++ b/web/app/lib/zoom-jobs/lock.server.ts
@@ -1,0 +1,20 @@
+import { adminClient } from '@/lib/supabase/adminClient'
+
+export const tryAcquireZoomClassLock = async (classId: string) => {
+  const { data, error } = await adminClient.rpc('zoom_try_advisory_lock', {
+    p_lock_name: `zoom:class:${classId}`,
+  })
+  if (error) throw new Error(`Failed to acquire Zoom class lock: ${error.message}`)
+  return data === true
+}
+
+export const releaseZoomClassLock = async (classId: string) => {
+  const { data, error } = await adminClient.rpc('zoom_advisory_unlock', {
+    p_lock_name: `zoom:class:${classId}`,
+  })
+  if (error) {
+    console.error('[zoom-jobs][lock] unlock failed', { classId, error: error.message })
+    return false
+  }
+  return data === true
+}

--- a/web/app/lib/zoom-jobs/provision.server.ts
+++ b/web/app/lib/zoom-jobs/provision.server.ts
@@ -1,4 +1,5 @@
 import { adminClient } from '@/lib/supabase/adminClient'
+import { releaseZoomClassLock, tryAcquireZoomClassLock } from '@/lib/zoom-jobs/lock.server'
 import { zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
 import { hashZlrToken, newZlrToken } from '@/lib/zoom-jobs/zlr-token.server'
 
@@ -39,6 +40,8 @@ type ProvisionClassResult = {
   meetingCreated: boolean
   registrantsCreated: number
   registrantsSkipped: number
+  skipped?: boolean
+  skipReason?: string
   error?: string
 }
 
@@ -264,6 +267,19 @@ const ensureRegistrantsForClass = async ({
 }
 
 export const provisionClassById = async (classId: string): Promise<ProvisionClassResult> => {
+  const lockAcquired = await tryAcquireZoomClassLock(classId)
+  if (!lockAcquired) {
+    return {
+      classId,
+      attendanceRowsEnsured: 0,
+      meetingCreated: false,
+      registrantsCreated: 0,
+      registrantsSkipped: 0,
+      skipped: true,
+      skipReason: 'lock_not_acquired',
+    }
+  }
+
   const { data: classRowRaw, error: classError } = await adminClient
     .from('class')
     .select('id, workshop_id, starts_at, ends_at, workshop:workshop_id ( description )')
@@ -271,6 +287,7 @@ export const provisionClassById = async (classId: string): Promise<ProvisionClas
     .single()
 
   if (classError || !classRowRaw) {
+    await releaseZoomClassLock(classId)
     return { classId, attendanceRowsEnsured: 0, meetingCreated: false, registrantsCreated: 0, registrantsSkipped: 0, error: classError?.message ?? 'Class not found' }
   }
 
@@ -303,6 +320,8 @@ export const provisionClassById = async (classId: string): Promise<ProvisionClas
       registrantsSkipped: 0,
       error: error instanceof Error ? error.message : 'Unknown provisioning error',
     }
+  } finally {
+    await releaseZoomClassLock(classId)
   }
 }
 

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -1,7 +1,7 @@
 import { sendTransactionalEmail } from '@/lib/email/send-email.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { getClassesInWindow, provisionClassById } from '@/lib/zoom-jobs/provision.server'
-import { zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
+import { ZoomApiError, zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
 import { hashZlrToken, newZlrToken } from '@/lib/zoom-jobs/zlr-token.server'
 
 const toIso = (date: Date) => date.toISOString()
@@ -11,6 +11,10 @@ const addMinutes = (date: Date, minutes: number) => new Date(date.getTime() + mi
 const normalizeEmail = (value: string | null) => (value ?? '').trim().toLowerCase()
 
 const ensureOrigin = (origin: string) => origin.replace(/\/+$/, '')
+
+const RUNNING_SYNC_TIMEOUT_MINUTES = 20
+
+const FAILED_SYNC_RETRY_COOLDOWN_MINUTES = 10
 
 const provisionWindow = async ({ now, leadMinutes }: { now: Date; leadMinutes: number }) => {
   const classIds = await getClassesInWindow({
@@ -25,7 +29,8 @@ const provisionWindow = async ({ now, leadMinutes }: { now: Date; leadMinutes: n
 
   return {
     scanned: classIds.length,
-    provisioned: results.filter(result => !result.error).length,
+    provisioned: results.filter(result => !result.error && !result.skipped).length,
+    skipped: results.filter(result => result.skipped).length,
     failed: results.filter(result => Boolean(result.error)).length,
     details: results,
   }
@@ -44,9 +49,95 @@ const reprovision2h30m = async ({ now }: { now: Date }) => {
 
   return {
     scanned: classIds.length,
-    reprovisioned: results.filter(result => !result.error).length,
+    reprovisioned: results.filter(result => !result.error && !result.skipped).length,
+    skipped: results.filter(result => result.skipped).length,
     failed: results.filter(result => Boolean(result.error)).length,
     details: results,
+  }
+}
+
+const buildCoverageCheck = async ({ now }: { now: Date }) => {
+  const classIds = await getClassesInWindow({
+    startsAt: toIso(now),
+    endsAt: toIso(addMinutes(now, 24 * 60)),
+  })
+
+  if (!classIds.length) {
+    return {
+      scanned: 0,
+      classesMissingMeeting: 0,
+      classesWithRegistrantGaps: 0,
+      missingMeetingClassIds: [] as string[],
+      registrantGapClassIds: [] as string[],
+    }
+  }
+
+  const { data: classes } = await adminClient.from('class').select('id, workshop_id').in('id', classIds)
+  const workshopIds = Array.from(new Set((classes ?? []).map(row => row.workshop_id).filter((id): id is string => Boolean(id))))
+
+  const { data: meetings } = await adminClient
+    .from('class_zoom_meeting')
+    .select('class_id, status')
+    .in('class_id', classIds)
+
+  const { data: registrants } = await adminClient
+    .from('class_zoom_registrant')
+    .select('class_id, profile_id')
+    .in('class_id', classIds)
+
+  const { data: enrollments } = workshopIds.length
+    ? await adminClient
+        .from('workshop_enrollment')
+        .select('workshop_id, profile_id, status')
+        .in('workshop_id', workshopIds)
+        .eq('status', 'approved')
+        .not('profile_id', 'is', null)
+    : { data: [] }
+
+  const classToWorkshop = new Map((classes ?? []).map(row => [row.id, row.workshop_id]))
+  const hasMeeting = new Set((meetings ?? []).filter(row => row.status === 'created').map(row => row.class_id))
+
+  const expectedByWorkshop = new Map<string, Set<string>>()
+  for (const enrollment of enrollments ?? []) {
+    if (!enrollment.workshop_id || !enrollment.profile_id) continue
+    if (!expectedByWorkshop.has(enrollment.workshop_id)) {
+      expectedByWorkshop.set(enrollment.workshop_id, new Set<string>())
+    }
+    expectedByWorkshop.get(enrollment.workshop_id)?.add(enrollment.profile_id)
+  }
+
+  const actualByClass = new Map<string, Set<string>>()
+  for (const registrant of registrants ?? []) {
+    if (!registrant.class_id || !registrant.profile_id) continue
+    if (!actualByClass.has(registrant.class_id)) {
+      actualByClass.set(registrant.class_id, new Set<string>())
+    }
+    actualByClass.get(registrant.class_id)?.add(registrant.profile_id)
+  }
+
+  const missingMeetingClassIds: string[] = []
+  const registrantGapClassIds: string[] = []
+
+  for (const classId of classIds) {
+    if (!hasMeeting.has(classId)) {
+      missingMeetingClassIds.push(classId)
+    }
+
+    const workshopId = classToWorkshop.get(classId)
+    if (!workshopId) continue
+    const expectedCount = expectedByWorkshop.get(workshopId)?.size ?? 0
+    const actualCount = actualByClass.get(classId)?.size ?? 0
+    if (actualCount < expectedCount) {
+      registrantGapClassIds.push(classId)
+    }
+  }
+
+  return {
+    scanned: classIds.length,
+    classesMissingMeeting: missingMeetingClassIds.length,
+    classesWithRegistrantGaps: registrantGapClassIds.length,
+    missingMeetingClassIds,
+    registrantGapClassIds,
   }
 }
 
@@ -169,6 +260,64 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
   let scanned = 0
   let synced = 0
   let failed = 0
+  let pendingRetry = 0
+  let skippedCooldown = 0
+
+  const nowIso = now.toISOString()
+
+  const isRecent = (value: string | null, windowMinutes: number) => {
+    if (!value) return false
+    const timestamp = new Date(value).getTime()
+    if (!Number.isFinite(timestamp)) return false
+    return now.getTime() - timestamp < windowMinutes * 60_000
+  }
+
+  const dedupeParticipants = (participants: Array<Record<string, unknown>>) => {
+    const seen = new Set<string>()
+    const rows: Array<{
+      class_zoom_meeting_id: string
+      class_id: string
+      profile_id: null
+      zoom_user_id: string | null
+      user_name: string | null
+      user_email: string | null
+      join_time: string | null
+      leave_time: string | null
+      duration_seconds: number | null
+      camera_on: null
+      attentiveness_score: null
+      raw: Record<string, unknown>
+    }> = []
+
+    for (const participant of participants) {
+      const zoomUserId = typeof participant.id === 'string' ? participant.id : null
+      const userName = typeof participant.name === 'string' ? participant.name : null
+      const userEmail = typeof participant.user_email === 'string' ? participant.user_email.toLowerCase() : null
+      const joinTime = typeof participant.join_time === 'string' ? participant.join_time : null
+      const leaveTime = typeof participant.leave_time === 'string' ? participant.leave_time : null
+      const durationSeconds = typeof participant.duration === 'number' ? participant.duration : null
+      const signature = [zoomUserId ?? '', userEmail ?? '', joinTime ?? '', leaveTime ?? '', userName ?? ''].join('|')
+      if (seen.has(signature)) continue
+      seen.add(signature)
+
+      rows.push({
+        class_zoom_meeting_id: '',
+        class_id: '',
+        profile_id: null,
+        zoom_user_id: zoomUserId,
+        user_name: userName,
+        user_email: userEmail,
+        join_time: joinTime,
+        leave_time: leaveTime,
+        duration_seconds: durationSeconds,
+        camera_on: null,
+        attentiveness_score: null,
+        raw: participant,
+      })
+    }
+
+    return rows
+  }
 
   for (const meeting of meetings ?? []) {
     const classRelation = Array.isArray(meeting.class) ? meeting.class[0] : null
@@ -177,9 +326,42 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
     if (!meeting.zoom_meeting_uuid) continue
     scanned += 1
 
+    const { data: latestSync } = await adminClient
+      .from('class_zoom_participant_sync')
+      .select('status, started_at, completed_at, payload')
+      .eq('class_zoom_meeting_id', meeting.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    const latestPayload = latestSync?.payload && typeof latestSync.payload === 'object' ? latestSync.payload : {}
+    const previousAttemptCount =
+      typeof (latestPayload as { attempt_count?: unknown }).attempt_count === 'number'
+        ? Math.floor((latestPayload as { attempt_count?: number }).attempt_count ?? 0)
+        : 0
+    const attemptCount = Math.max(1, previousAttemptCount + 1)
+
+    if (latestSync?.status === 'running' && isRecent(latestSync.started_at, RUNNING_SYNC_TIMEOUT_MINUTES)) {
+      skippedCooldown += 1
+      continue
+    }
+
+    if (latestSync?.status === 'failed' && isRecent(latestSync.completed_at, FAILED_SYNC_RETRY_COOLDOWN_MINUTES)) {
+      skippedCooldown += 1
+      continue
+    }
+
     const { data: syncRun, error: syncCreateError } = await adminClient
       .from('class_zoom_participant_sync')
-      .insert({ class_zoom_meeting_id: meeting.id, status: 'running', started_at: new Date().toISOString() })
+      .insert({
+        class_zoom_meeting_id: meeting.id,
+        status: 'running',
+        started_at: nowIso,
+        payload: {
+          attempt_count: attemptCount,
+          started_at: nowIso,
+        },
+      })
       .select('id')
       .single()
 
@@ -191,21 +373,19 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
     try {
       const participantsPayload = await zoomApiClient.getParticipants(meeting.zoom_meeting_uuid)
       const participants = participantsPayload.participants ?? []
+      const dedupedRows = dedupeParticipants(participants)
 
-      const rows = participants.map(participant => ({
+      const rows = dedupedRows.map(row => ({
+        ...row,
         class_zoom_meeting_id: meeting.id,
         class_id: meeting.class_id,
-        profile_id: null,
-        zoom_user_id: typeof participant.id === 'string' ? participant.id : null,
-        user_name: typeof participant.name === 'string' ? participant.name : null,
-        user_email: typeof participant.user_email === 'string' ? participant.user_email.toLowerCase() : null,
-        join_time: typeof participant.join_time === 'string' ? participant.join_time : null,
-        leave_time: typeof participant.leave_time === 'string' ? participant.leave_time : null,
-        duration_seconds: typeof participant.duration === 'number' ? participant.duration : null,
-        camera_on: null,
-        attentiveness_score: null,
-        raw: participant,
       }))
+
+      const { error: deleteError } = await adminClient
+        .from('class_zoom_participant')
+        .delete()
+        .eq('class_zoom_meeting_id', meeting.id)
+      if (deleteError) throw new Error(deleteError.message)
 
       if (rows.length) {
         const { error: insertError } = await adminClient.from('class_zoom_participant').insert(rows)
@@ -236,7 +416,15 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
 
       await adminClient
         .from('class_zoom_participant_sync')
-        .update({ status: 'completed', completed_at: new Date().toISOString(), payload: { participant_count: rows.length } })
+        .update({
+          status: 'completed',
+          completed_at: new Date().toISOString(),
+          payload: {
+            attempt_count: attemptCount,
+            participant_count: rows.length,
+            deduplicated_from: participants.length,
+          },
+        })
         .eq('id', syncRun.id)
 
       await adminClient
@@ -246,32 +434,66 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
 
       synced += 1
     } catch (err) {
-      failed += 1
+      const isRetryableNotReady = err instanceof ZoomApiError && err.status === 409
+      if (isRetryableNotReady) {
+        pendingRetry += 1
+      } else {
+        failed += 1
+      }
+
+      const retryAfter = new Date(addMinutes(now, FAILED_SYNC_RETRY_COOLDOWN_MINUTES)).toISOString()
       await adminClient
         .from('class_zoom_participant_sync')
         .update({
-          status: 'failed',
+          status: isRetryableNotReady ? 'pending' : 'failed',
           completed_at: new Date().toISOString(),
           error_message: err instanceof Error ? err.message : 'Unknown attendance sync error',
+          payload: {
+            attempt_count: attemptCount,
+            retry_after: retryAfter,
+            retryable: isRetryableNotReady,
+            error_type: err instanceof Error ? err.name : 'UnknownError',
+          },
         })
         .eq('id', syncRun.id)
     }
   }
 
-  return { scanned, synced, failed }
+  return { scanned, synced, failed, pendingRetry, skippedCooldown }
 }
 
-export const runZoomJobs = async ({ now = new Date(), appOrigin }: { now?: Date; appOrigin: string }) => {
+export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?: Date; appOrigin: string; runId?: string }) => {
+  console.info('[zoom-jobs] run started', {
+    runId: runId ?? null,
+    now: now.toISOString(),
+  })
+
   const provision24h = await provisionWindow({ now, leadMinutes: 24 * 60 })
   const reprovision = await reprovision2h30m({ now })
+  const coverageCheck = await buildCoverageCheck({ now })
   const reminders = await send2hReminders({ now, appOrigin })
   const attendanceSync = await syncPostClassAttendance({ now })
 
+  console.info('[zoom-jobs] run completed', {
+    runId: runId ?? null,
+    ranAt: now.toISOString(),
+    provisionScanned: provision24h.scanned,
+    reprovisionScanned: reprovision.scanned,
+    coverageScanned: coverageCheck.scanned,
+    coverageMissingMeetings: coverageCheck.classesMissingMeeting,
+    coverageRegistrantGaps: coverageCheck.classesWithRegistrantGaps,
+    reminderScanned: reminders.scannedClasses,
+    attendanceScanned: attendanceSync.scanned,
+    attendanceFailed: attendanceSync.failed,
+  })
+
   return {
     ok: true,
+    runId: runId ?? null,
     ranAt: now.toISOString(),
     provision24h,
     reprovision2h30m: reprovision,
+    coverageCheck,
     reminders2h: reminders,
     attendanceSync,
   }

--- a/web/app/lib/zoom-jobs/zoom-api.client.server.ts
+++ b/web/app/lib/zoom-jobs/zoom-api.client.server.ts
@@ -20,6 +20,20 @@ type ZoomCreateMeetingResponse = {
   join_url: string
 }
 
+export class ZoomApiError extends Error {
+  status: number
+  path: string
+  payload: unknown
+
+  constructor({ status, path, payload }: { status: number; path: string; payload: unknown }) {
+    super(`zoom-api ${path} failed (${status})`)
+    this.name = 'ZoomApiError'
+    this.status = status
+    this.path = path
+    this.payload = payload
+  }
+}
+
 const getConfig = () => {
   const endpoint = (process.env.ZOOM_API_ENDPOINT ?? '').trim()
   const apiKey = (process.env.ZOOM_API_KEY ?? '').trim()
@@ -48,7 +62,7 @@ const requestJson = async <T>({ method, path, body }: { method: 'GET' | 'POST'; 
 
   const payload = await parsePayload(response)
   if (!response.ok) {
-    throw new Error(`zoom-api ${path} failed (${response.status}): ${typeof payload === 'string' ? payload : JSON.stringify(payload)}`)
+    throw new ZoomApiError({ status: response.status, path, payload })
   }
   return payload as T
 }

--- a/web/app/routes/internal/zoom-jobs.run.ts
+++ b/web/app/routes/internal/zoom-jobs.run.ts
@@ -21,6 +21,6 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const appOrigin = new URL(request.url).origin
   console.info('[internal][zoom-jobs.run] starting', { runId: authCheck.runId })
-  const result = await runZoomJobs({ appOrigin })
-  return Response.json({ runId: authCheck.runId, ...result })
+  const result = await runZoomJobs({ appOrigin, runId: authCheck.runId })
+  return Response.json(result)
 }


### PR DESCRIPTION
## What
- add DB-backed advisory lock helpers and class-level lock usage for provisioning
- prevent overlapping cron runs from provisioning the same class concurrently
- improve attendance sync with cooldown checks, retryable pending state for Zoom 409, and richer payload metadata
- deduplicate participant rows per sync and replace prior rows to fill gaps without accumulating duplicates
- add zoom coverage checks for missing meetings/registrant gaps in the next 24h window
- improve zoom cron observability with runId-aware logging
- add scheduler troubleshooting notes for runbook-level operations

## Data model updates
- add `zoom_try_advisory_lock(text)` and `zoom_advisory_unlock(text)` functions
- grant execute to `supabase_auth_admin` and `service_role`

## Verification
- web: `npm run typecheck`
- web: `npm run test` (Playwright suite)
- zoom-api: `make test`