### PR TITLE
Fix Zoom scheduling window and add safe reset/deprovision

### DIFF
--- a/web/app/lib/zoom-jobs/provision.server.ts
+++ b/web/app/lib/zoom-jobs/provision.server.ts
@@ -67,6 +67,14 @@ type ProvisionOptions = {
   excludedHostIds?: string[]
 }
 
+type ClassScheduleRelation = { starts_at: string; ends_at: string }
+
+const relationRow = <T extends Record<string, unknown>>(value: T | T[] | null | undefined): T | null => {
+  if (Array.isArray(value)) return value[0] ?? null
+  if (value && typeof value === 'object') return value
+  return null
+}
+
 const overlaps = (aStart: string, aEnd: string, bStart: string, bEnd: string) => {
   const aS = new Date(aStart).getTime()
   const aE = new Date(aEnd).getTime()
@@ -245,7 +253,7 @@ const selectAvailableHost = async ({
     class_id: string
     zoom_host_id: string
     status: string
-    class: Array<{ starts_at: string; ends_at: string }> | null
+    class: ClassScheduleRelation | ClassScheduleRelation[] | null
   }>
 
   for (const host of hostRows) {
@@ -253,7 +261,7 @@ const selectAvailableHost = async ({
 
     const isBusy = meetingRows.some(meeting => {
       if (excludeMeetingId && meeting.id === excludeMeetingId) return false
-      const classRelation = Array.isArray(meeting.class) ? meeting.class[0] : null
+      const classRelation = relationRow<ClassScheduleRelation>(meeting.class)
       if (meeting.zoom_host_id !== host.id || !classRelation) return false
       return overlaps(classRow.starts_at, classRow.ends_at, classRelation.starts_at, classRelation.ends_at)
     })
@@ -451,10 +459,7 @@ const ensureRegistrantsForClass = async ({
       row.profile_id,
       {
         ...row,
-        zoom_meeting_id:
-          Array.isArray(row.class_zoom_meeting) && row.class_zoom_meeting[0]?.zoom_meeting_id
-            ? row.class_zoom_meeting[0].zoom_meeting_id
-            : null,
+        zoom_meeting_id: relationRow<{ zoom_meeting_id: string | null }>(row.class_zoom_meeting)?.zoom_meeting_id ?? null,
       },
     ])
   )
@@ -470,9 +475,10 @@ const ensureRegistrantsForClass = async ({
     const profileId = row.profile_id
     if (!profileId || eligibleProfileIds.has(profileId)) continue
 
-    if (row.zoom_registrant_id && Array.isArray(row.class_zoom_meeting) && row.class_zoom_meeting[0]?.zoom_meeting_id) {
+    const existingMeeting = relationRow<{ zoom_meeting_id: string | null }>(row.class_zoom_meeting)
+    if (row.zoom_registrant_id && existingMeeting?.zoom_meeting_id) {
       try {
-        await zoomApiClient.removeRegistrant(row.class_zoom_meeting[0].zoom_meeting_id, row.zoom_registrant_id)
+        await zoomApiClient.removeRegistrant(existingMeeting.zoom_meeting_id, row.zoom_registrant_id)
       } catch (error) {
         console.error('[zoom-jobs][registrant] failed to remove stale registrant from zoom', {
           classId: classRow.id,

--- a/web/app/lib/zoom-jobs/reset.server.ts
+++ b/web/app/lib/zoom-jobs/reset.server.ts
@@ -1,0 +1,197 @@
+import { adminClient } from '@/lib/supabase/adminClient'
+import { ZoomApiError, zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
+
+const HORIZON_MINUTES = 36 * 60
+const IN_CLAUSE_BATCH_SIZE = 150
+
+const toIso = (date: Date) => date.toISOString()
+
+const addMinutes = (date: Date, minutes: number) => new Date(date.getTime() + minutes * 60_000)
+
+const chunkArray = <T,>(items: T[], size: number) => {
+  if (size <= 0 || !items.length) return [] as T[][]
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+const countByIds = async ({ table, column, ids }: { table: string; column: string; ids: string[] }) => {
+  if (!ids.length) return 0
+  let total = 0
+  for (const chunk of chunkArray(ids, IN_CLAUSE_BATCH_SIZE)) {
+    const { count, error } = await adminClient.from(table).select('id', { count: 'exact', head: true }).in(column, chunk)
+    if (error) throw new Error(error.message)
+    total += count ?? 0
+  }
+  return total
+}
+
+const listClassIdsInScope = async ({ now, scope }: { now: Date; scope: 'within_36h' | 'all_future' }) => {
+  const query = adminClient.from('class').select('id').gte('starts_at', toIso(now)).order('starts_at', { ascending: true })
+  if (scope === 'within_36h') {
+    query.lt('starts_at', toIso(addMinutes(now, HORIZON_MINUTES)))
+  }
+
+  const { data, error } = await query
+  if (error) throw new Error(error.message)
+  return (data ?? []).map(row => row.id)
+}
+
+export const resetZoomProcessingState = async ({
+  now = new Date(),
+  dryRun = false,
+  scope = 'all_future',
+}: {
+  now?: Date
+  dryRun?: boolean
+  scope?: 'within_36h' | 'all_future'
+}) => {
+  const classIds = await listClassIdsInScope({ now, scope })
+
+  if (!classIds.length) {
+    return {
+      dryRun,
+      scope,
+      classCount: 0,
+      meetingCount: 0,
+      registrantCount: 0,
+      participantSyncCount: 0,
+      participantCount: 0,
+      attendanceCount: 0,
+      attendanceRowsReset: 0,
+      meetingsDeleted: 0,
+      ranAt: now.toISOString(),
+    }
+  }
+
+  const meetingCount = await countByIds({ table: 'class_zoom_meeting', column: 'class_id', ids: classIds })
+  const registrantCount = await countByIds({ table: 'class_zoom_registrant', column: 'class_id', ids: classIds })
+  const attendanceCount = await countByIds({ table: 'class_attendance', column: 'class_id', ids: classIds })
+
+  const meetingIdRows: Array<{ id: string; zoom_meeting_id: string | null }> = []
+  for (const chunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { data, error } = await adminClient.from('class_zoom_meeting').select('id, zoom_meeting_id').in('class_id', chunk)
+    if (error) throw new Error(error.message)
+    meetingIdRows.push(...((data ?? []) as Array<{ id: string; zoom_meeting_id: string | null }>))
+  }
+  const meetingIds = meetingIdRows.map(row => row.id)
+  const zoomMeetingIds = Array.from(
+    new Set(meetingIdRows.map(row => row.zoom_meeting_id).filter((meetingId): meetingId is string => Boolean(meetingId)))
+  )
+
+  const participantSyncCount = await countByIds({
+    table: 'class_zoom_participant_sync',
+    column: 'class_zoom_meeting_id',
+    ids: meetingIds,
+  })
+  const participantCount = await countByIds({ table: 'class_zoom_participant', column: 'class_zoom_meeting_id', ids: meetingIds })
+
+  if (dryRun) {
+    return {
+      dryRun: true,
+      scope,
+      classCount: classIds.length,
+      meetingCount,
+      registrantCount,
+      participantSyncCount,
+      participantCount,
+      attendanceCount,
+      attendanceRowsReset: 0,
+      meetingsDeleted: 0,
+      zoomMeetingsTargeted: zoomMeetingIds.length,
+      zoomMeetingsDeleted: 0,
+      zoomMeetingDeleteFailures: 0,
+      zoomMeetingDeleteFailureDetails: [] as Array<{ meetingId: string; status: number | null; error: string }>,
+      ranAt: now.toISOString(),
+    }
+  }
+
+  let zoomMeetingsDeleted = 0
+  let zoomMeetingDeleteFailures = 0
+  const zoomMeetingDeleteFailureDetails: Array<{ meetingId: string; status: number | null; error: string }> = []
+
+  for (const meetingId of zoomMeetingIds) {
+    try {
+      await zoomApiClient.deleteMeeting(meetingId)
+      zoomMeetingsDeleted += 1
+    } catch (error) {
+      if (error instanceof ZoomApiError && error.status === 404) {
+        zoomMeetingsDeleted += 1
+        continue
+      }
+      zoomMeetingDeleteFailures += 1
+      zoomMeetingDeleteFailureDetails.push({
+        meetingId,
+        status: error instanceof ZoomApiError ? error.status : null,
+        error: error instanceof Error ? error.message : 'Unknown zoom meeting delete error',
+      })
+    }
+  }
+
+  if (zoomMeetingDeleteFailures > 0) {
+    return {
+      dryRun: false,
+      scope,
+      classCount: classIds.length,
+      meetingCount,
+      registrantCount,
+      participantSyncCount,
+      participantCount,
+      attendanceCount,
+      attendanceRowsReset: 0,
+      meetingsDeleted: 0,
+      zoomMeetingsTargeted: zoomMeetingIds.length,
+      zoomMeetingsDeleted,
+      zoomMeetingDeleteFailures,
+      zoomMeetingDeleteFailureDetails,
+      aborted: true,
+      ranAt: now.toISOString(),
+    }
+  }
+
+  let meetingsDeleted = 0
+  for (const chunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { error, count } = await adminClient
+      .from('class_zoom_meeting')
+      .delete({ count: 'exact' })
+      .in('class_id', chunk)
+    if (error) throw new Error(error.message)
+    meetingsDeleted += count ?? 0
+  }
+
+  let attendanceRowsReset = 0
+  for (const chunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { error, count } = await adminClient
+      .from('class_attendance')
+      .update({
+        status: null,
+        photo_status: null,
+        camera_on: null,
+        recorded_by: null,
+      }, { count: 'exact' })
+      .in('class_id', chunk)
+    if (error) throw new Error(error.message)
+    attendanceRowsReset += count ?? 0
+  }
+
+  return {
+    dryRun: false,
+    scope,
+    classCount: classIds.length,
+    meetingCount,
+    registrantCount,
+    participantSyncCount,
+    participantCount,
+    attendanceCount,
+    attendanceRowsReset,
+    meetingsDeleted,
+    zoomMeetingsTargeted: zoomMeetingIds.length,
+    zoomMeetingsDeleted,
+    zoomMeetingDeleteFailures,
+    zoomMeetingDeleteFailureDetails,
+    aborted: false,
+    ranAt: now.toISOString(),
+  }
+}

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -1,11 +1,7 @@
 import { sendTransactionalEmail } from '@/lib/email/send-email.server'
 import { resolveFamilyContactsByProfileId } from '@/lib/family.server'
 import { adminClient } from '@/lib/supabase/adminClient'
-import {
-  getClassesInWindow,
-  getClassesStartingAtOrAfter,
-  provisionClassById,
-} from '@/lib/zoom-jobs/provision.server'
+import { getClassesInWindow, provisionClassById } from '@/lib/zoom-jobs/provision.server'
 import { ZoomApiError, zoomApiClient } from '@/lib/zoom-jobs/zoom-api.client.server'
 import { hashZlrToken, newZlrToken } from '@/lib/zoom-jobs/zlr-token.server'
 
@@ -22,25 +18,7 @@ const REMINDER_WINDOW_MINUTES = 2 * 60
 const RUNNING_SYNC_TIMEOUT_MINUTES = 20
 const FAILED_SYNC_RETRY_COOLDOWN_MINUTES = 10
 
-const reprovision36hAndOnward = async ({ now }: { now: Date }) => {
-  const start = addMinutes(now, REPROVISION_HORIZON_MINUTES)
-  const classIds = await getClassesStartingAtOrAfter({ startsAt: toIso(start) })
-
-  const results = [] as Awaited<ReturnType<typeof provisionClassById>>[]
-  for (const classId of classIds) {
-    results.push(await provisionClassById(classId))
-  }
-
-  return {
-    scanned: classIds.length,
-    reconciled: results.filter(result => !result.error && !result.skipped).length,
-    skipped: results.filter(result => result.skipped).length,
-    failed: results.filter(result => Boolean(result.error)).length,
-    details: results,
-  }
-}
-
-const nearTermGapFill = async ({ now }: { now: Date }) => {
+const provisionWithin36h = async ({ now }: { now: Date }) => {
   const classIds = await getClassesInWindow({
     startsAt: toIso(now),
     endsAt: toIso(addMinutes(now, REPROVISION_HORIZON_MINUTES)),
@@ -65,7 +43,13 @@ type UpcomingMeeting = {
   class_id: string
   zoom_host_id: string
   zoom_meeting_id: string | null
-  class: { starts_at: string; ends_at: string }[] | null
+  class: { starts_at: string; ends_at: string } | Array<{ starts_at: string; ends_at: string }> | null
+}
+
+const relationRow = <T extends Record<string, unknown>>(value: T | T[] | null | undefined): T | null => {
+  if (Array.isArray(value)) return value[0] ?? null
+  if (value && typeof value === 'object') return value
+  return null
 }
 
 const hasOverlap = (left: { starts_at: string; ends_at: string }, right: { starts_at: string; ends_at: string }) => {
@@ -88,8 +72,8 @@ const findHostConflicts = (meetings: UpcomingMeeting[]) => {
 
   for (const [hostId, hostMeetings] of byHost.entries()) {
     hostMeetings.sort((a, b) => {
-      const aClass = Array.isArray(a.class) ? a.class[0] : null
-      const bClass = Array.isArray(b.class) ? b.class[0] : null
+      const aClass = relationRow<{ starts_at: string; ends_at: string }>(a.class)
+      const bClass = relationRow<{ starts_at: string; ends_at: string }>(b.class)
       const aStart = aClass?.starts_at ? new Date(aClass.starts_at).getTime() : Number.POSITIVE_INFINITY
       const bStart = bClass?.starts_at ? new Date(bClass.starts_at).getTime() : Number.POSITIVE_INFINITY
       return aStart - bStart
@@ -98,8 +82,8 @@ const findHostConflicts = (meetings: UpcomingMeeting[]) => {
     for (let index = 1; index < hostMeetings.length; index += 1) {
       const prev = hostMeetings[index - 1]
       const curr = hostMeetings[index]
-      const prevClass = Array.isArray(prev.class) ? prev.class[0] : null
-      const currClass = Array.isArray(curr.class) ? curr.class[0] : null
+      const prevClass = relationRow<{ starts_at: string; ends_at: string }>(prev.class)
+      const currClass = relationRow<{ starts_at: string; ends_at: string }>(curr.class)
       if (!prevClass || !currClass) continue
       if (!hasOverlap(prevClass, currClass)) continue
 
@@ -132,7 +116,7 @@ const reconcileHostOverlaps = async ({ now }: { now: Date }) => {
   }
 
   const upcoming = ((meetings ?? []) as UpcomingMeeting[]).filter(meeting => {
-    const classRow = Array.isArray(meeting.class) ? meeting.class[0] : null
+    const classRow = relationRow<{ starts_at: string; ends_at: string }>(meeting.class)
     if (!classRow) return false
     return new Date(classRow.ends_at).getTime() >= now.getTime()
   })
@@ -163,7 +147,12 @@ const reconcileHostOverlaps = async ({ now }: { now: Date }) => {
     .select('id, class_id, zoom_host_id, zoom_meeting_id, class:class_id ( starts_at, ends_at )')
     .eq('status', 'created')
 
-  const remaining = findHostConflicts((meetingsAfter ?? []) as UpcomingMeeting[]).length
+  const remainingUpcoming = ((meetingsAfter ?? []) as UpcomingMeeting[]).filter(meeting => {
+    const classRow = relationRow<{ starts_at: string; ends_at: string }>(meeting.class)
+    if (!classRow) return false
+    return new Date(classRow.ends_at).getTime() >= now.getTime()
+  })
+  const remaining = findHostConflicts(remainingUpcoming).length
 
   return {
     scanned: upcoming.length,
@@ -196,7 +185,7 @@ const resolveReminderRecipientEmail = async (profileId: string) => {
 }
 
 const sendReminderCoverage = async ({ now, appOrigin }: { now: Date; appOrigin: string }) => {
-  const reminderStart = addMinutes(now, -REMINDER_WINDOW_MINUTES)
+  const reminderStart = now
   const reminderEnd = addMinutes(now, REMINDER_WINDOW_MINUTES)
   const classIds = await getClassesInWindow({ startsAt: toIso(reminderStart), endsAt: toIso(reminderEnd) })
 
@@ -364,7 +353,7 @@ const syncPostClassAttendance = async ({ now }: { now: Date }) => {
   const nowIso = now.toISOString()
 
   for (const meeting of meetings ?? []) {
-    const classRelation = Array.isArray(meeting.class) ? meeting.class[0] : null
+    const classRelation = relationRow<{ starts_at: string; ends_at: string }>(meeting.class)
     const classEndsAt = classRelation?.ends_at ? new Date(classRelation.ends_at) : null
     if (!classEndsAt || classEndsAt.getTime() > addMinutes(now, -15).getTime()) continue
     if (!meeting.zoom_meeting_uuid) continue
@@ -515,8 +504,7 @@ export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?
     now: now.toISOString(),
   })
 
-  const reprovision = await reprovision36hAndOnward({ now })
-  const nearTerm = await nearTermGapFill({ now })
+  const within36h = await provisionWithin36h({ now })
   const hostReconciliation = await reconcileHostOverlaps({ now })
   const reminders = await sendReminderCoverage({ now, appOrigin })
   const attendanceSync = await syncPostClassAttendance({ now })
@@ -524,8 +512,7 @@ export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?
   console.info('[zoom-jobs] run completed', {
     runId: runId ?? null,
     ranAt: now.toISOString(),
-    reprovisionScanned: reprovision.scanned,
-    nearTermScanned: nearTerm.scanned,
+    within36hScanned: within36h.scanned,
     hostConflictsDetected: hostReconciliation.detected,
     reminderScanned: reminders.scannedClasses,
     attendanceScanned: attendanceSync.scanned,
@@ -536,8 +523,7 @@ export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?
     ok: true,
     runId: runId ?? null,
     ranAt: now.toISOString(),
-    reprovision36hAndOnward: reprovision,
-    nearTermGapFill: nearTerm,
+    provisionWithin36h: within36h,
     hostOverlapReconciliation: hostReconciliation,
     reminderCoverage: reminders,
     attendanceSync,

--- a/web/app/lib/zoom-jobs/zoom-api.client.server.ts
+++ b/web/app/lib/zoom-jobs/zoom-api.client.server.ts
@@ -88,6 +88,8 @@ export const zoomApiClient = {
     requestJson<ZoomCreateMeetingResponse>({ method: 'POST', path: '/meetings', body }),
   updateMeeting: (meetingId: string, body: ZoomUpdateMeetingRequest) =>
     requestJson<{ ok: boolean }>({ method: 'PATCH', path: `/meetings/${meetingId}`, body }),
+  deleteMeeting: (meetingId: string) =>
+    requestJson<{ ok: boolean }>({ method: 'DELETE', path: `/meetings/${meetingId}` }),
   registerParticipant: async (meetingId: string, registrant: ZoomRegistrantRequest) => {
     const results = await requestJson<Array<{ registrant_id?: string; join_url?: string }>>({
       method: 'POST',

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -36,6 +36,7 @@ export default [
   route("internal/export-jobs/run", "routes/internal/export-jobs.run.ts"),
   route("internal/export-jobs/cleanup", "routes/internal/export-jobs.cleanup.ts"),
   route("internal/zoom-jobs/run", "routes/internal/zoom-jobs.run.ts"),
+  route("internal/zoom-jobs/reset", "routes/internal/zoom-jobs.reset.ts"),
   route("manage", "routes/manage/team.tsx", [
     index("routes/manage/index.tsx"),
     route("participants", "routes/manage/participants.tsx"),

--- a/web/app/routes/internal/zoom-jobs.reset.ts
+++ b/web/app/routes/internal/zoom-jobs.reset.ts
@@ -10,10 +10,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return new Response('Method not allowed', { status: 405 })
   }
 
-  const authCheck = validateInternalRunnerRequest(request, {
-    specificEnvVar: 'ZOOM_RUNNER_SECRET',
-    specificHeader: 'x-zoom-runner-secret',
-  })
+  const authCheck = validateInternalRunnerRequest(request)
 
   if (!authCheck.ok) {
     return unauthorized()

--- a/web/app/routes/internal/zoom-jobs.reset.ts
+++ b/web/app/routes/internal/zoom-jobs.reset.ts
@@ -1,0 +1,36 @@
+import type { ActionFunctionArgs } from 'react-router'
+
+import { validateInternalRunnerRequest } from '@/lib/internal-runner-auth.server'
+import { resetZoomProcessingState } from '@/lib/zoom-jobs/reset.server'
+
+const unauthorized = () => new Response('Unauthorized', { status: 401 })
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
+  const authCheck = validateInternalRunnerRequest(request, {
+    specificEnvVar: 'ZOOM_RUNNER_SECRET',
+    specificHeader: 'x-zoom-runner-secret',
+  })
+
+  if (!authCheck.ok) {
+    return unauthorized()
+  }
+
+  let body: { dryRun?: unknown; scope?: unknown; now?: unknown } = {}
+  try {
+    body = (await request.json()) as typeof body
+  } catch {
+    body = {}
+  }
+
+  const scope = body.scope === 'within_36h' ? 'within_36h' : 'all_future'
+  const dryRun = body.dryRun === false ? false : true
+  const nowValue = typeof body.now === 'string' ? new Date(body.now) : new Date()
+  const now = Number.isFinite(nowValue.getTime()) ? nowValue : new Date()
+
+  const result = await resetZoomProcessingState({ now, dryRun, scope })
+  return Response.json({ runId: authCheck.runId, ...result })
+}

--- a/web/app/routes/internal/zoom-jobs.run.ts
+++ b/web/app/routes/internal/zoom-jobs.run.ts
@@ -10,10 +10,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return new Response('Method not allowed', { status: 405 })
   }
 
-  const authCheck = validateInternalRunnerRequest(request, {
-    specificEnvVar: 'ZOOM_RUNNER_SECRET',
-    specificHeader: 'x-zoom-runner-secret',
-  })
+  const authCheck = validateInternalRunnerRequest(request)
 
   if (!authCheck.ok) {
     return unauthorized()

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -8,11 +8,56 @@ import { createTableLoader } from './table-loader'
 
 const baseLoader = createTableLoader('class-attendance')
 
+type AttendanceRow = Record<string, unknown> & {
+  class_display?: { label?: unknown; timestamp?: unknown } | string | null
+  profile_display?: string | null
+}
+
+const timestampMs = (value: unknown) => {
+  if (typeof value !== 'string' || !value) return Number.POSITIVE_INFINITY
+  const time = new Date(value).getTime()
+  return Number.isFinite(time) ? time : Number.POSITIVE_INFINITY
+}
+
+const classLabel = (value: AttendanceRow['class_display']) => {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object' && typeof value.label === 'string') return value.label
+  return ''
+}
+
+const profileLabel = (value: unknown) => (typeof value === 'string' ? value : '')
+
 export async function loader(args: Route.LoaderArgs) {
   const auth = await requireAuth(args.request)
   const base = await baseLoader(args)
+
+  const sortedRows = [...((base.rows ?? []) as AttendanceRow[])].sort((left, right) => {
+    const leftClassTimestamp =
+      left.class_display && typeof left.class_display === 'object'
+        ? timestampMs(left.class_display.timestamp)
+        : Number.POSITIVE_INFINITY
+    const rightClassTimestamp =
+      right.class_display && typeof right.class_display === 'object'
+        ? timestampMs(right.class_display.timestamp)
+        : Number.POSITIVE_INFINITY
+
+    if (leftClassTimestamp !== rightClassTimestamp) {
+      return leftClassTimestamp - rightClassTimestamp
+    }
+
+    const leftClassLabel = classLabel(left.class_display)
+    const rightClassLabel = classLabel(right.class_display)
+    const byClassLabel = leftClassLabel.localeCompare(rightClassLabel)
+    if (byClassLabel !== 0) return byClassLabel
+
+    const leftProfile = profileLabel(left.profile_display)
+    const rightProfile = profileLabel(right.profile_display)
+    return leftProfile.localeCompare(rightProfile)
+  })
+
   return {
     ...base,
+    rows: sortedRows,
     canEditStatus: isRoleAtLeast(auth.claims.role, 'staff'),
   }
 }

--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -262,6 +262,16 @@ def update_meeting(meeting_id: str, body: UpdateMeetingRequest) -> dict[str, boo
     return {"ok": True}
 
 
+@app.delete("/meetings/{meeting_id}", dependencies=[Depends(get_api_key)])
+def delete_meeting(meeting_id: str) -> dict[str, bool]:
+    """Deletes a scheduled Zoom meeting."""
+    try:
+        _zoom().delete_meeting(meeting_id=meeting_id)
+    except httpx.HTTPStatusError as exc:
+        raise _as_http_exception(exc) from exc
+    return {"ok": True}
+
+
 @app.post("/meetings/{meeting_id}/registrants", dependencies=[Depends(get_api_key)])
 def register_participants(meeting_id: str, registrants: list[Registrant]) -> list[dict]:
     """Bulk-registers a list of participants for a scheduled meeting.

--- a/zoom-api/app/zoom.py
+++ b/zoom-api/app/zoom.py
@@ -76,20 +76,6 @@ class ZoomClient:
         r.raise_for_status()
         return r.json()
 
-    def update_meeting(self, meeting_id: str, topic: str, start_time: str, duration: int) -> dict:
-        payload = {
-            "topic": topic,
-            "start_time": start_time,
-            "duration": duration,
-        }
-        r = httpx.patch(
-            f"{ZOOM_API_BASE}/meetings/{meeting_id}",
-            json=payload,
-            headers=self._headers(),
-        )
-        r.raise_for_status()
-        return {"ok": True}
-
     def list_hosts(self) -> dict:
         r = httpx.get(
             f"{ZOOM_API_BASE}/users",
@@ -108,6 +94,13 @@ class ZoomClient:
         r = httpx.patch(
             f"{ZOOM_API_BASE}/meetings/{meeting_id}",
             json=payload,
+            headers=self._headers(),
+        )
+        r.raise_for_status()
+
+    def delete_meeting(self, meeting_id: str) -> None:
+        r = httpx.delete(
+            f"{ZOOM_API_BASE}/meetings/{meeting_id}",
             headers=self._headers(),
         )
         r.raise_for_status()

--- a/zoom-api/tests/test_main.py
+++ b/zoom-api/tests/test_main.py
@@ -299,6 +299,20 @@ def test_update_meeting_missing_auth(client):
     assert resp.status_code == 401
 
 
+def test_delete_meeting_success(client, headers):
+    with patch("app.zoom.httpx.post", return_value=ok(TOKEN_RESP)), \
+         patch("app.zoom.httpx.delete", return_value=ok({})) as mock_delete:
+        resp = client.delete("/meetings/99999", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    delete_url = mock_delete.call_args.args[0]
+    assert "/meetings/99999" in delete_url
+
+
+def test_delete_meeting_missing_auth(client):
+    assert client.delete("/meetings/99999").status_code == 401
+
+
 # ── POST /meetings/{id}/registrants ──────────────────────────────────────────
 
 def test_register_participants_success(client, headers):


### PR DESCRIPTION
## What this changes
- Limits Zoom provisioning to classes starting in the next 36 hours (>= now and < now + 36h)
- Limits reminder sending to classes starting within the next 2 hours
- Fixes host overlap detection and selection by handling embedded class relations consistently
- Adds Zoom meeting deletion support in zoom-api at DELETE /meetings/{meeting_id}
- Adds internal reset endpoint POST /internal/zoom-jobs/reset for dry-run and execution
- Reset flow deprovisions Zoom meetings first, then clears local Zoom processing state and resets attendance fields
- Includes class-attendance default sort by class order

## Safety
- Reset endpoint defaults to dryRun=true
- If Zoom meeting deletions fail, local DB reset aborts to avoid orphaning remote meetings

## Verification
- web: npm run typecheck
- zoom-api: .venv/bin/pytest tests/ -v (38 passed)