### PR TITLE
Fix scheduler auth header duplication and disable Zoom reminder emails

### DIFF
--- a/scheduler/scripts/common.sh
+++ b/scheduler/scripts/common.sh
@@ -20,12 +20,23 @@ post_json() {
   local secret_value="$3"
   local run_id_value="$4"
 
+  local secret_header_name_lc
+  secret_header_name_lc="$(printf '%s' "$secret_header_name" | tr '[:upper:]' '[:lower:]')"
+
+  local -a header_args
+  header_args=(
+    -H "x-internal-runner-secret: ${secret_value}"
+    -H "x-cron-run-id: ${run_id_value}"
+  )
+
+  if [[ -n "$secret_header_name" && "$secret_header_name_lc" != "x-internal-runner-secret" ]]; then
+    header_args+=( -H "${secret_header_name}: ${secret_value}" )
+  fi
+
   curl --fail --silent --show-error \
     --max-time 60 \
     --retry 2 \
     --retry-delay 3 \
     -X POST "$url" \
-    -H "${secret_header_name}: ${secret_value}" \
-    -H "x-cron-run-id: ${run_id_value}" \
-    -H "x-internal-runner-secret: ${secret_value}"
+    "${header_args[@]}"
 }

--- a/zoom-api/app/zoom.py
+++ b/zoom-api/app/zoom.py
@@ -58,7 +58,12 @@ class ZoomClient:
             "type": 2,  # scheduled
             "start_time": start_time,
             "duration": duration,
-            "settings": {"approval_type": 0, "registration_type": 1},
+            "settings": {
+                "approval_type": 0,
+                "registration_type": 1,
+                "registrants_email_notification": False,
+                "registrants_confirmation_email": False,
+            },
         }
         user_id = "me"
         if isinstance(host_zoom_user_id, str) and host_zoom_user_id.strip():

--- a/zoom-api/tests/test_main.py
+++ b/zoom-api/tests/test_main.py
@@ -222,7 +222,7 @@ def test_get_participants_meeting_in_progress(client, headers):
 # ── POST /meetings ────────────────────────────────────────────────────────────
 
 def test_create_meeting_success(client, headers):
-    with patch("app.zoom.httpx.post", side_effect=[ok(TOKEN_RESP), ok(CREATE_RESP)]):
+    with patch("app.zoom.httpx.post", side_effect=[ok(TOKEN_RESP), ok(CREATE_RESP)]) as mock_post:
         resp = client.post("/meetings", headers=headers, json={
             "topic": "Q2 Review",
             "start_time": "2026-06-01T14:00:00",
@@ -233,6 +233,10 @@ def test_create_meeting_success(client, headers):
     assert data["id"] == 99999
     assert data["uuid"] == "meeting-uuid-123"
     assert data["join_url"] == "https://zoom.us/j/99999"
+    payload = mock_post.call_args_list[1].kwargs["json"]
+    settings = payload["settings"]
+    assert settings["registrants_email_notification"] is False
+    assert settings["registrants_confirmation_email"] is False
 
 
 def test_create_meeting_with_host_success(client, headers):


### PR DESCRIPTION
## What
- fix scheduler curl helper to avoid duplicate x-internal-runner-secret headers
- disable Zoom registrant email notifications in meeting creation settings
- add assertion coverage for notification settings in zoom-api tests

## Why
- duplicate secret headers can produce false 401 responses
- Zoom-generated reminder/confirmation emails should be disabled for app-managed flows

## Verification
- scheduler Docker smoke call succeeds with a single auth header
- zoom-api: make test