### PR TITLE
Add family rescan and align discrepancy IP selection

### DIFF
--- a/web/app/lib/ip-evidence-recompute.server.ts
+++ b/web/app/lib/ip-evidence-recompute.server.ts
@@ -27,6 +27,8 @@ type RecomputeResult = RecomputePreview & {
 type RecomputeOptions = {
   maxRowsPerSource?: number
   refreshSignals?: boolean
+  profileIds?: string[]
+  userIds?: string[]
 }
 
 type EventRow = {
@@ -270,21 +272,37 @@ const scoreCandidate = async (
   }
 }
 
-const selectRows = async (source: RecomputeSource, maxRowsPerSource: number) => {
+const selectRows = async (
+  source: RecomputeSource,
+  maxRowsPerSource: number,
+  filters?: { profileIds?: string[]; userIds?: string[] }
+) => {
   if (source === 'form_submission') {
-    const { data } = await (adminClient.from('form_submission' as any) as any)
+    let query = (adminClient.from('form_submission' as any) as any)
       .select(
         'id, profile_id, ip_address, ip_selected, ip_selected_source, ip_chain, request_headers, forwarded_for, ip_classification'
       )
       .order('submitted_at', { ascending: false })
       .limit(maxRowsPerSource)
+
+    if (filters?.profileIds?.length) {
+      query = query.in('profile_id', filters.profileIds)
+    }
+
+    const { data } = await query
     return (data ?? []) as EventRow[]
   }
 
-  const { data } = await (adminClient.from('login_event' as any) as any)
+  let query = (adminClient.from('login_event' as any) as any)
     .select('id, ip_address, ip_selected, ip_selected_source, ip_chain, request_headers, forwarded_for, ip_classification')
     .order('event_at', { ascending: false })
     .limit(maxRowsPerSource)
+
+  if (filters?.userIds?.length) {
+    query = query.in('user_id', filters.userIds)
+  }
+
+  const { data } = await query
   return (data ?? []) as EventRow[]
 }
 
@@ -296,8 +314,12 @@ const updateEventRow = async (source: RecomputeSource, rowId: string, payload: R
 export const previewIpEvidenceRecompute = async (options: RecomputeOptions = {}): Promise<RecomputePreview> => {
   const maxRowsPerSource = normalizeMaxRows(options.maxRowsPerSource)
   const [formRows, loginRows] = await Promise.all([
-    selectRows('form_submission', maxRowsPerSource),
-    selectRows('login_event', maxRowsPerSource),
+    selectRows('form_submission', maxRowsPerSource, {
+      profileIds: options.profileIds,
+    }),
+    selectRows('login_event', maxRowsPerSource, {
+      userIds: options.userIds,
+    }),
   ])
 
   const allRows = [...formRows, ...loginRows]
@@ -321,10 +343,18 @@ export const runIpEvidenceRecompute = async (options: RecomputeOptions = {}): Pr
   const refreshSignals = Boolean(options.refreshSignals)
 
   const [preview, orgPolicies, formRows, loginRows] = await Promise.all([
-    previewIpEvidenceRecompute({ maxRowsPerSource }),
+    previewIpEvidenceRecompute({
+      maxRowsPerSource,
+      profileIds: options.profileIds,
+      userIds: options.userIds,
+    }),
     loadOrgPolicies(),
-    selectRows('form_submission', maxRowsPerSource),
-    selectRows('login_event', maxRowsPerSource),
+    selectRows('form_submission', maxRowsPerSource, {
+      profileIds: options.profileIds,
+    }),
+    selectRows('login_event', maxRowsPerSource, {
+      userIds: options.userIds,
+    }),
   ])
 
   const geoCache = new Map<string, Awaited<ReturnType<typeof resolveIpGeolocation>>>()

--- a/web/app/lib/suspicious-signals.server.ts
+++ b/web/app/lib/suspicious-signals.server.ts
@@ -28,8 +28,8 @@ type LoginEventRow = {
   event_at: string
   ip_address: unknown
   ip_selected: unknown
-  ip_chain: unknown
-  forwarded_for: string | null
+  ip_selected_source: string | null
+  ip_parse_version: number | null
   metadata: Json
 }
 
@@ -43,41 +43,41 @@ type OrgPolicyRow = {
   priority: number
 }
 
-const parseForwardedFirstIp = (value: string | null) => {
-  if (!value) return null
-  const first = value
-    .split(',')
-    .map(part => part.trim())
-    .find(Boolean)
-  return first || null
+const trimIp = (value: unknown) => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed || null
 }
 
-const parseIpChain = (value: unknown) => {
-  if (!Array.isArray(value)) return [] as string[]
-  return value
-    .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
-    .filter(Boolean)
-}
+const normalizeParseVersion = (value: unknown) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : 0
 
-const collectCandidateIps = (input: {
-  ip_chain?: unknown
+const selectSolidIp = (input: {
   ip_selected?: unknown
   ip_address?: unknown
-  forwarded_for?: string | null
+  ip_parse_version?: unknown
 }) => {
-  const seen = new Set<string>()
-  const values: string[] = []
-  for (const ip of [
-    ...parseIpChain(input.ip_chain),
-    typeof input.ip_selected === 'string' ? input.ip_selected.trim() : '',
-    typeof input.ip_address === 'string' ? input.ip_address.trim() : '',
-    parseForwardedFirstIp(input.forwarded_for ?? null) ?? '',
-  ]) {
-    if (!ip || seen.has(ip)) continue
-    seen.add(ip)
-    values.push(ip)
+  const selectedIp = trimIp(input.ip_selected)
+  const fallbackIp = trimIp(input.ip_address)
+  const parseVersion = normalizeParseVersion(input.ip_parse_version)
+
+  if (parseVersion >= 2) {
+    return selectedIp ?? fallbackIp
   }
-  return values
+
+  return fallbackIp ?? selectedIp
+}
+
+const filterToPreferredParseVersion = <T extends { ip_parse_version: number; ip_address: string }>(events: T[]) => {
+  if (!events.length) return events
+
+  const maxVersion = Math.max(...events.map(event => event.ip_parse_version))
+  if (maxVersion <= 0) return events
+
+  const highestVersionEvents = events.filter(event => event.ip_parse_version === maxVersion)
+  const higherVersionIsFulsome = highestVersionEvents.length >= 3 || highestVersionEvents.length === events.length
+
+  return higherVersionIsFulsome ? highestVersionEvents : events
 }
 
 const matchOrgPolicy = (org: string | null, policies: OrgPolicyRow[]) => {
@@ -99,23 +99,6 @@ const matchOrgPolicy = (org: string | null, policies: OrgPolicyRow[]) => {
     }
   }
   return null
-}
-
-const orgPolicyRank = (policyClass: OrgPolicyClass | null) => {
-  switch (policyClass) {
-    case 'consumer_isp':
-      return 40
-    case 'trusted_enterprise':
-      return 35
-    case 'unknown':
-      return 25
-    case 'vpn_hosting_datacenter':
-      return 15
-    case 'infra_proxy':
-      return 5
-    default:
-      return 20
-  }
 }
 
 const detectIpOrgGreylistSignal = (args: {
@@ -205,7 +188,7 @@ const refreshSuspiciousSignalsForProfileWithOptions = async (
       .in('id', familyProfileIds),
     adminClient
       .from('form_submission')
-      .select('id, profile_id, submitted_at, ip_address, ip_selected, ip_chain, forwarded_for, metadata')
+      .select('id, profile_id, submitted_at, ip_address, ip_selected, ip_selected_source, ip_parse_version, metadata')
       .in('profile_id', familyProfileIds)
       .order('submitted_at', { ascending: false })
       .limit(40),
@@ -317,7 +300,7 @@ const refreshSuspiciousSignalsForProfileWithOptions = async (
     const { data: loginEvents } = subjectUserId
       ? await adminClient
           .from('login_event')
-          .select('id, event_at, ip_address, ip_selected, ip_chain, forwarded_for, metadata')
+          .select('id, event_at, ip_address, ip_selected, ip_selected_source, ip_parse_version, metadata')
           .eq('user_id', subjectUserId)
           .order('event_at', { ascending: false })
           .limit(20)
@@ -357,45 +340,45 @@ const refreshSuspiciousSignalsForProfileWithOptions = async (
       eventId: string
       source: 'form_submission' | 'login_event'
       occurredAt: string
-      ips: string[]
-      selectedIp: string | null
+      ip_address: string
+      ip_parse_version: number
     }> = []
 
     for (const submission of subjectSubmissions) {
-      const ips = collectCandidateIps({
-        ip_chain: (submission as Record<string, unknown>).ip_chain,
+      const selectedIp = selectSolidIp({
         ip_selected: submission.ip_selected,
         ip_address: submission.ip_address,
-        forwarded_for: typeof submission.forwarded_for === 'string' ? submission.forwarded_for : null,
+        ip_parse_version: (submission as Record<string, unknown>).ip_parse_version,
       })
-      if (!ips.length || !submission.id || !submission.submitted_at) continue
+      if (!selectedIp || !submission.id || !submission.submitted_at) continue
       eventCandidates.push({
         eventId: submission.id,
         source: 'form_submission',
         occurredAt: submission.submitted_at,
-        ips,
-        selectedIp: typeof submission.ip_selected === 'string' ? submission.ip_selected : null,
+        ip_address: selectedIp,
+        ip_parse_version: normalizeParseVersion((submission as Record<string, unknown>).ip_parse_version),
       })
     }
 
     for (const event of (loginEvents ?? []) as LoginEventRow[]) {
-      const ips = collectCandidateIps({
-        ip_chain: event.ip_chain,
+      const selectedIp = selectSolidIp({
         ip_selected: event.ip_selected,
         ip_address: event.ip_address,
-        forwarded_for: event.forwarded_for,
+        ip_parse_version: event.ip_parse_version,
       })
-      if (!ips.length || !event.id || !event.event_at) continue
+      if (!selectedIp || !event.id || !event.event_at) continue
       eventCandidates.push({
         eventId: event.id,
         source: 'login_event',
         occurredAt: event.event_at,
-        ips,
-        selectedIp: typeof event.ip_selected === 'string' ? event.ip_selected : null,
+        ip_address: selectedIp,
+        ip_parse_version: normalizeParseVersion(event.ip_parse_version),
       })
     }
 
-    const uniqueIps = Array.from(new Set(eventCandidates.flatMap(event => event.ips)))
+    const preferredEventCandidates = filterToPreferredParseVersion(eventCandidates)
+
+    const uniqueIps = Array.from(new Set(preferredEventCandidates.map(event => event.ip_address)))
     const locationByIp = new Map<string, Awaited<ReturnType<typeof resolveIpGeolocation>>>()
     await Promise.all(
       uniqueIps.map(async ip => {
@@ -413,49 +396,35 @@ const refreshSuspiciousSignalsForProfileWithOptions = async (
       policy: OrgPolicyRow | null
     }> = []
 
-    const ipEvents = eventCandidates
+    const ipEvents = preferredEventCandidates
       .map((candidate): IpLocationEvidence | null => {
-        const evaluated = candidate.ips
-          .map(ip => {
-            const location = locationByIp.get(ip) ?? null
-            const org = location?.org ?? null
-            const policy = matchOrgPolicy(org, orgPolicies)
-            if (policy?.policy_class === 'vpn_hosting_datacenter') {
-              greylistEvidence.push({
-                event_id: candidate.eventId,
-                source: candidate.source,
-                occurred_at: candidate.occurredAt,
-                ip_address: ip,
-                org,
-                policy,
-              })
-            }
-            const score =
-              (policy ? orgPolicyRank(policy.policy_class) : 20) +
-              (candidate.selectedIp === ip ? 8 : 0) +
-              (location ? 10 : 0)
-            return {
-              ip,
-              location,
-              score,
-            }
-          })
-          .sort((left, right) => right.score - left.score)
+        const location = locationByIp.get(candidate.ip_address) ?? null
+        if (!location) return null
 
-        const best = evaluated.find(entry => entry.location) ?? evaluated[0]
-        if (!best?.location) return null
+        const org = location.org ?? null
+        const policy = matchOrgPolicy(org, orgPolicies)
+        if (policy?.policy_class === 'vpn_hosting_datacenter') {
+          greylistEvidence.push({
+            event_id: candidate.eventId,
+            source: candidate.source,
+            occurred_at: candidate.occurredAt,
+            ip_address: candidate.ip_address,
+            org,
+            policy,
+          })
+        }
 
         return {
           event_id: candidate.eventId,
           source: candidate.source,
           occurred_at: candidate.occurredAt,
-          ip_address: best.ip,
-          country_code: best.location.countryCode,
-          region: best.location.region,
-          city: best.location.city,
-          latitude: best.location.latitude,
-          longitude: best.location.longitude,
-          provider: best.location.source ?? null,
+          ip_address: candidate.ip_address,
+          country_code: location.countryCode,
+          region: location.region,
+          city: location.city,
+          latitude: location.latitude,
+          longitude: location.longitude,
+          provider: location.source ?? null,
         }
       })
       .filter((event): event is IpLocationEvidence => event !== null)

--- a/web/app/routes/manage/person.tsx
+++ b/web/app/routes/manage/person.tsx
@@ -1,10 +1,12 @@
 import { isIP } from 'node:net'
 
-import { Link, NavLink, Outlet, redirect, useLoaderData, useLocation } from 'react-router'
+import { Form, Link, NavLink, Outlet, redirect, useActionData, useLoaderData, useLocation, useNavigation } from 'react-router'
 
 import { requireAuth } from '@/lib/auth.server'
 import { resolveIpGeolocation } from '@/lib/geoip.server'
+import { runIpEvidenceRecompute } from '@/lib/ip-evidence-recompute.server'
 import { isRoleAtLeast } from '@/lib/roles'
+import { refreshSuspiciousSignalsForProfile } from '@/lib/suspicious-signals.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -38,6 +40,37 @@ const headerValue = (headers: unknown, key: string) => {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
   return trimmed || null
+}
+
+const loadFamilyGraph = async (seedProfileId: string) => {
+  const seen = new Set<string>([seedProfileId])
+  const queue: string[] = [seedProfileId]
+  const edges: Array<{ guardian_profile_id: string; child_profile_id: string; primary_child: boolean }> = []
+
+  while (queue.length) {
+    const batch = queue.splice(0, queue.length)
+    const { data: batchEdges } = await adminClient
+      .from('person_guardian_child')
+      .select('guardian_profile_id, child_profile_id, primary_child')
+      .or(`guardian_profile_id.in.(${batch.join(',')}),child_profile_id.in.(${batch.join(',')})`)
+
+    for (const edge of batchEdges ?? []) {
+      edges.push(edge)
+      if (!seen.has(edge.guardian_profile_id)) {
+        seen.add(edge.guardian_profile_id)
+        queue.push(edge.guardian_profile_id)
+      }
+      if (!seen.has(edge.child_profile_id)) {
+        seen.add(edge.child_profile_id)
+        queue.push(edge.child_profile_id)
+      }
+    }
+  }
+
+  return {
+    familyProfileIds: Array.from(seen),
+    edges,
+  }
 }
 
 const geoStatusReasonFor = (input: {
@@ -143,20 +176,34 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw redirect('/manage/participants', { headers: auth.headers })
   }
 
+  const { familyProfileIds, edges } = await loadFamilyGraph(profileRow.id)
+
+  const { data: familyProfilesRaw } = await adminClient
+    .from('profile')
+    .select(
+      'id, user_id, role, firstname, surname, email, phone, street_address, city, province, postcode, date_of_birth, federal_electoral_district_name, riding_lookup_status, riding_lookup_last_attempt_at, riding_lookup_error'
+    )
+    .in('id', familyProfileIds)
+
+  const familyProfiles = (familyProfilesRaw ?? []) as ProfileRow[]
+  const familyUserIds = Array.from(
+    new Set(familyProfiles.map(profile => profile.user_id).filter((userId): userId is string => Boolean(userId)))
+  )
+
   const [latestFormSubmissionResult, latestLoginEventResult] = await Promise.all([
     adminClient
       .from('form_submission')
       .select('id, form_id, submitted_at, ip_address, ip_selected, ip_selected_source, ip_parse_confidence, ip_classification, ip_confidence_level, ip_reason_codes, ip_reason_text, ip_classifier_version, proxy_provider_match, proxy_match_cidr, forwarded_for, request_headers')
-      .eq('profile_id', profileRow.id)
+      .in('profile_id', familyProfileIds)
       .order('submitted_at', { ascending: false })
-      .limit(25),
-    profileRow.user_id
+      .limit(100),
+    familyUserIds.length
       ? adminClient
           .from('login_event')
           .select('id, event_at, email, login_method, success, ip_address, ip_selected, ip_selected_source, ip_parse_confidence, ip_classification, ip_confidence_level, ip_reason_codes, ip_reason_text, ip_classifier_version, proxy_provider_match, proxy_match_cidr, forwarded_for, request_headers')
-          .eq('user_id', profileRow.user_id)
+          .in('user_id', familyUserIds)
           .order('event_at', { ascending: false })
-          .limit(25)
+          .limit(100)
       : Promise.resolve({ data: [] as Array<Record<string, unknown>> }),
   ])
 
@@ -325,39 +372,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const ipEvidence = activityEvents.slice(0, 8)
 
-  const seen = new Set<string>([profileRow.id])
-  const queue: string[] = [profileRow.id]
-  const edges: Array<{ guardian_profile_id: string; child_profile_id: string; primary_child: boolean }> = []
-
-  while (queue.length) {
-    const batch = queue.splice(0, queue.length)
-    const { data: batchEdges } = await adminClient
-      .from('person_guardian_child')
-      .select('guardian_profile_id, child_profile_id, primary_child')
-      .or(`guardian_profile_id.in.(${batch.join(',')}),child_profile_id.in.(${batch.join(',')})`)
-
-    for (const edge of batchEdges ?? []) {
-      edges.push(edge)
-      if (!seen.has(edge.guardian_profile_id)) {
-        seen.add(edge.guardian_profile_id)
-        queue.push(edge.guardian_profile_id)
-      }
-      if (!seen.has(edge.child_profile_id)) {
-        seen.add(edge.child_profile_id)
-        queue.push(edge.child_profile_id)
-      }
-    }
-  }
-
-  const familyProfileIds = Array.from(seen)
-
-  const [{ data: familyProfilesRaw }, { data: enrollmentRowsRaw }, { data: suspiciousSignalsRaw }, { data: districtRowsRaw }] = await Promise.all([
-    adminClient
-      .from('profile')
-      .select(
-        'id, user_id, role, firstname, surname, email, phone, street_address, city, province, postcode, date_of_birth, federal_electoral_district_name, riding_lookup_status, riding_lookup_last_attempt_at, riding_lookup_error'
-      )
-      .in('id', familyProfileIds),
+  const [{ data: enrollmentRowsRaw }, { data: suspiciousSignalsRaw }, { data: districtRowsRaw }] = await Promise.all([
     adminClient
       .from('workshop_enrollment')
       .select('id, profile_id, workshop_id, semester_id, status, requested_at')
@@ -375,14 +390,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
       .order('name', { ascending: true }),
   ])
 
-  const familyProfiles = (familyProfilesRaw ?? []) as ProfileRow[]
   const enrollments = (enrollmentRowsRaw ?? []) as PersonLoaderData['enrollments']
   const suspiciousSignals = ((suspiciousSignalsRaw ?? []) as SuspiciousSignalRow[]).filter(signal =>
     signal.family_profile_ids?.some(profileId => familyProfileIds.includes(profileId))
-  )
-
-  const familyUserIds = Array.from(
-    new Set(familyProfiles.map(profile => profile.user_id).filter((userId): userId is string => Boolean(userId)))
   )
 
   const { data: profileLinkedSubmissionsRaw } = familyProfileIds.length
@@ -518,8 +528,57 @@ export async function action({ request }: LoaderFunctionArgs) {
 
   const formData = await request.formData()
   const intent = String(formData.get('intent') ?? '')
-  if (intent !== 'update-riding') {
+  if (intent !== 'update-riding' && intent !== 'rescan-family') {
     return new Response('Unsupported action', { status: 400, headers: auth.headers })
+  }
+
+  if (intent === 'rescan-family') {
+    const profileId = String(formData.get('profile_id') ?? '').trim()
+    if (!profileId) {
+      return { error: 'Missing profile id.' }
+    }
+
+    const { familyProfileIds } = await loadFamilyGraph(profileId)
+    if (!familyProfileIds.length) {
+      return { error: 'No family members found for rescan.' }
+    }
+
+    const { data: familyProfilesRaw } = await adminClient
+      .from('profile')
+      .select('id, user_id')
+      .in('id', familyProfileIds)
+
+    const familyProfiles = (familyProfilesRaw ?? []) as Array<{ id: string; user_id: string | null }>
+    const familyUserIds = Array.from(
+      new Set(familyProfiles.map(profile => profile.user_id).filter((userId): userId is string => Boolean(userId)))
+    )
+
+    const recomputeResult = await runIpEvidenceRecompute({
+      maxRowsPerSource: 2000,
+      refreshSignals: false,
+      profileIds: familyProfileIds,
+      userIds: familyUserIds,
+    })
+
+    let refreshedFamilies = 0
+    for (const familyProfileId of familyProfileIds) {
+      try {
+        await refreshSuspiciousSignalsForProfile(familyProfileId)
+        refreshedFamilies += 1
+      } catch (error) {
+        console.error('[manage/person] family rescan signal refresh failed', {
+          familyProfileId,
+          error,
+        })
+      }
+    }
+
+    return {
+      success: true,
+      rescanned: true,
+      recomputeResult,
+      refreshedFamilies,
+    }
   }
 
   const profileId = String(formData.get('profile_id') ?? '').trim()
@@ -561,11 +620,28 @@ export async function action({ request }: LoaderFunctionArgs) {
 
 export default function ManagePersonLayoutPage() {
   const data = useLoaderData() as PersonLoaderData
+  const actionData = useActionData() as
+    | {
+        success?: boolean
+        error?: string
+        rescanned?: boolean
+        refreshedFamilies?: number
+        recomputeResult?: {
+          updatedRows: {
+            formSubmission: number
+            loginEvent: number
+          }
+        }
+      }
+    | undefined
   const { profile, suspiciousSignals } = data
   const location = useLocation()
+  const navigation = useNavigation()
   const returnTo = new URLSearchParams(location.search).get('returnTo')
   const backTo = returnTo && returnTo.startsWith('/') ? returnTo : '/manage/participants'
   const openSignalCount = suspiciousSignals.filter(signal => signal.status === 'open').length
+  const isRescanning =
+    navigation.state === 'submitting' && navigation.formData?.get('intent') === 'rescan-family'
 
   return (
     <div className="space-y-5">
@@ -582,6 +658,24 @@ export default function ManagePersonLayoutPage() {
         <Button asChild variant="outline" size="sm">
           <Link to={backTo}>Back</Link>
         </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Form method="post">
+          <input type="hidden" name="intent" value="rescan-family" />
+          <input type="hidden" name="profile_id" value={profile.id} />
+          <Button type="submit" variant="secondary" size="sm" disabled={isRescanning}>
+            {isRescanning ? 'Re-scanning family...' : 'Re-scan family'}
+          </Button>
+        </Form>
+        {actionData?.rescanned ? (
+          <p className="text-xs text-muted-foreground">
+            Re-scan complete: {actionData.recomputeResult?.updatedRows.formSubmission ?? 0} form rows,{' '}
+            {actionData.recomputeResult?.updatedRows.loginEvent ?? 0} login rows,{' '}
+            {actionData.refreshedFamilies ?? 0} profile discrepancy refreshes.
+          </p>
+        ) : null}
+        {actionData?.error ? <p className="text-xs text-destructive">{actionData.error}</p> : null}
       </div>
 
       <nav className="sticky left-0 top-0 z-30 -mx-2 overflow-x-auto border-b bg-background/95 px-2 pb-2 pt-2 backdrop-blur supports-[backdrop-filter]:bg-background/80">


### PR DESCRIPTION
## What\n- scope Manage Person activity/IP logs to family profiles and linked users\n- add a `Re-scan family` action on Manage Person that recomputes IP evidence for that family and refreshes discrepancy signals\n- update suspicious-signal IP org/mismatch evaluation to use a single solid IP per event (prefer v2-selected IP when available)\n- prefer highest `ip_parse_version` evidence when higher-version rows are fulsome\n- add scoped filters to `runIpEvidenceRecompute` / preview for targeted family rescans\n\n## Verification\n- `cd web && npm run typecheck`