### PR TITLE
Reconcile Zoom meetings when class schedule changes

### DIFF
--- a/web/app/lib/zoom-jobs/provision.server.ts
+++ b/web/app/lib/zoom-jobs/provision.server.ts
@@ -24,6 +24,11 @@ type ClassZoomMeetingRow = {
   class_id: string
   zoom_host_id: string
   status: 'pending' | 'created' | 'failed' | 'cancelled'
+  start_time?: string | null
+  duration_minutes?: number | null
+  topic?: string | null
+  zoom_meeting_id?: string | null
+  zoom_meeting_uuid?: string | null
   class?: Array<{ starts_at: string; ends_at: string }> | null
 }
 
@@ -143,15 +148,73 @@ const upsertFailedMeeting = async (classId: string, errorMessage: string) => {
   }
 }
 
+const isMeetingScheduleOutOfSync = ({
+  existingStart,
+  existingDuration,
+  existingTopic,
+  nextStart,
+  nextDuration,
+  nextTopic,
+}: {
+  existingStart: string | null | undefined
+  existingDuration: number | null | undefined
+  existingTopic: string | null | undefined
+  nextStart: string
+  nextDuration: number
+  nextTopic: string
+}) => {
+  const existingStartMs = existingStart ? new Date(existingStart).getTime() : Number.NaN
+  const nextStartMs = new Date(nextStart).getTime()
+  const startOutOfSync = !Number.isFinite(existingStartMs) || !Number.isFinite(nextStartMs) || Math.abs(existingStartMs - nextStartMs) > 60_000
+
+  const durationOutOfSync = typeof existingDuration !== 'number' || existingDuration !== nextDuration
+  const topicOutOfSync = (existingTopic ?? '').trim() !== nextTopic.trim()
+
+  return startOutOfSync || durationOutOfSync || topicOutOfSync
+}
+
 const ensureMeetingForClass = async (classRow: ClassRow) => {
+  const desiredTopic = buildTopic(classRow)
+  const durationMinutes = Math.max(1, Math.round((new Date(classRow.ends_at).getTime() - new Date(classRow.starts_at).getTime()) / 60000))
+
   const { data: existingMeeting, error: existingError } = await adminClient
     .from('class_zoom_meeting')
-    .select('id, class_id, zoom_host_id, status, zoom_meeting_id, zoom_meeting_uuid')
+    .select('id, class_id, zoom_host_id, status, zoom_meeting_id, zoom_meeting_uuid, start_time, duration_minutes, topic')
     .eq('class_id', classRow.id)
     .maybeSingle()
 
   if (existingError) throw new Error(existingError.message)
   if (existingMeeting?.status === 'created' && existingMeeting.zoom_meeting_id && existingMeeting.zoom_meeting_uuid) {
+    if (
+      isMeetingScheduleOutOfSync({
+        existingStart: existingMeeting.start_time,
+        existingDuration: existingMeeting.duration_minutes,
+        existingTopic: existingMeeting.topic,
+        nextStart: classRow.starts_at,
+        nextDuration: durationMinutes,
+        nextTopic: desiredTopic,
+      })
+    ) {
+      await zoomApiClient.updateMeeting(existingMeeting.zoom_meeting_id, {
+        topic: desiredTopic,
+        start_time: classRow.starts_at,
+        duration: durationMinutes,
+      })
+
+      const { error: updateError } = await adminClient
+        .from('class_zoom_meeting')
+        .update({
+          topic: desiredTopic,
+          start_time: classRow.starts_at,
+          duration_minutes: durationMinutes,
+          error_message: null,
+          last_synced_at: new Date().toISOString(),
+        })
+        .eq('id', existingMeeting.id)
+
+      if (updateError) throw new Error(updateError.message)
+    }
+
     return { id: existingMeeting.id, zoom_meeting_id: existingMeeting.zoom_meeting_id, created: false }
   }
 
@@ -162,9 +225,8 @@ const ensureMeetingForClass = async (classRow: ClassRow) => {
     throw new Error(msg)
   }
 
-  const durationMinutes = Math.max(1, Math.round((new Date(classRow.ends_at).getTime() - new Date(classRow.starts_at).getTime()) / 60000))
   const createResp = await zoomApiClient.createMeeting({
-    topic: buildTopic(classRow),
+    topic: desiredTopic,
     start_time: classRow.starts_at,
     duration: durationMinutes,
     ...(host.zoom_user_id ? { host_zoom_user_id: host.zoom_user_id } : {}),
@@ -181,7 +243,7 @@ const ensureMeetingForClass = async (classRow: ClassRow) => {
         host_zoom_user_email: host.zoom_user_email,
         zoom_meeting_id: String(createResp.id),
         zoom_meeting_uuid: createResp.uuid,
-        topic: buildTopic(classRow),
+        topic: desiredTopic,
         start_time: classRow.starts_at,
         duration_minutes: durationMinutes,
         join_url: createResp.join_url,

--- a/web/app/lib/zoom-jobs/zoom-api.client.server.ts
+++ b/web/app/lib/zoom-jobs/zoom-api.client.server.ts
@@ -14,6 +14,12 @@ type ZoomCreateMeetingRequest = {
   host_zoom_user_email?: string
 }
 
+type ZoomUpdateMeetingRequest = {
+  topic: string
+  start_time: string
+  duration: number
+}
+
 type ZoomCreateMeetingResponse = {
   id: number
   uuid: string
@@ -49,7 +55,7 @@ const parsePayload = async (response: Response) => {
   return response.text().catch(() => null)
 }
 
-const requestJson = async <T>({ method, path, body }: { method: 'GET' | 'POST'; path: string; body?: unknown }): Promise<T> => {
+const requestJson = async <T>({ method, path, body }: { method: 'GET' | 'POST' | 'PATCH'; path: string; body?: unknown }): Promise<T> => {
   const { endpoint, apiKey } = getConfig()
   const response = await fetch(`${endpoint}${path}`, {
     method,
@@ -72,6 +78,8 @@ export const zoomApiClient = {
   listHosts: () => requestJson<Record<string, unknown>>({ method: 'GET', path: '/hosts' }),
   createMeeting: (body: ZoomCreateMeetingRequest) =>
     requestJson<ZoomCreateMeetingResponse>({ method: 'POST', path: '/meetings', body }),
+  updateMeeting: (meetingId: string, body: ZoomUpdateMeetingRequest) =>
+    requestJson<{ ok: boolean }>({ method: 'PATCH', path: `/meetings/${meetingId}`, body }),
   registerParticipant: async (meetingId: string, registrant: ZoomRegistrantRequest) => {
     const results = await requestJson<Array<{ registrant_id?: string; join_url?: string }>>({
       method: 'POST',

--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -61,6 +61,15 @@ class CreateMeetingResponse(BaseModel):
     join_url: str = Field(description="URL participants use to join the meeting.")
 
 
+class UpdateMeetingRequest(BaseModel):
+    topic: str = Field(description="Meeting title.", examples=["Summer Lunch Program - Week 3"])
+    start_time: str = Field(
+        description="Meeting start time in ISO 8601 format. Include a timezone offset or 'Z' for UTC.",
+        examples=["2026-06-15T10:00:00Z"],
+    )
+    duration: int = Field(description="Meeting duration in minutes.", examples=[60])
+
+
 class ZoomUserSummary(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -236,6 +245,21 @@ def create_meeting(body: CreateMeetingRequest) -> CreateMeetingResponse:
     except httpx.HTTPStatusError as exc:
         raise _as_http_exception(exc) from exc
     return {"id": result["id"], "uuid": result["uuid"], "join_url": result["join_url"]}
+
+
+@app.patch("/meetings/{meeting_id}", dependencies=[Depends(get_api_key)])
+def update_meeting(meeting_id: str, body: UpdateMeetingRequest) -> dict[str, bool]:
+    """Updates a scheduled Zoom meeting's topic/start time/duration."""
+    try:
+        _zoom().update_meeting(
+            meeting_id=meeting_id,
+            topic=body.topic,
+            start_time=body.start_time,
+            duration=body.duration,
+        )
+    except httpx.HTTPStatusError as exc:
+        raise _as_http_exception(exc) from exc
+    return {"ok": True}
 
 
 @app.post("/meetings/{meeting_id}/registrants", dependencies=[Depends(get_api_key)])

--- a/zoom-api/app/zoom.py
+++ b/zoom-api/app/zoom.py
@@ -85,6 +85,19 @@ class ZoomClient:
         r.raise_for_status()
         return r.json()
 
+    def update_meeting(self, meeting_id: str, topic: str, start_time: str, duration: int) -> None:
+        payload = {
+            "topic": topic,
+            "start_time": start_time,
+            "duration": duration,
+        }
+        r = httpx.patch(
+            f"{ZOOM_API_BASE}/meetings/{meeting_id}",
+            json=payload,
+            headers=self._headers(),
+        )
+        r.raise_for_status()
+
     def register_participants(self, meeting_id: str, registrants: list[dict]) -> list[dict]:
         results = []
         headers = self._headers()

--- a/zoom-api/tests/test_main.py
+++ b/zoom-api/tests/test_main.py
@@ -275,6 +275,30 @@ def test_create_meeting_missing_auth(client):
     assert resp.status_code == 401
 
 
+def test_update_meeting_success(client, headers):
+    with patch("app.zoom.httpx.post", return_value=ok(TOKEN_RESP)), \
+         patch("app.zoom.httpx.patch", return_value=ok({})) as mock_patch:
+        resp = client.patch("/meetings/99999", headers=headers, json={
+            "topic": "Q2 Review Updated",
+            "start_time": "2026-06-01T15:00:00",
+            "duration": 90,
+        })
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    payload = mock_patch.call_args.kwargs["json"]
+    assert payload["topic"] == "Q2 Review Updated"
+    assert payload["duration"] == 90
+
+
+def test_update_meeting_missing_auth(client):
+    resp = client.patch("/meetings/99999", json={
+        "topic": "Q2 Review Updated",
+        "start_time": "2026-06-01T15:00:00",
+        "duration": 90,
+    })
+    assert resp.status_code == 401
+
+
 # ── POST /meetings/{id}/registrants ──────────────────────────────────────────
 
 def test_register_participants_success(client, headers):


### PR DESCRIPTION
## What
- add zoom-api endpoint to patch scheduled meeting metadata (`PATCH /meetings/{meeting_id}`)
- add web zoom-api client support for PATCH requests
- detect schedule/topic drift for existing created class meetings during provisioning
- update existing Zoom meeting when class start/duration/topic changes
- update zoom-api tests for new endpoint

## Verification
- web: `npm run typecheck`
- zoom-api: `make test`