### PR TITLE
Overhaul Zoom reconciliation runners and participant lifecycle

### DIFF
--- a/web/app/lib/zoom-jobs/provision.server.ts
+++ b/web/app/lib/zoom-jobs/provision.server.ts
@@ -19,12 +19,16 @@ type ZoomHostRow = {
   display_name: string | null
 }
 
-type ClassZoomMeetingRow = {
+type ExistingMeeting = {
   id: string
   class_id: string
   zoom_host_id: string
   status: 'pending' | 'created' | 'failed' | 'cancelled'
-  class?: Array<{ starts_at: string; ends_at: string }> | null
+  zoom_meeting_id: string | null
+  zoom_meeting_uuid: string | null
+  start_time: string | null
+  duration_minutes: number | null
+  topic: string | null
 }
 
 type ProfileRow = {
@@ -32,15 +36,33 @@ type ProfileRow = {
   firstname: string | null
   surname: string | null
   email: string | null
+  updated_at: string | null
+}
+
+type ProfileIdentity = {
+  profileId: string
+  firstName: string
+  lastName: string
+  email: string
+  source: 'profile' | 'guardian_fallback'
+  profileUpdatedAt: string | null
 }
 
 type ProvisionClassResult = {
   classId: string
   attendanceRowsEnsured: number
   meetingCreated: boolean
+  meetingRecreated: boolean
   registrantsCreated: number
+  registrantsUpdated: number
+  registrantsRemoved: number
   registrantsSkipped: number
   error?: string
+}
+
+type ProvisionOptions = {
+  forceMeetingRecreate?: boolean
+  excludedHostIds?: string[]
 }
 
 const overlaps = (aStart: string, aEnd: string, bStart: string, bEnd: string) => {
@@ -51,11 +73,13 @@ const overlaps = (aStart: string, aEnd: string, bStart: string, bEnd: string) =>
   return aS < bE && bS < aE
 }
 
-const toDisplayName = (profile: ProfileRow) => {
+const toDisplayName = (profile: Pick<ProfileRow, 'firstname' | 'surname'>) => {
   const first = (profile.firstname ?? '').trim()
   const last = (profile.surname ?? '').trim()
   return [first, last].filter(Boolean).join(' ').trim()
 }
+
+const normalizeEmail = (value: string | null) => (value ?? '').trim().toLowerCase()
 
 const randomToken = () => randomBytes(24).toString('base64url')
 
@@ -72,6 +96,7 @@ const buildTopic = (classRow: ClassRow) => {
 
 const getApprovedProfilesForClass = async (classRow: ClassRow) => {
   if (!classRow.workshop_id) return [] as ProfileRow[]
+
   const { data: enrollments, error: enrollmentError } = await adminClient
     .from('workshop_enrollment')
     .select('profile_id')
@@ -80,27 +105,128 @@ const getApprovedProfilesForClass = async (classRow: ClassRow) => {
     .not('profile_id', 'is', null)
 
   if (enrollmentError) throw new Error(enrollmentError.message)
-  const profileIds = Array.from(new Set((enrollments ?? []).map(row => row.profile_id).filter((id): id is string => Boolean(id))))
+
+  const profileIds = Array.from(
+    new Set((enrollments ?? []).map(row => row.profile_id).filter((id): id is string => Boolean(id)))
+  )
   if (!profileIds.length) return []
 
   const { data: profiles, error: profileError } = await adminClient
     .from('profile')
-    .select('id, firstname, surname, email')
+    .select('id, firstname, surname, email, updated_at')
     .in('id', profileIds)
 
   if (profileError) throw new Error(profileError.message)
   return (profiles ?? []) as ProfileRow[]
 }
 
-const ensureAttendanceRowsForClass = async (classId: string, profiles: ProfileRow[]) => {
-  const rows = profiles.map(profile => ({ class_id: classId, profile_id: profile.id, status: null }))
+const getGuardianFallbackIdentities = async (profileIds: string[]) => {
+  if (!profileIds.length) return new Map<string, ProfileIdentity>()
+
+  const { data: edges, error: edgeError } = await adminClient
+    .from('person_guardian_child')
+    .select('guardian_profile_id, child_profile_id, primary_child')
+    .in('child_profile_id', profileIds)
+
+  if (edgeError) throw new Error(edgeError.message)
+
+  const guardianIds = Array.from(
+    new Set((edges ?? []).map(edge => edge.guardian_profile_id).filter((id): id is string => Boolean(id)))
+  )
+  if (!guardianIds.length) return new Map<string, ProfileIdentity>()
+
+  const { data: guardians, error: guardianError } = await adminClient
+    .from('profile')
+    .select('id, firstname, surname, email, updated_at')
+    .in('id', guardianIds)
+
+  if (guardianError) throw new Error(guardianError.message)
+
+  const guardianById = new Map((guardians ?? []).map(guardian => [guardian.id, guardian]))
+  const fallbackByChild = new Map<string, ProfileIdentity>()
+
+  const sortedEdges = [...(edges ?? [])].sort((a, b) => {
+    if (a.primary_child && !b.primary_child) return -1
+    if (!a.primary_child && b.primary_child) return 1
+    return a.guardian_profile_id.localeCompare(b.guardian_profile_id)
+  })
+
+  for (const edge of sortedEdges) {
+    if (fallbackByChild.has(edge.child_profile_id)) continue
+    const guardian = guardianById.get(edge.guardian_profile_id)
+    if (!guardian) continue
+    const email = normalizeEmail(guardian.email)
+    if (!email) continue
+
+    const fullName = toDisplayName(guardian)
+    const [firstName, ...rest] = fullName ? fullName.split(' ') : ['Family']
+    const lastName = rest.join(' ').trim() || 'Contact'
+
+    fallbackByChild.set(edge.child_profile_id, {
+      profileId: edge.child_profile_id,
+      firstName: firstName || 'Family',
+      lastName,
+      email,
+      source: 'guardian_fallback',
+      profileUpdatedAt: guardian.updated_at ?? null,
+    })
+  }
+
+  return fallbackByChild
+}
+
+const buildIdentities = async (profiles: ProfileRow[]) => {
+  const identities = new Map<string, ProfileIdentity>()
+  const missingEmailProfileIds: string[] = []
+
+  for (const profile of profiles) {
+    const email = normalizeEmail(profile.email)
+    const fullName = toDisplayName(profile)
+    const [firstName, ...rest] = fullName ? fullName.split(' ') : ['Student']
+    const lastName = rest.join(' ').trim() || 'Participant'
+
+    if (!email) {
+      missingEmailProfileIds.push(profile.id)
+      continue
+    }
+
+    identities.set(profile.id, {
+      profileId: profile.id,
+      firstName: firstName || 'Student',
+      lastName,
+      email,
+      source: 'profile',
+      profileUpdatedAt: profile.updated_at ?? null,
+    })
+  }
+
+  const fallbacks = await getGuardianFallbackIdentities(missingEmailProfileIds)
+  for (const [profileId, identity] of fallbacks.entries()) {
+    identities.set(profileId, identity)
+  }
+
+  return identities
+}
+
+const ensureAttendanceRowsForClass = async (classId: string, profileIds: string[]) => {
+  const rows = profileIds.map(profileId => ({ class_id: classId, profile_id: profileId, status: null }))
   if (!rows.length) return 0
   const { error } = await adminClient.from('class_attendance').upsert(rows, { onConflict: 'class_id,profile_id' })
   if (error) throw new Error(error.message)
   return rows.length
 }
 
-const selectAvailableHost = async (classRow: ClassRow) => {
+const selectAvailableHost = async ({
+  classRow,
+  excludeMeetingId,
+  excludedHostIds,
+}: {
+  classRow: ClassRow
+  excludeMeetingId?: string
+  excludedHostIds?: string[]
+}) => {
+  const excludedHostSet = new Set((excludedHostIds ?? []).filter(Boolean))
+
   const { data: hosts, error: hostError } = await adminClient
     .from('zoom_host')
     .select('id, zoom_user_id, zoom_user_email, priority, display_name')
@@ -117,13 +243,24 @@ const selectAvailableHost = async (classRow: ClassRow) => {
   if (meetingError) throw new Error(meetingError.message)
 
   const hostRows = (hosts ?? []) as ZoomHostRow[]
-  const meetingRows = (activeMeetings ?? []) as unknown as ClassZoomMeetingRow[]
+  const meetingRows = (activeMeetings ?? []) as Array<{
+    id: string
+    class_id: string
+    zoom_host_id: string
+    status: string
+    class: Array<{ starts_at: string; ends_at: string }> | null
+  }>
+
   for (const host of hostRows) {
+    if (excludedHostSet.has(host.id)) continue
+
     const isBusy = meetingRows.some(meeting => {
+      if (excludeMeetingId && meeting.id === excludeMeetingId) return false
       const classRelation = Array.isArray(meeting.class) ? meeting.class[0] : null
       if (meeting.zoom_host_id !== host.id || !classRelation) return false
       return overlaps(classRow.starts_at, classRow.ends_at, classRelation.starts_at, classRelation.ends_at)
     })
+
     if (!isBusy) return host
   }
 
@@ -133,7 +270,7 @@ const selectAvailableHost = async (classRow: ClassRow) => {
 const upsertFailedMeeting = async (classId: string, errorMessage: string) => {
   const { data: existing } = await adminClient
     .from('class_zoom_meeting')
-    .select('id, zoom_host_id, host_zoom_user_id, host_zoom_user_email')
+    .select('id, zoom_host_id')
     .eq('class_id', classId)
     .maybeSingle()
 
@@ -145,28 +282,112 @@ const upsertFailedMeeting = async (classId: string, errorMessage: string) => {
   }
 }
 
-const ensureMeetingForClass = async (classRow: ClassRow) => {
+const isMeetingScheduleOutOfSync = ({
+  existingStart,
+  existingDuration,
+  existingTopic,
+  nextStart,
+  nextDuration,
+  nextTopic,
+}: {
+  existingStart: string | null | undefined
+  existingDuration: number | null | undefined
+  existingTopic: string | null | undefined
+  nextStart: string
+  nextDuration: number
+  nextTopic: string
+}) => {
+  const existingStartMs = existingStart ? new Date(existingStart).getTime() : Number.NaN
+  const nextStartMs = new Date(nextStart).getTime()
+  const startOutOfSync =
+    !Number.isFinite(existingStartMs) || !Number.isFinite(nextStartMs) || Math.abs(existingStartMs - nextStartMs) > 60_000
+  const durationOutOfSync = typeof existingDuration !== 'number' || existingDuration !== nextDuration
+  const topicOutOfSync = (existingTopic ?? '').trim() !== nextTopic.trim()
+  return startOutOfSync || durationOutOfSync || topicOutOfSync
+}
+
+const ensureMeetingForClass = async ({
+  classRow,
+  forceMeetingRecreate = false,
+  excludedHostIds,
+}: {
+  classRow: ClassRow
+  forceMeetingRecreate?: boolean
+  excludedHostIds?: string[]
+}) => {
+  const desiredTopic = buildTopic(classRow)
+  const durationMinutes = Math.max(
+    1,
+    Math.round((new Date(classRow.ends_at).getTime() - new Date(classRow.starts_at).getTime()) / 60000)
+  )
+
   const { data: existingMeeting, error: existingError } = await adminClient
     .from('class_zoom_meeting')
-    .select('id, class_id, zoom_host_id, status, zoom_meeting_id, zoom_meeting_uuid')
+    .select('id, class_id, zoom_host_id, status, zoom_meeting_id, zoom_meeting_uuid, start_time, duration_minutes, topic')
     .eq('class_id', classRow.id)
-    .maybeSingle()
+    .maybeSingle<ExistingMeeting>()
 
   if (existingError) throw new Error(existingError.message)
-  if (existingMeeting?.status === 'created' && existingMeeting.zoom_meeting_id && existingMeeting.zoom_meeting_uuid) {
-    return { id: existingMeeting.id, zoom_meeting_id: existingMeeting.zoom_meeting_id, created: false }
+
+  if (
+    existingMeeting?.status === 'created' &&
+    existingMeeting.zoom_meeting_id &&
+    existingMeeting.zoom_meeting_uuid &&
+    !forceMeetingRecreate
+  ) {
+    if (
+      isMeetingScheduleOutOfSync({
+        existingStart: existingMeeting.start_time,
+        existingDuration: existingMeeting.duration_minutes,
+        existingTopic: existingMeeting.topic,
+        nextStart: classRow.starts_at,
+        nextDuration: durationMinutes,
+        nextTopic: desiredTopic,
+      })
+    ) {
+      await zoomApiClient.updateMeeting(existingMeeting.zoom_meeting_id, {
+        topic: desiredTopic,
+        start_time: classRow.starts_at,
+        duration: durationMinutes,
+      })
+
+      const { error: updateError } = await adminClient
+        .from('class_zoom_meeting')
+        .update({
+          topic: desiredTopic,
+          start_time: classRow.starts_at,
+          duration_minutes: durationMinutes,
+          error_message: null,
+          last_synced_at: new Date().toISOString(),
+        })
+        .eq('id', existingMeeting.id)
+
+      if (updateError) throw new Error(updateError.message)
+    }
+
+    return {
+      id: existingMeeting.id,
+      zoom_meeting_id: existingMeeting.zoom_meeting_id,
+      created: false,
+      recreated: false,
+      zoom_host_id: existingMeeting.zoom_host_id,
+    }
   }
 
-  const host = await selectAvailableHost(classRow)
+  const host = await selectAvailableHost({
+    classRow,
+    excludeMeetingId: existingMeeting?.id,
+    excludedHostIds,
+  })
+
   if (!host) {
     const msg = 'No available Zoom host for class time window.'
     await upsertFailedMeeting(classRow.id, msg)
     throw new Error(msg)
   }
 
-  const durationMinutes = Math.max(1, Math.round((new Date(classRow.ends_at).getTime() - new Date(classRow.starts_at).getTime()) / 60000))
   const createResp = await zoomApiClient.createMeeting({
-    topic: buildTopic(classRow),
+    topic: desiredTopic,
     start_time: classRow.starts_at,
     duration: durationMinutes,
     ...(host.zoom_user_id ? { host_zoom_user_id: host.zoom_user_id } : {}),
@@ -183,7 +404,7 @@ const ensureMeetingForClass = async (classRow: ClassRow) => {
         host_zoom_user_email: host.zoom_user_email,
         zoom_meeting_id: String(createResp.id),
         zoom_meeting_uuid: createResp.uuid,
-        topic: buildTopic(classRow),
+        topic: desiredTopic,
         start_time: classRow.starts_at,
         duration_minutes: durationMinutes,
         join_url: createResp.join_url,
@@ -193,65 +414,120 @@ const ensureMeetingForClass = async (classRow: ClassRow) => {
       },
       { onConflict: 'class_id' }
     )
-    .select('id, zoom_meeting_id')
-    .single()
+    .select('id, zoom_meeting_id, zoom_host_id')
+    .single<{ id: string; zoom_meeting_id: string; zoom_host_id: string }>()
 
   if (upsertError || !upserted?.id || !upserted.zoom_meeting_id) {
     throw new Error(upsertError?.message ?? 'Failed to persist class_zoom_meeting')
   }
 
-  return { id: upserted.id, zoom_meeting_id: upserted.zoom_meeting_id, created: true }
+  return {
+    id: upserted.id,
+    zoom_meeting_id: upserted.zoom_meeting_id,
+    created: !existingMeeting,
+    recreated: Boolean(existingMeeting),
+    zoom_host_id: upserted.zoom_host_id,
+  }
 }
 
 const ensureRegistrantsForClass = async ({
   classRow,
   classZoomMeetingId,
   meetingId,
-  profiles,
+  identities,
+  forceReregister,
 }: {
   classRow: ClassRow
   classZoomMeetingId: string
   meetingId: string
-  profiles: ProfileRow[]
+  identities: Map<string, ProfileIdentity>
+  forceReregister: boolean
 }) => {
   const { data: existingRows, error: existingError } = await adminClient
     .from('class_zoom_registrant')
-    .select('id, profile_id, zoom_registrant_id, zoom_join_url')
+    .select('id, profile_id, zoom_registrant_id, zoom_join_url, class_zoom_meeting_id, updated_at, class_zoom_meeting:class_zoom_meeting_id ( zoom_meeting_id )')
     .eq('class_id', classRow.id)
 
   if (existingError) throw new Error(existingError.message)
-  const existingByProfileId = new Map((existingRows ?? []).map(row => [row.profile_id, row]))
+
+  const existingByProfileId = new Map(
+    (existingRows ?? []).map(row => [
+      row.profile_id,
+      {
+        ...row,
+        zoom_meeting_id:
+          Array.isArray(row.class_zoom_meeting) && row.class_zoom_meeting[0]?.zoom_meeting_id
+            ? row.class_zoom_meeting[0].zoom_meeting_id
+            : null,
+      },
+    ])
+  )
+
+  const eligibleProfileIds = new Set(Array.from(identities.keys()))
 
   let created = 0
+  let updated = 0
+  let removed = 0
   let skipped = 0
 
-  for (const profile of profiles) {
-    const email = (profile.email ?? '').trim().toLowerCase()
-    const existing = existingByProfileId.get(profile.id)
-    if (!email) {
-      skipped += 1
-      continue
+  for (const row of existingRows ?? []) {
+    const profileId = row.profile_id
+    if (!profileId || eligibleProfileIds.has(profileId)) continue
+
+    if (row.zoom_registrant_id && Array.isArray(row.class_zoom_meeting) && row.class_zoom_meeting[0]?.zoom_meeting_id) {
+      try {
+        await zoomApiClient.removeRegistrant(row.class_zoom_meeting[0].zoom_meeting_id, row.zoom_registrant_id)
+      } catch (error) {
+        console.error('[zoom-jobs][registrant] failed to remove stale registrant from zoom', {
+          classId: classRow.id,
+          profileId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        })
+      }
     }
-    if (existing?.zoom_registrant_id && existing.zoom_join_url) {
+
+    await adminClient.from('class_zoom_registrant').delete().eq('id', row.id)
+    await adminClient.from('class_attendance').delete().eq('class_id', classRow.id).eq('profile_id', profileId)
+    removed += 1
+  }
+
+  for (const identity of identities.values()) {
+    const existing = existingByProfileId.get(identity.profileId)
+    const mustReregister =
+      forceReregister ||
+      !existing?.zoom_registrant_id ||
+      !existing.zoom_join_url ||
+      existing.class_zoom_meeting_id !== classZoomMeetingId ||
+      (identity.profileUpdatedAt && existing.updated_at && new Date(identity.profileUpdatedAt).getTime() > new Date(existing.updated_at).getTime())
+
+    if (!mustReregister) {
       skipped += 1
       continue
     }
 
-    const fullName = toDisplayName(profile)
-    const [firstName, ...rest] = fullName ? fullName.split(' ') : ['Student']
-    const lastName = rest.join(' ') || 'Participant'
+    if (existing?.zoom_registrant_id && existing.zoom_meeting_id) {
+      try {
+        await zoomApiClient.removeRegistrant(existing.zoom_meeting_id, existing.zoom_registrant_id)
+      } catch (error) {
+        console.error('[zoom-jobs][registrant] failed to remove previous registrant before refresh', {
+          classId: classRow.id,
+          profileId: identity.profileId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        })
+      }
+    }
 
     const registrant = await zoomApiClient.registerParticipant(meetingId, {
-      first_name: firstName || 'Student',
-      last_name: lastName,
-      email,
+      first_name: identity.firstName,
+      last_name: identity.lastName,
+      email: identity.email,
     })
 
     const tokenHash = sha256(randomToken())
     const { error: upsertError } = await adminClient.from('class_zoom_registrant').upsert(
       {
         class_id: classRow.id,
-        profile_id: profile.id,
+        profile_id: identity.profileId,
         class_zoom_meeting_id: classZoomMeetingId,
         zoom_registrant_id: registrant?.registrant_id ?? null,
         zoom_join_url: registrant?.join_url ?? null,
@@ -262,13 +538,18 @@ const ensureRegistrantsForClass = async ({
     )
 
     if (upsertError) throw new Error(upsertError.message)
-    created += 1
+
+    if (existing) {
+      updated += 1
+    } else {
+      created += 1
+    }
   }
 
-  return { created, skipped }
+  return { created, updated, removed, skipped }
 }
 
-export const provisionClassById = async (classId: string): Promise<ProvisionClassResult> => {
+export const provisionClassById = async (classId: string, options: ProvisionOptions = {}): Promise<ProvisionClassResult> => {
   const { data: classRowRaw, error: classError } = await adminClient
     .from('class')
     .select('id, workshop_id, starts_at, ends_at, workshop:workshop_id ( description )')
@@ -276,27 +557,48 @@ export const provisionClassById = async (classId: string): Promise<ProvisionClas
     .single()
 
   if (classError || !classRowRaw) {
-    return { classId, attendanceRowsEnsured: 0, meetingCreated: false, registrantsCreated: 0, registrantsSkipped: 0, error: classError?.message ?? 'Class not found' }
+    return {
+      classId,
+      attendanceRowsEnsured: 0,
+      meetingCreated: false,
+      meetingRecreated: false,
+      registrantsCreated: 0,
+      registrantsUpdated: 0,
+      registrantsRemoved: 0,
+      registrantsSkipped: 0,
+      error: classError?.message ?? 'Class not found',
+    }
   }
 
   const classRow = classRowRaw as unknown as ClassRow
 
   try {
     const profiles = await getApprovedProfilesForClass(classRow)
-    const attendanceRowsEnsured = await ensureAttendanceRowsForClass(classId, profiles)
-    const meeting = await ensureMeetingForClass(classRow)
+    const identities = await buildIdentities(profiles)
+    const attendanceRowsEnsured = await ensureAttendanceRowsForClass(classId, Array.from(identities.keys()))
+
+    const meeting = await ensureMeetingForClass({
+      classRow,
+      forceMeetingRecreate: Boolean(options.forceMeetingRecreate),
+      excludedHostIds: options.excludedHostIds,
+    })
+
     const registrants = await ensureRegistrantsForClass({
       classRow,
       classZoomMeetingId: meeting.id,
       meetingId: meeting.zoom_meeting_id,
-      profiles,
+      identities,
+      forceReregister: meeting.recreated,
     })
 
     return {
       classId,
       attendanceRowsEnsured,
       meetingCreated: meeting.created,
+      meetingRecreated: meeting.recreated,
       registrantsCreated: registrants.created,
+      registrantsUpdated: registrants.updated,
+      registrantsRemoved: registrants.removed,
       registrantsSkipped: registrants.skipped,
     }
   } catch (error) {
@@ -304,7 +606,10 @@ export const provisionClassById = async (classId: string): Promise<ProvisionClas
       classId,
       attendanceRowsEnsured: 0,
       meetingCreated: false,
+      meetingRecreated: false,
       registrantsCreated: 0,
+      registrantsUpdated: 0,
+      registrantsRemoved: 0,
       registrantsSkipped: 0,
       error: error instanceof Error ? error.message : 'Unknown provisioning error',
     }
@@ -323,6 +628,21 @@ export const getClassesInWindow = async ({
     .select('id')
     .gte('starts_at', startsAt)
     .lt('starts_at', endsAt)
+    .order('starts_at', { ascending: true })
+
+  if (error) throw new Error(error.message)
+  return (data ?? []).map(row => row.id)
+}
+
+export const getClassesStartingAtOrAfter = async ({
+  startsAt,
+}: {
+  startsAt: string
+}) => {
+  const { data, error } = await adminClient
+    .from('class')
+    .select('id')
+    .gte('starts_at', startsAt)
     .order('starts_at', { ascending: true })
 
   if (error) throw new Error(error.message)

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -1,9 +1,14 @@
 import { createHash, randomBytes } from 'node:crypto'
 
 import { sendTransactionalEmail } from '@/lib/email/send-email.server'
+import { resolveFamilyContactsByProfileId } from '@/lib/family.server'
 import { adminClient } from '@/lib/supabase/adminClient'
-import { getClassesInWindow, provisionClassById } from '@/lib/zoom-jobs/provision.server'
-import { zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
+import {
+  getClassesInWindow,
+  getClassesStartingAtOrAfter,
+  provisionClassById,
+} from '@/lib/zoom-jobs/provision.server'
+import { ZoomApiError, zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
 
 const toIso = (date: Date) => date.toISOString()
 
@@ -17,10 +22,30 @@ const normalizeEmail = (value: string | null) => (value ?? '').trim().toLowerCas
 
 const ensureOrigin = (origin: string) => origin.replace(/\/+$/, '')
 
-const provisionWindow = async ({ now, leadMinutes }: { now: Date; leadMinutes: number }) => {
+const REPROVISION_HORIZON_MINUTES = 36 * 60
+const REMINDER_WINDOW_MINUTES = 2 * 60
+
+const reprovision36hAndOnward = async ({ now }: { now: Date }) => {
+  const start = addMinutes(now, REPROVISION_HORIZON_MINUTES)
+  const classIds = await getClassesStartingAtOrAfter({ startsAt: toIso(start) })
+
+  const results = [] as Awaited<ReturnType<typeof provisionClassById>>[]
+  for (const classId of classIds) {
+    results.push(await provisionClassById(classId))
+  }
+
+  return {
+    scanned: classIds.length,
+    reconciled: results.filter(result => !result.error).length,
+    failed: results.filter(result => Boolean(result.error)).length,
+    details: results,
+  }
+}
+
+const nearTermGapFill = async ({ now }: { now: Date }) => {
   const classIds = await getClassesInWindow({
     startsAt: toIso(now),
-    endsAt: toIso(addMinutes(now, leadMinutes)),
+    endsAt: toIso(addMinutes(now, REPROVISION_HORIZON_MINUTES)),
   })
 
   const results = [] as Awaited<ReturnType<typeof provisionClassById>>[]
@@ -30,34 +55,150 @@ const provisionWindow = async ({ now, leadMinutes }: { now: Date; leadMinutes: n
 
   return {
     scanned: classIds.length,
-    provisioned: results.filter(result => !result.error).length,
+    reconciled: results.filter(result => !result.error).length,
     failed: results.filter(result => Boolean(result.error)).length,
     details: results,
   }
 }
 
-const reprovision2h30m = async ({ now }: { now: Date }) => {
-  const classIds = await getClassesInWindow({
-    startsAt: toIso(addMinutes(now, 140)),
-    endsAt: toIso(addMinutes(now, 160)),
+type UpcomingMeeting = {
+  id: string
+  class_id: string
+  zoom_host_id: string
+  zoom_meeting_id: string | null
+  class: { starts_at: string; ends_at: string }[] | null
+}
+
+const hasOverlap = (left: { starts_at: string; ends_at: string }, right: { starts_at: string; ends_at: string }) => {
+  const leftStart = new Date(left.starts_at).getTime()
+  const leftEnd = new Date(left.ends_at).getTime()
+  const rightStart = new Date(right.starts_at).getTime()
+  const rightEnd = new Date(right.ends_at).getTime()
+  return leftStart < rightEnd && rightStart < leftEnd
+}
+
+const findHostConflicts = (meetings: UpcomingMeeting[]) => {
+  const conflicts: Array<{ hostId: string; sourceClassId: string; targetClassId: string }> = []
+  const byHost = new Map<string, UpcomingMeeting[]>()
+
+  for (const meeting of meetings) {
+    const bucket = byHost.get(meeting.zoom_host_id) ?? []
+    bucket.push(meeting)
+    byHost.set(meeting.zoom_host_id, bucket)
+  }
+
+  for (const [hostId, hostMeetings] of byHost.entries()) {
+    hostMeetings.sort((a, b) => {
+      const aClass = Array.isArray(a.class) ? a.class[0] : null
+      const bClass = Array.isArray(b.class) ? b.class[0] : null
+      const aStart = aClass?.starts_at ? new Date(aClass.starts_at).getTime() : Number.POSITIVE_INFINITY
+      const bStart = bClass?.starts_at ? new Date(bClass.starts_at).getTime() : Number.POSITIVE_INFINITY
+      return aStart - bStart
+    })
+
+    for (let index = 1; index < hostMeetings.length; index += 1) {
+      const prev = hostMeetings[index - 1]
+      const curr = hostMeetings[index]
+      const prevClass = Array.isArray(prev.class) ? prev.class[0] : null
+      const currClass = Array.isArray(curr.class) ? curr.class[0] : null
+      if (!prevClass || !currClass) continue
+      if (!hasOverlap(prevClass, currClass)) continue
+
+      conflicts.push({
+        hostId,
+        sourceClassId: prev.class_id,
+        targetClassId: curr.class_id,
+      })
+    }
+  }
+
+  return conflicts
+}
+
+const reconcileHostOverlaps = async ({ now }: { now: Date }) => {
+  const { data: meetings, error } = await adminClient
+    .from('class_zoom_meeting')
+    .select('id, class_id, zoom_host_id, zoom_meeting_id, class:class_id ( starts_at, ends_at )')
+    .eq('status', 'created')
+
+  if (error) {
+    return {
+      scanned: 0,
+      detected: 0,
+      fixed: 0,
+      failed: 1,
+      remaining: 0,
+      error: error.message,
+    }
+  }
+
+  const upcoming = ((meetings ?? []) as UpcomingMeeting[]).filter(meeting => {
+    const classRow = Array.isArray(meeting.class) ? meeting.class[0] : null
+    if (!classRow) return false
+    return new Date(classRow.ends_at).getTime() >= now.getTime()
   })
 
-  const results = [] as Awaited<ReturnType<typeof provisionClassById>>[]
-  for (const classId of classIds) {
-    results.push(await provisionClassById(classId))
+  const conflicts = findHostConflicts(upcoming)
+  let fixed = 0
+  let failed = 0
+  const targetClassSet = new Set<string>()
+
+  for (const conflict of conflicts) {
+    if (targetClassSet.has(conflict.targetClassId)) continue
+    targetClassSet.add(conflict.targetClassId)
+
+    const result = await provisionClassById(conflict.targetClassId, {
+      forceMeetingRecreate: true,
+      excludedHostIds: [conflict.hostId],
+    })
+
+    if (result.error) {
+      failed += 1
+    } else {
+      fixed += 1
+    }
   }
 
+  const { data: meetingsAfter } = await adminClient
+    .from('class_zoom_meeting')
+    .select('id, class_id, zoom_host_id, zoom_meeting_id, class:class_id ( starts_at, ends_at )')
+    .eq('status', 'created')
+
+  const remaining = findHostConflicts((meetingsAfter ?? []) as UpcomingMeeting[]).length
+
   return {
-    scanned: classIds.length,
-    reprovisioned: results.filter(result => !result.error).length,
-    failed: results.filter(result => Boolean(result.error)).length,
-    details: results,
+    scanned: upcoming.length,
+    detected: conflicts.length,
+    fixed,
+    failed,
+    remaining,
   }
 }
 
-const send2hReminders = async ({ now, appOrigin }: { now: Date; appOrigin: string }) => {
-  const reminderStart = addMinutes(now, 110)
-  const reminderEnd = addMinutes(now, 130)
+const resolveReminderRecipientEmail = async (profileId: string) => {
+  const { data: profile } = await adminClient
+    .from('profile')
+    .select('email')
+    .eq('id', profileId)
+    .maybeSingle<{ email: string | null }>()
+
+  const profileEmail = normalizeEmail(profile?.email ?? null)
+  if (profileEmail) return profileEmail
+
+  try {
+    const familyContacts = await resolveFamilyContactsByProfileId(adminClient, profileId)
+    const guardianEmail = familyContacts
+      .map(contact => normalizeEmail(contact.email))
+      .find(email => Boolean(email))
+    return guardianEmail ?? ''
+  } catch {
+    return ''
+  }
+}
+
+const sendReminderCoverage = async ({ now, appOrigin }: { now: Date; appOrigin: string }) => {
+  const reminderStart = now
+  const reminderEnd = addMinutes(now, REMINDER_WINDOW_MINUTES)
   const classIds = await getClassesInWindow({ startsAt: toIso(reminderStart), endsAt: toIso(reminderEnd) })
 
   let sent = 0
@@ -75,7 +216,7 @@ const send2hReminders = async ({ now, appOrigin }: { now: Date; appOrigin: strin
 
     const { data: registrants, error: registrantError } = await adminClient
       .from('class_zoom_registrant')
-      .select('id, profile_id')
+      .select('id, profile_id, last_sent_at')
       .eq('class_id', classId)
 
     if (registrantError || !classRow) {
@@ -83,26 +224,13 @@ const send2hReminders = async ({ now, appOrigin }: { now: Date; appOrigin: strin
       continue
     }
 
-    const profileIds = Array.from(new Set((registrants ?? []).map(row => row.profile_id).filter((id): id is string => Boolean(id))))
-    if (!profileIds.length) {
-      skipped += 1
-      continue
-    }
-
-    const { data: profiles, error: profileError } = await adminClient
-      .from('profile')
-      .select('id, email')
-      .in('id', profileIds)
-
-    if (profileError) {
-      failed += 1
-      continue
-    }
-
-    const emailByProfile = new Map((profiles ?? []).map(profile => [profile.id, normalizeEmail(profile.email)]))
-
     for (const registrant of registrants ?? []) {
-      const email = emailByProfile.get(registrant.profile_id) ?? ''
+      if (registrant.last_sent_at) {
+        skipped += 1
+        continue
+      }
+
+      const email = await resolveReminderRecipientEmail(registrant.profile_id)
       if (!email) {
         skipped += 1
         continue
@@ -111,18 +239,8 @@ const send2hReminders = async ({ now, appOrigin }: { now: Date; appOrigin: strin
       const token = newToken()
       const tokenHash = hashToken(token)
       const expiresAt = addMinutes(new Date(classRow.starts_at), 240).toISOString()
-
-      const { error: tokenUpdateError } = await adminClient
-        .from('class_zoom_registrant')
-        .update({ zlr_token_hash: tokenHash, zlr_expires_at: expiresAt, last_sent_at: new Date().toISOString() })
-        .eq('id', registrant.id)
-
-      if (tokenUpdateError) {
-        failed += 1
-        continue
-      }
-
       const joinLink = `${ensureOrigin(appOrigin)}/zlr/${token}`
+
       const workshopName =
         typeof classRow.workshop === 'object' && classRow.workshop && 'description' in classRow.workshop
           ? (classRow.workshop.description ?? 'your class')
@@ -144,14 +262,27 @@ const send2hReminders = async ({ now, appOrigin }: { now: Date; appOrigin: strin
           startsAt: classRow.starts_at,
           joinLink,
         },
-        eventKey: `class:${classId}:reminder_2h:v1:${registrant.profile_id}`,
+        eventKey: `class:${classId}:registrant:${registrant.id}:reminder_v2:${tokenHash.slice(0, 12)}`,
         profileId: registrant.profile_id,
       })
 
-      if (result.status === 'sent') {
-        sent += 1
-      } else if (result.status === 'skipped') {
-        skipped += 1
+      if (result.status === 'sent' || result.status === 'skipped') {
+        const { error: tokenUpdateError } = await adminClient
+          .from('class_zoom_registrant')
+          .update({
+            zlr_token_hash: tokenHash,
+            zlr_expires_at: expiresAt,
+            last_sent_at: new Date().toISOString(),
+          })
+          .eq('id', registrant.id)
+
+        if (tokenUpdateError) {
+          failed += 1
+        } else if (result.status === 'sent') {
+          sent += 1
+        } else {
+          skipped += 1
+        }
       } else {
         failed += 1
       }
@@ -168,12 +299,13 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
     .eq('status', 'created')
 
   if (error) {
-    return { scanned: 0, synced: 0, failed: 1, error: error.message }
+    return { scanned: 0, synced: 0, failed: 1, pendingRetry: 0, error: error.message }
   }
 
   let scanned = 0
   let synced = 0
   let failed = 0
+  let pendingRetry = 0
 
   for (const meeting of meetings ?? []) {
     const classRelation = Array.isArray(meeting.class) ? meeting.class[0] : null
@@ -196,6 +328,8 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
     try {
       const participantsPayload = await zoomApiClient.getParticipants(meeting.zoom_meeting_uuid)
       const participants = participantsPayload.participants ?? []
+
+      await adminClient.from('class_zoom_participant').delete().eq('class_zoom_meeting_id', meeting.id)
 
       const rows = participants.map(participant => ({
         class_zoom_meeting_id: meeting.id,
@@ -222,10 +356,7 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
       )
 
       if (participantEmails.length) {
-        const { data: profiles } = await adminClient
-          .from('profile')
-          .select('id, email')
-          .in('email', participantEmails)
+        const { data: profiles } = await adminClient.from('profile').select('id, email').in('email', participantEmails)
 
         for (const profile of profiles ?? []) {
           const { error: attendanceUpdateError } = await adminClient
@@ -251,11 +382,17 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
 
       synced += 1
     } catch (err) {
-      failed += 1
+      const retryable = err instanceof ZoomApiError && err.status === 409
+      if (retryable) {
+        pendingRetry += 1
+      } else {
+        failed += 1
+      }
+
       await adminClient
         .from('class_zoom_participant_sync')
         .update({
-          status: 'failed',
+          status: retryable ? 'pending' : 'failed',
           completed_at: new Date().toISOString(),
           error_message: err instanceof Error ? err.message : 'Unknown attendance sync error',
         })
@@ -263,21 +400,23 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
     }
   }
 
-  return { scanned, synced, failed }
+  return { scanned, synced, failed, pendingRetry }
 }
 
 export const runZoomJobs = async ({ now = new Date(), appOrigin }: { now?: Date; appOrigin: string }) => {
-  const provision24h = await provisionWindow({ now, leadMinutes: 24 * 60 })
-  const reprovision = await reprovision2h30m({ now })
-  const reminders = await send2hReminders({ now, appOrigin })
+  const reprovision = await reprovision36hAndOnward({ now })
+  const nearTerm = await nearTermGapFill({ now })
+  const hostReconciliation = await reconcileHostOverlaps({ now })
+  const reminders = await sendReminderCoverage({ now, appOrigin })
   const attendanceSync = await syncPostClassAttendance({ now })
 
   return {
     ok: true,
     ranAt: now.toISOString(),
-    provision24h,
-    reprovision2h30m: reprovision,
-    reminders2h: reminders,
+    reprovision36hAndOnward: reprovision,
+    nearTermGapFill: nearTerm,
+    hostOverlapReconciliation: hostReconciliation,
+    reminderCoverage: reminders,
     attendanceSync,
   }
 }

--- a/web/app/lib/zoom-jobs/zoom-api.client.server.ts
+++ b/web/app/lib/zoom-jobs/zoom-api.client.server.ts
@@ -20,6 +20,26 @@ type ZoomCreateMeetingResponse = {
   join_url: string
 }
 
+type ZoomUpdateMeetingRequest = {
+  topic: string
+  start_time: string
+  duration: number
+}
+
+export class ZoomApiError extends Error {
+  status: number
+  path: string
+  payload: unknown
+
+  constructor({ status, path, payload }: { status: number; path: string; payload: unknown }) {
+    super(`zoom-api ${path} failed (${status})`)
+    this.name = 'ZoomApiError'
+    this.status = status
+    this.path = path
+    this.payload = payload
+  }
+}
+
 const getConfig = () => {
   const endpoint = (process.env.ZOOM_API_ENDPOINT ?? '').trim()
   const apiKey = (process.env.ZOOM_API_KEY ?? '').trim()
@@ -35,7 +55,7 @@ const parsePayload = async (response: Response) => {
   return response.text().catch(() => null)
 }
 
-const requestJson = async <T>({ method, path, body }: { method: 'GET' | 'POST'; path: string; body?: unknown }): Promise<T> => {
+const requestJson = async <T>({ method, path, body }: { method: 'GET' | 'POST' | 'PATCH' | 'DELETE'; path: string; body?: unknown }): Promise<T> => {
   const { endpoint, apiKey } = getConfig()
   const response = await fetch(`${endpoint}${path}`, {
     method,
@@ -48,7 +68,7 @@ const requestJson = async <T>({ method, path, body }: { method: 'GET' | 'POST'; 
 
   const payload = await parsePayload(response)
   if (!response.ok) {
-    throw new Error(`zoom-api ${path} failed (${response.status}): ${typeof payload === 'string' ? payload : JSON.stringify(payload)}`)
+    throw new ZoomApiError({ status: response.status, path, payload })
   }
   return payload as T
 }
@@ -58,6 +78,8 @@ export const zoomApiClient = {
   listHosts: () => requestJson<Record<string, unknown>>({ method: 'GET', path: '/hosts' }),
   createMeeting: (body: ZoomCreateMeetingRequest) =>
     requestJson<ZoomCreateMeetingResponse>({ method: 'POST', path: '/meetings', body }),
+  updateMeeting: (meetingId: string, body: ZoomUpdateMeetingRequest) =>
+    requestJson<{ ok: boolean }>({ method: 'PATCH', path: `/meetings/${meetingId}`, body }),
   registerParticipant: async (meetingId: string, registrant: ZoomRegistrantRequest) => {
     const results = await requestJson<Array<{ registrant_id?: string; join_url?: string }>>({
       method: 'POST',
@@ -66,6 +88,11 @@ export const zoomApiClient = {
     })
     return results[0] ?? null
   },
+  removeRegistrant: (meetingId: string, registrantId: string) =>
+    requestJson<{ ok: boolean }>({
+      method: 'DELETE',
+      path: `/meetings/${meetingId}/registrants/${encodeURIComponent(registrantId)}`,
+    }),
   getParticipants: (meetingUuid: string) =>
     requestJson<{ participants?: Array<Record<string, unknown>> }>({
       method: 'GET',

--- a/zoom-api/README.md
+++ b/zoom-api/README.md
@@ -79,7 +79,9 @@ All endpoints except `/health` require `Authorization: Bearer <api_key>`.
 | `GET` | `/meetings/past` | List past meetings (`?days=30&force_refresh=false`) |
 | `GET` | `/meetings/{uuid}/participants` | Attendance report for a meeting (`?force_refresh=false`) |
 | `POST` | `/meetings` | Create a scheduled meeting (`host_zoom_user_id` or `host_zoom_user_email` optional) |
+| `PATCH` | `/meetings/{id}` | Update a scheduled meeting (`topic`, `start_time`, `duration`) |
 | `POST` | `/meetings/{id}/registrants` | Bulk register participants |
+| `DELETE` | `/meetings/{id}/registrants/{registrant_id}` | Remove a registrant from meeting |
 
 Full request/response schemas are documented in Swagger UI at `/docs`.
 

--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -61,6 +61,15 @@ class CreateMeetingResponse(BaseModel):
     join_url: str = Field(description="URL participants use to join the meeting.")
 
 
+class UpdateMeetingRequest(BaseModel):
+    topic: str = Field(description="Meeting title.", examples=["Summer Lunch Program - Week 3"])
+    start_time: str = Field(
+        description="Meeting start time in ISO 8601 format. Include a timezone offset or 'Z' for UTC.",
+        examples=["2026-06-15T10:00:00Z"],
+    )
+    duration: int = Field(description="Meeting duration in minutes.", examples=[60])
+
+
 class ZoomUserSummary(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -238,6 +247,20 @@ def create_meeting(body: CreateMeetingRequest) -> CreateMeetingResponse:
     return {"id": result["id"], "uuid": result["uuid"], "join_url": result["join_url"]}
 
 
+@app.patch("/meetings/{meeting_id}", dependencies=[Depends(get_api_key)])
+def update_meeting(meeting_id: str, body: UpdateMeetingRequest) -> dict[str, bool]:
+    """Updates a scheduled Zoom meeting's topic, start time, and duration."""
+    try:
+        return _zoom().update_meeting(
+            meeting_id=meeting_id,
+            topic=body.topic,
+            start_time=body.start_time,
+            duration=body.duration,
+        )
+    except httpx.HTTPStatusError as exc:
+        raise _as_http_exception(exc) from exc
+
+
 @app.post("/meetings/{meeting_id}/registrants", dependencies=[Depends(get_api_key)])
 def register_participants(meeting_id: str, registrants: list[Registrant]) -> list[dict]:
     """Bulk-registers a list of participants for a scheduled meeting.
@@ -249,5 +272,14 @@ def register_participants(meeting_id: str, registrants: list[Registrant]) -> lis
             meeting_id=meeting_id,
             registrants=[r.model_dump() for r in registrants],
         )
+    except httpx.HTTPStatusError as exc:
+        raise _as_http_exception(exc) from exc
+
+
+@app.delete("/meetings/{meeting_id}/registrants/{registrant_id}", dependencies=[Depends(get_api_key)])
+def remove_registrant(meeting_id: str, registrant_id: str) -> dict[str, bool]:
+    """Removes a registrant from a scheduled meeting by registrant id."""
+    try:
+        return _zoom().remove_registrant(meeting_id=meeting_id, registrant_id=registrant_id)
     except httpx.HTTPStatusError as exc:
         raise _as_http_exception(exc) from exc

--- a/zoom-api/app/zoom.py
+++ b/zoom-api/app/zoom.py
@@ -71,6 +71,20 @@ class ZoomClient:
         r.raise_for_status()
         return r.json()
 
+    def update_meeting(self, meeting_id: str, topic: str, start_time: str, duration: int) -> dict:
+        payload = {
+            "topic": topic,
+            "start_time": start_time,
+            "duration": duration,
+        }
+        r = httpx.patch(
+            f"{ZOOM_API_BASE}/meetings/{meeting_id}",
+            json=payload,
+            headers=self._headers(),
+        )
+        r.raise_for_status()
+        return {"ok": True}
+
     def list_hosts(self) -> dict:
         r = httpx.get(
             f"{ZOOM_API_BASE}/users",
@@ -92,6 +106,15 @@ class ZoomClient:
             r.raise_for_status()
             results.append(r.json())
         return results
+
+    def remove_registrant(self, meeting_id: str, registrant_id: str) -> dict:
+        encoded_registrant_id = quote(registrant_id, safe="")
+        r = httpx.delete(
+            f"{ZOOM_API_BASE}/meetings/{meeting_id}/registrants/{encoded_registrant_id}",
+            headers=self._headers(),
+        )
+        r.raise_for_status()
+        return {"ok": True}
 
     def list_past_meetings(self, user_id: str = "me", days: int = 30) -> dict:
         from datetime import date, timedelta

--- a/zoom-api/tests/test_main.py
+++ b/zoom-api/tests/test_main.py
@@ -271,6 +271,30 @@ def test_create_meeting_missing_auth(client):
     assert resp.status_code == 401
 
 
+def test_update_meeting_success(client, headers):
+    with patch("app.zoom.httpx.post", return_value=ok(TOKEN_RESP)), \
+         patch("app.zoom.httpx.patch", return_value=ok({})) as mock_patch:
+        resp = client.patch("/meetings/99999", headers=headers, json={
+            "topic": "Q2 Review Updated",
+            "start_time": "2026-06-01T15:00:00",
+            "duration": 90,
+        })
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    payload = mock_patch.call_args.kwargs["json"]
+    assert payload["topic"] == "Q2 Review Updated"
+    assert payload["duration"] == 90
+
+
+def test_update_meeting_missing_auth(client):
+    resp = client.patch("/meetings/99999", json={
+        "topic": "Q2 Review Updated",
+        "start_time": "2026-06-01T15:00:00",
+        "duration": 90,
+    })
+    assert resp.status_code == 401
+
+
 # ── POST /meetings/{id}/registrants ──────────────────────────────────────────
 
 def test_register_participants_success(client, headers):
@@ -291,3 +315,17 @@ def test_register_participants_missing_fields(client, headers):
 
 def test_register_participants_missing_auth(client):
     assert client.post("/meetings/99999/registrants", json=REGISTRANTS).status_code == 401
+
+
+def test_remove_registrant_success(client, headers):
+    with patch("app.zoom.httpx.post", return_value=ok(TOKEN_RESP)), \
+         patch("app.zoom.httpx.delete", return_value=ok({})) as mock_delete:
+        resp = client.delete("/meetings/99999/registrants/reg-abc", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    delete_url = mock_delete.call_args.args[0]
+    assert "/meetings/99999/registrants/reg-abc" in delete_url
+
+
+def test_remove_registrant_missing_auth(client):
+    assert client.delete("/meetings/99999/registrants/reg-abc").status_code == 401


### PR DESCRIPTION
## What
- replace windowed provisioning with 36h-and-onward reconciliation plus near-term gap fill
- add recurring host overlap detection and auto-fix pass during zoom runs
- convert registrant flow to full reconciliation (add/update/remove) including moved/removed students
- add guardian-contact fallback identity when enrolled profile has no email
- add zoom-api meeting update and registrant delete endpoints
- update web zoom-api client with PATCH/DELETE support and typed ZoomApiError

## Verification
- web: npm run typecheck
- zoom-api: make test
- web e2e: npm run test (environment timeouts observed in local run) 