### PR TITLE
Allow Vite dev access from Docker scheduler

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,4 +5,8 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+  server: {
+    host: true,
+    allowedHosts: ['host.docker.internal', 'localhost', '127.0.0.1'],
+  },
 });


### PR DESCRIPTION
## What
- enable Vite dev server host access for Docker-based local scheduler runs
- allow host.docker.internal, localhost, and 127.0.0.1

## Why
- scheduler container requests to local web dev server were returning 403 in local cron smoke runs

## Verification
- run make cron in scheduler/ with local web dev server running