### PR TITLE
Ensure attendance rows from 36h pre-class onward

### DIFF
--- a/supabase/migrations/20260630145500_attendance_gap_fill_within_36h_and_after.sql
+++ b/supabase/migrations/20260630145500_attendance_gap_fill_within_36h_and_after.sql
@@ -1,0 +1,16 @@
+create or replace function public.ensure_class_attendance_rows()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.class_attendance (class_id, profile_id, status)
+  select c.id, we.profile_id, null
+  from public.class c
+  join public.workshop_enrollment we on we.workshop_id = c.workshop_id
+  where c.starts_at <= now() + interval '36 hours'
+    and we.status = 'approved'
+  on conflict (class_id, profile_id) do nothing;
+end;
+$$;

--- a/supabase/schemas/03_semesters_cohorts_classes.sql
+++ b/supabase/schemas/03_semesters_cohorts_classes.sql
@@ -345,7 +345,7 @@ begin
   select c.id, we.profile_id, null
   from public.class c
   join public.workshop_enrollment we on we.workshop_id = c.workshop_id
-  where c.ends_at < now()
+  where c.starts_at <= now() + interval '36 hours'
     and we.status = 'approved'
   on conflict (class_id, profile_id) do nothing;
 end;


### PR DESCRIPTION
## What changed
- Updates ensure_class_attendance_rows() to fill rows for any class with starts_at <= now() + 36 hours
- This keeps attendance row generation active from 36h before class start and continues after class end
- Adds matching migration for deployed environments

## Why
- Ensures recently finished classes with missing attendance rows are backfilled on each run
- Removes dependency on class end time for attendance row generation

## Notes
- Zoom runner already invokes ensure_class_attendance_rows() every run