### PR TITLE
Fix auth code callback routing to confirm

### DIFF
--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -19,6 +19,13 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const url = new URL(request.url);
   const pathname = url.pathname;
+  const hasAuthCode = Boolean(url.searchParams.get('code'))
+  const hasOtpToken = Boolean(url.searchParams.get('token_hash') && url.searchParams.get('type'))
+
+  if (pathname !== '/auth/confirm' && (hasAuthCode || hasOtpToken)) {
+    throw redirect(`/auth/confirm${url.search}`, { status: 302 })
+  }
+
   const allowlist = new Set([
     "/login",
     "/sign-up",


### PR DESCRIPTION
## What changed
- detect auth callback query params (code or token_hash/type) in root loader
- redirect those requests to /auth/confirm with the original querystring when they hit non-confirm paths
- prevents password recovery links opened at / from being intercepted and redirected to /login

## Verification
- npm run typecheck