### PR TITLE
Show CF-Connecting-IP in person activity

### DIFF
--- a/web/app/routes/manage/person.activity.tsx
+++ b/web/app/routes/manage/person.activity.tsx
@@ -59,6 +59,7 @@ export default function ManagePersonActivityPage() {
           success: successLabel,
           email: event.login_email ?? '-',
           ip: event.ip_selected ?? event.ip_address ?? event.ip_candidate ?? event.ip_legacy ?? '-',
+          cf_connecting_ip: event.cf_connecting_ip ?? '-',
           ip_selected: event.ip_selected ?? '-',
           source_confidence: [event.ip_selected_source, event.ip_parse_confidence].filter(Boolean).join(' / ') || '-',
           classification:
@@ -88,6 +89,7 @@ export default function ManagePersonActivityPage() {
     'geo',
     'org',
     'ip',
+    'cf_connecting_ip',
     'forwarded_chain',
     'success',
     'email',
@@ -117,6 +119,7 @@ export default function ManagePersonActivityPage() {
       source_detail: { label: 'Source detail', preferredWidth: 200, fitContentOnLoad: true },
       geo: { label: 'Geo', preferredWidth: 220, fitContentOnLoad: true },
       org: { label: 'Org', preferredWidth: 260, truncate: true, fitContentOnLoad: true },
+      cf_connecting_ip: { label: 'CF-Connecting-IP', preferredWidth: 170, fitContentOnLoad: true },
       success: { label: 'Success', preferredWidth: 110, fitContentOnLoad: true },
       email: { label: 'Email', preferredWidth: 220, fitContentOnLoad: true },
       ip: { label: 'IP', preferredWidth: 170, fitContentOnLoad: true },

--- a/web/app/routes/manage/person.shared.ts
+++ b/web/app/routes/manage/person.shared.ts
@@ -55,6 +55,7 @@ export type PersonLoaderData = {
     ip_classifier_version: number | null
     proxy_provider_match: string | null
     proxy_match_cidr: string | null
+    cf_connecting_ip: string | null
     forwarded_for: string | null
     ip_legacy: string | null
     ip_candidate: string | null

--- a/web/app/routes/manage/person.tsx
+++ b/web/app/routes/manage/person.tsx
@@ -32,6 +32,14 @@ const normalizeIp = (ipCandidate: string | null) => {
   return isIP(ipCandidate) ? ipCandidate : null
 }
 
+const headerValue = (headers: unknown, key: string) => {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) return null
+  const value = (headers as Record<string, unknown>)[key]
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
 const geoStatusReasonFor = (input: {
   ipCandidate: string | null
   normalizedIp: string | null
@@ -138,14 +146,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const [latestFormSubmissionResult, latestLoginEventResult] = await Promise.all([
     adminClient
       .from('form_submission')
-      .select('id, form_id, submitted_at, ip_address, ip_selected, ip_selected_source, ip_parse_confidence, ip_classification, ip_confidence_level, ip_reason_codes, ip_reason_text, ip_classifier_version, proxy_provider_match, proxy_match_cidr, forwarded_for')
+      .select('id, form_id, submitted_at, ip_address, ip_selected, ip_selected_source, ip_parse_confidence, ip_classification, ip_confidence_level, ip_reason_codes, ip_reason_text, ip_classifier_version, proxy_provider_match, proxy_match_cidr, forwarded_for, request_headers')
       .eq('profile_id', profileRow.id)
       .order('submitted_at', { ascending: false })
       .limit(25),
     profileRow.user_id
       ? adminClient
           .from('login_event')
-          .select('id, event_at, email, login_method, success, ip_address, ip_selected, ip_selected_source, ip_parse_confidence, ip_classification, ip_confidence_level, ip_reason_codes, ip_reason_text, ip_classifier_version, proxy_provider_match, proxy_match_cidr, forwarded_for')
+          .select('id, event_at, email, login_method, success, ip_address, ip_selected, ip_selected_source, ip_parse_confidence, ip_classification, ip_confidence_level, ip_reason_codes, ip_reason_text, ip_classifier_version, proxy_provider_match, proxy_match_cidr, forwarded_for, request_headers')
           .eq('user_id', profileRow.user_id)
           .order('event_at', { ascending: false })
           .limit(25)
@@ -171,6 +179,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ip_classifier_version: typeof row.ip_classifier_version === 'number' ? row.ip_classifier_version : null,
       proxy_provider_match: typeof row.proxy_provider_match === 'string' ? row.proxy_provider_match : null,
       proxy_match_cidr: typeof row.proxy_match_cidr === 'string' ? row.proxy_match_cidr : null,
+      cf_connecting_ip: headerValue(row.request_headers, 'cf-connecting-ip'),
       forwarded_for: typeof row.forwarded_for === 'string' ? row.forwarded_for : null,
       ip_legacy: typeof row.ip_address === 'string' ? row.ip_address : null,
       ip_candidate: resolveIpCandidate(
@@ -196,6 +205,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ip_classifier_version: typeof row.ip_classifier_version === 'number' ? row.ip_classifier_version : null,
       proxy_provider_match: typeof row.proxy_provider_match === 'string' ? row.proxy_provider_match : null,
       proxy_match_cidr: typeof row.proxy_match_cidr === 'string' ? row.proxy_match_cidr : null,
+      cf_connecting_ip: headerValue(row.request_headers, 'cf-connecting-ip'),
       forwarded_for: typeof row.forwarded_for === 'string' ? row.forwarded_for : null,
       ip_legacy: typeof row.ip_address === 'string' ? row.ip_address : null,
       ip_candidate: resolveIpCandidate(
@@ -295,6 +305,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         ip_classifier_version: row.ip_classifier_version,
         proxy_provider_match: row.proxy_provider_match,
         proxy_match_cidr: row.proxy_match_cidr,
+        cf_connecting_ip: row.cf_connecting_ip,
         forwarded_for: row.forwarded_for,
         ip_legacy: row.ip_legacy,
         ip_candidate: row.ip_candidate,


### PR DESCRIPTION
## What\n- read cf-connecting-ip from stored request_headers in person loader\n- add cf_connecting_ip to person activity event shape\n- display CF-Connecting-IP as the 7th column in Activity and IP logs\n\n## Why\n- make Cloudflare edge IP attribution visible directly in manage person activity\n\n## Verification\n- npm run typecheck