### PR TITLE
Make export download non-blocking with toast

### DIFF
--- a/web/app/routes/manage/exports.$jobId.download.ts
+++ b/web/app/routes/manage/exports.$jobId.download.ts
@@ -1,5 +1,3 @@
-import { redirect } from 'react-router'
-
 import { requireAuth } from '@/lib/auth.server'
 import { createExportDownloadSignedUrl, getExportJobById } from '@/lib/exports/repository.server'
 import { isRoleAtLeast } from '@/lib/roles'
@@ -10,19 +8,19 @@ import type { Route } from './+types/exports.$jobId.download'
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request)
   if (!isRoleAtLeast(auth.claims.role, 'staff')) {
-    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+    return Response.json({ error: 'Unauthorized' }, { status: 403, headers: auth.headers })
   }
 
   const jobId = params.jobId
   if (!jobId) {
-    return new Response('Missing export job id', { status: 400, headers: auth.headers })
+    return Response.json({ error: 'Missing export job id' }, { status: 400, headers: auth.headers })
   }
 
   const { supabase } = createClient(request)
   const job = await getExportJobById({ supabase, jobId })
 
   if (job.status !== 'completed' || !job.storage_bucket || !job.storage_path) {
-    return new Response('Export file is not available yet', { status: 409, headers: auth.headers })
+    return Response.json({ error: 'Export file is not available yet' }, { status: 409, headers: auth.headers })
   }
 
   const signedUrl = await createExportDownloadSignedUrl({
@@ -31,5 +29,11 @@ export async function action({ request, params }: Route.ActionArgs) {
     expiresIn: 600,
   })
 
-  throw redirect(signedUrl, { headers: auth.headers })
+  return Response.json(
+    {
+      signedUrl,
+      message: 'Export download started.',
+    },
+    { headers: auth.headers }
+  )
 }

--- a/web/app/routes/manage/exports.tsx
+++ b/web/app/routes/manage/exports.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react'
-import { Form, redirect, useActionData, useLoaderData, useNavigation, useRevalidator } from 'react-router'
+import { useEffect, useState } from 'react'
+import { Form, redirect, useActionData, useFetcher, useLoaderData, useNavigation, useRevalidator } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
@@ -24,6 +24,17 @@ type ActionData = {
   success?: string
   warning?: string
 }
+
+type DownloadActionData = {
+  signedUrl?: string
+  message?: string
+  error?: string
+}
+
+type ToastState = {
+  tone: 'success' | 'error'
+  message: string
+} | null
 
 const isActiveStatus = (status: string) => status === 'queued' || status === 'running'
 
@@ -161,8 +172,10 @@ export default function ManageExportsPage() {
   const actionData = useActionData<typeof action>()
   const navigation = useNavigation()
   const revalidator = useRevalidator()
+  const downloadFetcher = useFetcher<DownloadActionData>()
   const isSubmitting = navigation.state === 'submitting'
   const hasActiveJobs = jobs.some(job => isActiveStatus(job.status))
+  const [toast, setToast] = useState<ToastState>(null)
 
   useEffect(() => {
     if (!hasActiveJobs) return
@@ -175,8 +188,43 @@ export default function ManageExportsPage() {
     }
   }, [hasActiveJobs, revalidator])
 
+  useEffect(() => {
+    if (!downloadFetcher.data) return
+
+    if (downloadFetcher.data.signedUrl) {
+      window.open(downloadFetcher.data.signedUrl, '_blank', 'noopener,noreferrer')
+      setToast({
+        tone: 'success',
+        message: downloadFetcher.data.message ?? 'Export download started.',
+      })
+      return
+    }
+
+    if (downloadFetcher.data.error) {
+      setToast({ tone: 'error', message: downloadFetcher.data.error })
+    }
+  }, [downloadFetcher.data])
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = window.setTimeout(() => setToast(null), 3500)
+    return () => window.clearTimeout(timer)
+  }, [toast])
+
   return (
     <div className="space-y-4">
+      {toast ? (
+        <div
+          className={`fixed bottom-4 right-4 z-50 rounded border px-3 py-2 text-sm shadow-md ${
+            toast.tone === 'success'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-800'
+              : 'border-destructive/40 bg-destructive/10 text-destructive'
+          }`}
+        >
+          {toast.message}
+        </div>
+      ) : null}
+
       <section className="rounded-lg border bg-card p-4">
         <h1 className="text-xl font-semibold">Exports</h1>
         <p className="text-sm text-muted-foreground">
@@ -231,11 +279,24 @@ export default function ManageExportsPage() {
                 <td className="px-3 py-2">
                   <div className="flex flex-wrap gap-2">
                     {job.status === 'completed' ? (
-                      <Form method="post" action={`/manage/exports/${job.id}/download`}>
-                        <Button type="submit" size="sm" variant="outline" disabled={isSubmitting}>
-                          Download
-                        </Button>
-                      </Form>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={downloadFetcher.state === 'submitting'}
+                        onClick={() => {
+                          setToast({ tone: 'success', message: 'Preparing export download...' })
+                          downloadFetcher.submit(
+                            {},
+                            {
+                              method: 'post',
+                              action: `/manage/exports/${job.id}/download`,
+                            }
+                          )
+                        }}
+                      >
+                        Download
+                      </Button>
                     ) : null}
                     {job.status === 'failed' ? (
                       <Form method="post">


### PR DESCRIPTION
## What
- switch export download endpoint to return JSON with signed URL instead of redirect response
- update manage exports page to trigger downloads through a fetcher and open signed URL in a new tab
- add transient toast feedback for download start and download errors

## Why
- downloading should be a non-blocking action with immediate user feedback
- avoid waiting on server redirect before the user sees status updates

## Validation
- npm run typecheck
- npm run build