### PR TITLE
Add phone fields to workshop enrollment exports

### DIFF
--- a/web/app/lib/exports/runner.server.ts
+++ b/web/app/lib/exports/runner.server.ts
@@ -18,9 +18,11 @@ const WORKSHOP_PROFILE_SPLIT_COLUMNS = [
   'student_firstname',
   'student_lastname',
   'student_email',
+  'student_phone',
   'guardian_firstname',
   'guardian_lastname',
   'guardian_email',
+  'guardian_phone',
 ] as const
 
 const normalizeWorkshopExportColumns = (columns: string[]) => {

--- a/web/app/lib/exports/workshop-enrollment-export-row.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-export-row.server.ts
@@ -19,6 +19,7 @@ type ProfileRow = {
   firstname: string | null
   surname: string | null
   email: string | null
+  phone: string | null
 }
 
 type GuardianChildEdge = {
@@ -107,7 +108,7 @@ const buildProfileSplitData = async (enrollmentProfileIds: string[]) => {
   for (const chunk of chunkArray(Array.from(allRelatedIds), 250)) {
     const { data, error } = await adminClient
       .from('profile')
-      .select('id, role, firstname, surname, email')
+      .select('id, role, firstname, surname, email, phone')
       .in('id', chunk)
 
     if (error) {
@@ -147,9 +148,11 @@ const buildProfileSplitData = async (enrollmentProfileIds: string[]) => {
       student_firstname: normalizeText(studentProfile?.firstname),
       student_lastname: normalizeText(studentProfile?.surname),
       student_email: normalizeText(studentProfile?.email),
+      student_phone: normalizeText(studentProfile?.phone),
       guardian_firstname: normalizeText(guardianProfile?.firstname),
       guardian_lastname: normalizeText(guardianProfile?.surname),
       guardian_email: normalizeText(guardianProfile?.email),
+      guardian_phone: normalizeText(guardianProfile?.phone),
     })
   }
 

--- a/web/app/lib/exports/workshop-enrollment-snapshot.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-snapshot.server.ts
@@ -9,9 +9,11 @@ const PROFILE_SPLIT_COLUMNS = [
   'student_firstname',
   'student_lastname',
   'student_email',
+  'student_phone',
   'guardian_firstname',
   'guardian_lastname',
   'guardian_email',
+  'guardian_phone',
 ] as const
 
 const GENERATED_WORKSHOP_COLUMNS = new Set([


### PR DESCRIPTION
## What
- add student_phone and guardian_phone columns to workshop enrollment export schema
- include profile phone in export row materialization queries
- keep legacy runner column normalization aligned with the expanded split-column set

## Why
- exported workshop enrollment data needs phone contact fields for both student and guardian contexts

## Validation
- npm run typecheck
- npm run build