### PR TITLE
Adjust manage table height and fix reset password routing

### DIFF
--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -25,6 +25,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     "/sign-up/terms",
     "/sign-up/invite",
     "/forgot-password",
+    "/update-password",
     "/auth/sign-up-details",
     "/auth/waiting-on-guardian",
     "/auth/confirm",

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -2100,7 +2100,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
         </div>
       </div>
 
-      <div className="min-w-0 overflow-auto border-y max-h-[calc(100svh-19rem)]">
+      <div className="min-w-0 overflow-auto border-y max-h-[calc(100svh-17rem)]">
         <table className="w-max table-fixed text-sm" style={{ width: `${tableWidth}px`, minWidth: `${tableWidth}px` }}>
           <colgroup>
             {columns.map(column => (


### PR DESCRIPTION
## What changed
- increase manage table viewport height so table content sits closer to the bottom of the page
- allow /update-password through the onboarding guard allowlist so password recovery links land on the reset screen instead of bouncing to login

## Verification
- npm run typecheck