### PR TITLE
Unify enrollment revocation as status transitions

### DIFF
--- a/supabase/migrations/20260628231500_enrollment_revoke_reenroll.sql
+++ b/supabase/migrations/20260628231500_enrollment_revoke_reenroll.sql
@@ -1,0 +1,113 @@
+create or replace function public.request_family_workshop_enrollment(
+  p_workshop_id uuid,
+  p_profile_id uuid,
+  p_family_profile_ids uuid[]
+)
+returns table (
+  ok boolean,
+  enrollment_id uuid,
+  enrollment_status public.workshop_enrollment_status,
+  error_code text,
+  error_message text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_workshop public.workshop%rowtype;
+  v_now timestamptz := now();
+  v_existing_enrollment_id uuid;
+  v_reusable_enrollment_id uuid;
+  v_approved_count integer;
+  v_waitlisted_count integer;
+  v_status public.workshop_enrollment_status;
+  v_inserted_id uuid;
+begin
+  if p_workshop_id is null or p_profile_id is null then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'invalid_input', 'Missing workshop or profile id';
+    return;
+  end if;
+
+  select *
+  into v_workshop
+  from public.workshop
+  where id = p_workshop_id
+  for update;
+
+  if not found then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'workshop_not_found', 'Workshop not found';
+    return;
+  end if;
+
+  if (
+    (v_workshop.enrollment_open_at is not null and v_now < v_workshop.enrollment_open_at)
+    or (v_workshop.enrollment_close_at is not null and v_now > v_workshop.enrollment_close_at)
+  ) then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'enrollment_closed', 'Enrollment is closed for this workshop';
+    return;
+  end if;
+
+  select we.id
+  into v_existing_enrollment_id
+  from public.workshop_enrollment we
+  where we.semester_id = v_workshop.semester_id
+    and we.profile_id = any(coalesce(p_family_profile_ids, array[]::uuid[]))
+    and we.status not in ('rejected', 'revoked')
+  limit 1;
+
+  if v_existing_enrollment_id is not null then
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'family_already_enrolled', 'Your family is already enrolled in one workshop for this semester.';
+    return;
+  end if;
+
+  select we.id
+  into v_reusable_enrollment_id
+  from public.workshop_enrollment we
+  where we.semester_id = v_workshop.semester_id
+    and we.profile_id = p_profile_id
+    and we.status in ('rejected', 'revoked')
+  order by we.updated_at desc, we.requested_at desc
+  limit 1
+  for update;
+
+  select count(*)::integer
+  into v_approved_count
+  from public.workshop_enrollment
+  where workshop_id = p_workshop_id
+    and status = 'approved';
+
+  select count(*)::integer
+  into v_waitlisted_count
+  from public.workshop_enrollment
+  where workshop_id = p_workshop_id
+    and status = 'waitlisted';
+
+  if v_approved_count < greatest(coalesce(v_workshop.capacity, 0), 0) then
+    v_status := 'pending';
+  elsif v_waitlisted_count < greatest(coalesce(v_workshop.wait_list_capacity, 0), 0) then
+    v_status := 'waitlisted';
+  else
+    return query select false, null::uuid, null::public.workshop_enrollment_status, 'workshop_full', 'This workshop and its waitlist are full';
+    return;
+  end if;
+
+  if v_reusable_enrollment_id is not null then
+    update public.workshop_enrollment
+    set
+      workshop_id = p_workshop_id,
+      status = v_status,
+      requested_at = v_now,
+      decided_at = null,
+      decided_by = null
+    where id = v_reusable_enrollment_id
+    returning id into v_inserted_id;
+  else
+    insert into public.workshop_enrollment (workshop_id, profile_id, status)
+    values (p_workshop_id, p_profile_id, v_status)
+    returning id into v_inserted_id;
+  end if;
+
+  return query select true, v_inserted_id, v_status, null::text, null::text;
+end;
+$$;

--- a/supabase/schemas/03_semesters_cohorts_classes.sql
+++ b/supabase/schemas/03_semesters_cohorts_classes.sql
@@ -234,6 +234,7 @@ declare
   v_workshop public.workshop%rowtype;
   v_now timestamptz := now();
   v_existing_enrollment_id uuid;
+  v_reusable_enrollment_id uuid;
   v_approved_count integer;
   v_waitlisted_count integer;
   v_status public.workshop_enrollment_status;
@@ -268,12 +269,23 @@ begin
   from public.workshop_enrollment we
   where we.semester_id = v_workshop.semester_id
     and we.profile_id = any(coalesce(p_family_profile_ids, array[]::uuid[]))
+    and we.status not in ('rejected', 'revoked')
   limit 1;
 
   if v_existing_enrollment_id is not null then
     return query select false, null::uuid, null::public.workshop_enrollment_status, 'family_already_enrolled', 'Your family is already enrolled in one workshop for this semester.';
     return;
   end if;
+
+  select we.id
+  into v_reusable_enrollment_id
+  from public.workshop_enrollment we
+  where we.semester_id = v_workshop.semester_id
+    and we.profile_id = p_profile_id
+    and we.status in ('rejected', 'revoked')
+  order by we.updated_at desc, we.requested_at desc
+  limit 1
+  for update;
 
   select count(*)::integer
   into v_approved_count
@@ -296,9 +308,21 @@ begin
     return;
   end if;
 
-  insert into public.workshop_enrollment (workshop_id, profile_id, status)
-  values (p_workshop_id, p_profile_id, v_status)
-  returning id into v_inserted_id;
+  if v_reusable_enrollment_id is not null then
+    update public.workshop_enrollment
+    set
+      workshop_id = p_workshop_id,
+      status = v_status,
+      requested_at = v_now,
+      decided_at = null,
+      decided_by = null
+    where id = v_reusable_enrollment_id
+    returning id into v_inserted_id;
+  else
+    insert into public.workshop_enrollment (workshop_id, profile_id, status)
+    values (p_workshop_id, p_profile_id, v_status)
+    returning id into v_inserted_id;
+  end if;
 
   return query select true, v_inserted_id, v_status, null::text, null::text;
 end;

--- a/web/app/lib/workshop-enrollment-status.server.ts
+++ b/web/app/lib/workshop-enrollment-status.server.ts
@@ -1,0 +1,96 @@
+import type { Database } from '@/lib/database.types'
+import { adminClient } from '@/lib/supabase/adminClient'
+
+type EnrollmentStatus = Database['public']['Enums']['workshop_enrollment_status']
+
+type TransitionScope = 'family' | 'admin'
+
+type TransitionResult = {
+  ok: boolean
+  error?: string
+  code?: 'not_found' | 'forbidden' | 'invalid_status' | 'update_failed'
+  previousStatus?: EnrollmentStatus
+  enrollment?: {
+    id: string
+    workshop_id: string | null
+    semester_id: string
+    profile_id: string | null
+    status: EnrollmentStatus
+  }
+}
+
+const FAMILY_REVOCABLE_STATUSES = new Set<EnrollmentStatus>(['pending', 'waitlisted'])
+
+type EnrollmentRow = {
+  id: string
+  workshop_id: string | null
+  semester_id: string
+  profile_id: string | null
+  status: EnrollmentStatus
+}
+
+export const transitionWorkshopEnrollmentStatus = async ({
+  enrollmentId,
+  nextStatus,
+  actorUserId,
+  scope,
+  semesterId,
+  familyProfileIds,
+}: {
+  enrollmentId: string
+  nextStatus: EnrollmentStatus
+  actorUserId: string
+  scope: TransitionScope
+  semesterId?: string
+  familyProfileIds?: string[]
+}): Promise<TransitionResult> => {
+  const { data: enrollment, error } = await adminClient
+    .from('workshop_enrollment')
+    .select('id, workshop_id, semester_id, profile_id, status')
+    .eq('id', enrollmentId)
+    .single<EnrollmentRow>()
+
+  if (error || !enrollment) {
+    return { ok: false, error: error?.message ?? 'Enrollment not found', code: 'not_found' }
+  }
+
+  if (scope === 'family') {
+    if (!semesterId || enrollment.semester_id !== semesterId) {
+      return { ok: false, error: 'Enrollment does not belong to this semester', code: 'forbidden' }
+    }
+
+    if (!enrollment.profile_id || !familyProfileIds?.includes(enrollment.profile_id)) {
+      return { ok: false, error: 'Enrollment is not in your family', code: 'forbidden' }
+    }
+
+    if (nextStatus !== 'revoked') {
+      return { ok: false, error: 'Families can only revoke an enrollment request.', code: 'forbidden' }
+    }
+
+    if (!FAMILY_REVOCABLE_STATUSES.has(enrollment.status)) {
+      return { ok: false, error: 'Only pending or waitlisted enrollments can be revoked.', code: 'invalid_status' }
+    }
+  }
+
+  if (enrollment.status === nextStatus) {
+    return { ok: true, previousStatus: enrollment.status, enrollment }
+  }
+
+  const { error: updateError } = await adminClient
+    .from('workshop_enrollment')
+    .update({ status: nextStatus, decided_by: actorUserId })
+    .eq('id', enrollment.id)
+
+  if (updateError) {
+    return { ok: false, error: updateError.message, code: 'update_failed' }
+  }
+
+  return {
+    ok: true,
+    previousStatus: enrollment.status,
+    enrollment: {
+      ...enrollment,
+      status: nextStatus,
+    },
+  }
+}

--- a/web/app/routes/enroll.tsx
+++ b/web/app/routes/enroll.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/workshop-capacity'
 import { resolveSemesterSurveyForm } from '@/lib/semester-survey.server'
 import { createClient } from '@/lib/supabase/server'
+import { transitionWorkshopEnrollmentStatus } from '@/lib/workshop-enrollment-status.server'
 
 type WorkshopRow = {
   id: string
@@ -66,6 +67,8 @@ type EnrollmentRequestResult = {
 
 const ENROLLMENT_SUCCESS_MESSAGE =
   "Thank you for registering for summerlunch+! We're excited to welcome your family this summer. Your registration has been received and is currently pending approval. Our team will review your information and send you a confirmation email shortly with your program details, class schedule, and next steps."
+
+const ACTIVE_ENROLLMENT_STATUSES = new Set(['pending', 'waitlisted', 'approved'])
 
 const redirectWithEnrollmentMessage = (status: 'success' | 'error', message: string) => {
   const params = new URLSearchParams({
@@ -287,6 +290,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 export async function action({ request }: Route.ActionArgs) {
   const formData = await request.formData()
+  const intent = String(formData.get('intent') ?? 'request-enrollment')
+  const status = String(formData.get('status') ?? '')
   const workshop_id = String(formData.get('workshop_id') ?? '')
 
   const auth = await requireAuth(request)
@@ -298,6 +303,30 @@ export async function action({ request }: Route.ActionArgs) {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Profile not found'
     return { error: message } satisfies ActionData
+  }
+
+  if (intent === 'update-status') {
+    const enrollmentId = String(formData.get('enrollment_id') ?? '')
+    const semesterId = String(formData.get('semester_id') ?? '')
+
+    if (!enrollmentId || !semesterId || status !== 'revoked') {
+      return { error: 'Missing enrollment data for status update.' } satisfies ActionData
+    }
+
+    const transitionResult = await transitionWorkshopEnrollmentStatus({
+      enrollmentId,
+      nextStatus: 'revoked',
+      actorUserId: auth.user.id,
+      scope: 'family',
+      semesterId,
+      familyProfileIds: family.familyProfileIds,
+    })
+
+    if (!transitionResult.ok) {
+      return { error: transitionResult.error ?? 'Unable to update enrollment status.' } satisfies ActionData
+    }
+
+    return redirect(`/enroll/${semesterId}`)
   }
 
   const { data: workshopRow, error: workshopError } = await supabase
@@ -454,7 +483,12 @@ export default function EnrollPage() {
 
   const semesterId = selectedSemesterId
   const selectedSemester = semesterId ? semesters.find(semester => semester.id === semesterId) : null
-  const semesterEnrollment = semesterId ? enrollments.find(enrollment => enrollment.semester_id === semesterId) : null
+  const semesterEnrollment =
+    semesterId
+      ? enrollments.find(
+          enrollment => enrollment.semester_id === semesterId && ACTIVE_ENROLLMENT_STATUSES.has(enrollment.status)
+        )
+      : null
 
   return (
     <main className="flex w-full flex-col gap-6 px-6 pt-6 pb-10">
@@ -492,7 +526,9 @@ export default function EnrollPage() {
             <TableBody>
               {semesters.map(semester => {
                 const preSurvey = preSurveyBySemester[semester.id]
-                const status = enrollments.find(enrollment => enrollment.semester_id === semester.id)?.status
+                const status = enrollments.find(
+                  enrollment => enrollment.semester_id === semester.id && ACTIVE_ENROLLMENT_STATUSES.has(enrollment.status)
+                )?.status
                 return (
                   <TableRow key={semester.id}>
                     <TableCell className="font-medium">{semester.id.slice(0, 8)}</TableCell>
@@ -532,9 +568,22 @@ export default function EnrollPage() {
             <div className="rounded-lg border bg-card p-4 shadow-sm space-y-2">
               <p className="font-medium">Your family is already enrolled in one workshop for this semester.</p>
               <p className="text-sm text-muted-foreground capitalize">Enrollment status: {semesterEnrollment.status}</p>
-              <Button asChild variant="outline" size="sm">
-                <Link to="/home">Back to Family Workshops</Link>
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button asChild variant="outline" size="sm">
+                  <Link to="/home">Back to Family Workshops</Link>
+                </Button>
+                {(semesterEnrollment.status === 'pending' || semesterEnrollment.status === 'waitlisted') && semesterId ? (
+                  <Form method="post" onSubmit={() => setSubmitLocked(true)}>
+                    <input type="hidden" name="intent" value="update-status" />
+                    <input type="hidden" name="status" value="revoked" />
+                    <input type="hidden" name="enrollment_id" value={semesterEnrollment.id} />
+                    <input type="hidden" name="semester_id" value={semesterId} />
+                    <Button type="submit" variant="destructive" size="sm" disabled={mutationLocked}>
+                      {mutationLocked ? 'Revoking...' : 'Revoke request'}
+                    </Button>
+                  </Form>
+                ) : null}
+              </div>
             </div>
           ) : preSurveyBySemester[selectedSemester.id]?.required &&
             !preSurveyBySemester[selectedSemester.id]?.completed ? (

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -15,6 +15,7 @@ import { Download } from 'lucide-react'
 import type { Route } from './+types/workshop-enrollment'
 import TableDisplay from './table-display'
 import { EXPORT_TYPE_WORKSHOP_ENROLLMENT_CSV } from '@/lib/exports/types'
+import { transitionWorkshopEnrollmentStatus } from '@/lib/workshop-enrollment-status.server'
 
 const isLikelyEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
 
@@ -72,37 +73,30 @@ export async function action({ request }: Route.ActionArgs) {
       return new Response('Invalid status', { status: 400, headers: auth.headers })
     }
 
-    const { supabase } = createClient(request)
-    const { data: existingEnrollment, error: existingEnrollmentError } = await supabase
-      .from('workshop_enrollment')
-      .select('id, profile_id, workshop_id, status')
-      .eq('id', enrollmentId)
-      .single()
+    const transitionResult = await transitionWorkshopEnrollmentStatus({
+      enrollmentId,
+      nextStatus: status as Database['public']['Enums']['workshop_enrollment_status'],
+      actorUserId: auth.user.id,
+      scope: 'admin',
+    })
 
-    if (existingEnrollmentError || !existingEnrollment) {
-      return new Response(existingEnrollmentError?.message ?? 'Enrollment not found', {
-        status: 404,
+    if (!transitionResult.ok || !transitionResult.enrollment) {
+      return new Response(transitionResult.error ?? 'Unable to update enrollment', {
+        status: transitionResult.code === 'not_found' ? 404 : 500,
         headers: auth.headers,
       })
     }
 
-    const { error } = await supabase
-      .from('workshop_enrollment')
-      .update({ status, decided_by: auth.user.id })
-      .eq('id', enrollmentId)
+    const enrollment = transitionResult.enrollment
 
-    if (error) {
-      return new Response(error.message, { status: 500, headers: auth.headers })
-    }
-
-    const transitionedToApproved = existingEnrollment.status !== 'approved' && status === 'approved'
-    if (transitionedToApproved && existingEnrollment.profile_id) {
+    const transitionedToApproved = transitionResult.previousStatus !== 'approved' && status === 'approved'
+    if (transitionedToApproved && enrollment.profile_id) {
       try {
-        const familyContacts = await resolveFamilyContactsByProfileId(adminClient, existingEnrollment.profile_id)
+        const familyContacts = await resolveFamilyContactsByProfileId(adminClient, enrollment.profile_id)
         const { data: workshopRow } = await adminClient
           .from('workshop')
           .select('description')
-          .eq('id', existingEnrollment.workshop_id)
+          .eq('id', enrollment.workshop_id)
           .single()
 
         const workshopName = workshopRow?.description?.trim() || 'selected workshop'
@@ -129,9 +123,9 @@ export async function action({ request }: Route.ActionArgs) {
               triggeredByUserId: auth.user.id,
               recipientUserId: recipient?.user_id ?? null,
               profileId: recipient?.id ?? null,
-              familyProfileId: existingEnrollment.profile_id,
-              workshopEnrollmentId: enrollmentId,
-            })
+               familyProfileId: enrollment.profile_id,
+               workshopEnrollmentId: enrollmentId,
+             })
           })
         )
       } catch (notificationError) {


### PR DESCRIPTION
## What
- streamline enrollment revocation to use status transitions instead of dedicated revoke intents
- add shared enrollment status transition helper for family/admin scopes
- update enroll route to submit intent=update-status with status=revoked
- update manage workshop-enrollment route to use the same status transition pathway
- update enrollment request SQL flow to allow re-enroll after revoked/rejected statuses

## Verification
- web: npm run typecheck