### PR TITLE
Include phone fields in export split mapping

### DIFF
--- a/web/app/lib/exports/workshop-enrollment-export-row.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-export-row.server.ts
@@ -8,9 +8,11 @@ const PROFILE_SPLIT_COLUMNS = new Set([
   'student_firstname',
   'student_lastname',
   'student_email',
+  'student_phone',
   'guardian_firstname',
   'guardian_lastname',
   'guardian_email',
+  'guardian_phone',
 ])
 
 type ProfileRow = {


### PR DESCRIPTION
## What
- add student_phone and guardian_phone to the split-column mapping set used during workshop enrollment export materialization

## Why
- phone columns were present in export schema but not recognized as split columns during row materialization
- this caused phone values to fall back to missing row keys and export as blank

## Validation
- npm run typecheck