### PR TITLE
Move workshop enrollment status column

### DIFF
--- a/web/app/lib/exports/workshop-enrollment-query.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-query.server.ts
@@ -250,6 +250,16 @@ export async function loadWorkshopEnrollmentData(request: Request) {
     columns = [...columns.filter(column => column !== 'semester_range'), 'semester_range']
   }
 
+  if (columns.includes('status')) {
+    const columnsWithoutStatus = columns.filter(column => column !== 'status')
+    const insertAt = Math.min(2, columnsWithoutStatus.length)
+    columns = [
+      ...columnsWithoutStatus.slice(0, insertAt),
+      'status',
+      ...columnsWithoutStatus.slice(insertAt),
+    ]
+  }
+
   const baseColumnMeta = (base.columnMeta ?? {}) as Record<
     string,
     {


### PR DESCRIPTION
## What
- place status as the third column in manage workshop enrollment table ordering
- preserve existing dynamic column insertion behavior for enrichment fields

## Why
- align column order with expected workflow where status control appears earlier