### PR TITLE
Improve class attendance register visibility

### DIFF
--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -42,6 +42,8 @@ type MeetingRow = {
   id: string
   class_id: string
   status: string
+  error_message: string | null
+  last_synced_at: string | null
   zoom_meeting_id: string | null
   topic: string | null
   start_time: string | null
@@ -59,9 +61,14 @@ type RegistrantRow = {
 }
 
 type SyncRunRow = {
+  id: string
   class_zoom_meeting_id: string
   status: string
   created_at: string
+  started_at: string | null
+  completed_at: string | null
+  error_message: string | null
+  payload: unknown
 }
 
 const IN_CLAUSE_BATCH_SIZE = 150
@@ -113,7 +120,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       classIds.length
         ? adminClient
             .from('class_zoom_meeting')
-            .select('id, class_id, status, zoom_meeting_id, topic, start_time, duration_minutes, join_url, host_zoom_user_email')
+            .select('id, class_id, status, error_message, last_synced_at, zoom_meeting_id, topic, start_time, duration_minutes, join_url, host_zoom_user_email')
             .in('class_id', classIds)
         : Promise.resolve({ data: [] as MeetingRow[], error: null }),
       classIds.length
@@ -159,7 +166,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     meetingIds.length
       ? adminClient
           .from('class_zoom_participant_sync')
-          .select('class_zoom_meeting_id, status, created_at')
+          .select('id, class_zoom_meeting_id, status, created_at, started_at, completed_at, error_message, payload')
           .in('class_zoom_meeting_id', meetingIds)
           .order('created_at', { ascending: false })
       : Promise.resolve({ data: [] as SyncRunRow[], error: null }),
@@ -183,10 +190,29 @@ export async function loader({ request }: Route.LoaderArgs) {
     if (!meetingByClassId.has(row.class_id)) meetingByClassId.set(row.class_id, row)
   }
 
-  const latestSyncByMeetingId = new Map<string, { status: string; created_at: string }>()
+  const latestSyncByMeetingId = new Map<
+    string,
+    {
+      id: string
+      status: string
+      created_at: string
+      started_at: string | null
+      completed_at: string | null
+      error_message: string | null
+      payload: unknown
+    }
+  >()
   for (const row of (syncRows ?? []) as SyncRunRow[]) {
     if (!latestSyncByMeetingId.has(row.class_zoom_meeting_id)) {
-      latestSyncByMeetingId.set(row.class_zoom_meeting_id, { status: row.status, created_at: row.created_at })
+      latestSyncByMeetingId.set(row.class_zoom_meeting_id, {
+        id: row.id,
+        status: row.status,
+        created_at: row.created_at,
+        started_at: row.started_at,
+        completed_at: row.completed_at,
+        error_message: row.error_message,
+        payload: row.payload,
+      })
     }
   }
 
@@ -234,6 +260,40 @@ export async function loader({ request }: Route.LoaderArgs) {
       stepAttendanceSync = 'Failed'
     }
 
+    const stepMeetingDetail = [
+      `status=${meeting?.status ?? 'missing'}`,
+      `zoom_meeting_id=${meeting?.zoom_meeting_id ?? 'none'}`,
+      `host=${meeting?.host_zoom_user_email ?? 'none'}`,
+      `meeting_error=${meeting?.error_message ?? 'none'}`,
+      `meeting_last_synced=${meeting?.last_synced_at ?? 'none'}`,
+    ].join(' | ')
+
+    const stepRegistrantDetail = [
+      `zoom_registrant_id=${studentRegistrant?.zoom_registrant_id ?? 'none'}`,
+      `join_url=${studentRegistrant?.zoom_join_url ?? 'none'}`,
+      `registrant_last_updated=${studentRegistrant ? 'present' : 'none'}`,
+    ].join(' | ')
+
+    const stepReminderDetail = [
+      `last_sent_at=${studentRegistrant?.last_sent_at ?? 'none'}`,
+      `eligible=${studentRegistrant ? 'yes' : 'no'}`,
+    ].join(' | ')
+
+    const latestSyncPayload =
+      latestSync?.payload && typeof latestSync.payload === 'object'
+        ? JSON.stringify(latestSync.payload)
+        : latestSync?.payload == null
+          ? ''
+          : String(latestSync.payload)
+
+    const stepAttendanceSyncDetail = [
+      `sync_status=${latestSync?.status ?? 'none'}`,
+      `sync_id=${latestSync?.id ?? 'none'}`,
+      `sync_started=${latestSync?.started_at ?? 'none'}`,
+      `sync_completed=${latestSync?.completed_at ?? 'none'}`,
+      `sync_error=${latestSync?.error_message ?? 'none'}`,
+    ].join(' | ')
+
     return {
       ...row,
       workshop_description: workshop?.description ?? 'Workshop',
@@ -241,7 +301,6 @@ export async function loader({ request }: Route.LoaderArgs) {
       class_ends_at: classRow?.ends_at ?? null,
       profile_display: displayNameOrId(profile, row.profile_id),
       student_join_url: studentRegistrant?.zoom_join_url ?? null,
-      register_student_action: registrantReady ? '' : 'Register',
       zoom_meeting_id: meeting?.zoom_meeting_id ?? null,
       zoom_topic: meeting?.topic ?? null,
       zoom_start_at: meeting?.start_time ?? null,
@@ -253,6 +312,12 @@ export async function loader({ request }: Route.LoaderArgs) {
       step_attendance_rows: 'Done',
       step_reminder: reminderSent ? 'Done' : 'Missing',
       step_attendance_sync: stepAttendanceSync,
+      step_meeting_detail: stepMeetingDetail,
+      step_registrants_detail: stepRegistrantDetail,
+      step_reminder_detail: stepReminderDetail,
+      step_attendance_sync_detail: stepAttendanceSyncDetail,
+      latest_sync_payload: latestSyncPayload,
+      latest_sync_error: latestSync?.error_message ?? null,
       recorded_by_email:
         typeof row.recorded_by === 'string' && row.recorded_by
           ? displayName(profileByUserId.get(row.recorded_by) ?? null) || row.recorded_by
@@ -287,7 +352,6 @@ export async function loader({ request }: Route.LoaderArgs) {
       'photo_status',
       'camera_on',
       'student_join_url',
-      'register_student_action',
       'zoom_meeting_id',
       'zoom_topic',
       'zoom_start_at',
@@ -299,6 +363,12 @@ export async function loader({ request }: Route.LoaderArgs) {
       'step_attendance_rows',
       'step_reminder',
       'step_attendance_sync',
+      'step_meeting_detail',
+      'step_registrants_detail',
+      'step_reminder_detail',
+      'step_attendance_sync_detail',
+      'latest_sync_error',
+      'latest_sync_payload',
       'recorded_by_email',
       'created_at',
       'updated_at',
@@ -316,7 +386,6 @@ export async function loader({ request }: Route.LoaderArgs) {
       photo_status: { label: 'Photo status', filterable: true },
       camera_on: { label: 'Camera on', filterable: true },
       student_join_url: { label: 'Student join link', truncate: true, filterable: true },
-      register_student_action: { label: 'Register row', filterable: false },
       zoom_meeting_id: { label: 'Zoom meeting ID', filterable: true },
       zoom_topic: { label: 'Zoom topic', truncate: true, filterable: true },
       zoom_start_at: { label: 'Zoom start (UTC)', filterable: true },
@@ -328,6 +397,12 @@ export async function loader({ request }: Route.LoaderArgs) {
       step_attendance_rows: { label: 'Step 3: Attendance row', filterable: true },
       step_reminder: { label: 'Step 4: Reminder', filterable: true },
       step_attendance_sync: { label: 'Step 5: Attendance sync', filterable: true },
+      step_meeting_detail: { label: 'Step 1 detail', filterable: true, truncate: true },
+      step_registrants_detail: { label: 'Step 2 detail', filterable: true, truncate: true },
+      step_reminder_detail: { label: 'Step 4 detail', filterable: true, truncate: true },
+      step_attendance_sync_detail: { label: 'Step 5 detail', filterable: true, truncate: true },
+      latest_sync_error: { label: 'Latest sync error', filterable: true, truncate: true },
+      latest_sync_payload: { label: 'Latest sync payload', filterable: false, truncate: true },
       recorded_by_email: { label: 'Recorded by', filterable: true, truncate: true },
       created_at: { label: 'Created', filterable: true },
       updated_at: { label: 'Updated', filterable: true },
@@ -352,12 +427,29 @@ export async function action({ request }: Route.ActionArgs) {
     const classId = formData.get('class_id') as string
     const profileId = formData.get('profile_id') as string
     if (!classId || !profileId) {
-      return new Response('Missing identifiers', { status: 400, headers: auth.headers })
+      return {
+        ok: false,
+        intent: 'register-student',
+        class_id: classId,
+        profile_id: profileId,
+        error: 'Missing identifiers',
+      }
     }
 
     try {
       const appOrigin = new URL(request.url).origin
-      await runZoomJobsForClass({ classId, appOrigin, runId: `manual-row-${Date.now().toString(36)}` })
+      const runResult = await runZoomJobsForClass({ classId, appOrigin, runId: `manual-row-${Date.now().toString(36)}` })
+      const provision = runResult.provision
+      const provisionSummary =
+        provision && typeof provision === 'object'
+          ? [
+              `provision_error=${'error' in provision ? String(provision.error ?? 'none') : 'none'}`,
+              `meeting_recreated=${'meetingRecreated' in provision ? String(provision.meetingRecreated) : 'n/a'}`,
+              `registrants_created=${'registrantsCreated' in provision ? String(provision.registrantsCreated) : 'n/a'}`,
+              `registrants_updated=${'registrantsUpdated' in provision ? String(provision.registrantsUpdated) : 'n/a'}`,
+              `registrants_skipped=${'registrantsSkipped' in provision ? String(provision.registrantsSkipped) : 'n/a'}`,
+            ].join(' | ')
+          : 'provision=unknown'
 
       const { data: registrant, error } = await adminClient
         .from('class_zoom_registrant')
@@ -367,19 +459,44 @@ export async function action({ request }: Route.ActionArgs) {
         .maybeSingle<{ zoom_registrant_id: string | null; zoom_join_url: string | null }>()
 
       if (error) {
-        return new Response(error.message, { status: 500, headers: auth.headers })
+        return {
+          ok: false,
+          intent: 'register-student',
+          class_id: classId,
+          profile_id: profileId,
+          error: `${error.message} | ${provisionSummary}`,
+          run_result: runResult,
+        }
       }
 
       if (!registrant?.zoom_registrant_id || !registrant.zoom_join_url) {
-        return new Response('Sync ran but this student still has no join link.', { status: 409, headers: auth.headers })
+        return {
+          ok: false,
+          intent: 'register-student',
+          class_id: classId,
+          profile_id: profileId,
+          error: `Sync ran but this student still has no join link. | ${provisionSummary}`,
+          run_result: runResult,
+        }
       }
 
-      return { ok: true }
+      return {
+        ok: true,
+        intent: 'register-student',
+        class_id: classId,
+        profile_id: profileId,
+        zoom_join_url: registrant.zoom_join_url,
+        message: `Zoom join link created. | ${provisionSummary}`,
+        run_result: runResult,
+      }
     } catch (error) {
-      return new Response(error instanceof Error ? error.message : 'Failed to register student.', {
-        status: 500,
-        headers: auth.headers,
-      })
+      return {
+        ok: false,
+        intent: 'register-student',
+        class_id: classId,
+        profile_id: profileId,
+        error: error instanceof Error ? error.message : 'Failed to register student.',
+      }
     }
   }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -139,6 +139,16 @@ type LoaderData = {
   foreignKeyOptions?: Record<string, ForeignKeyOption[]>
 }
 
+type RegisterStudentActionResult = {
+  ok: boolean
+  intent: 'register-student'
+  class_id: string
+  profile_id: string
+  zoom_join_url?: string
+  message?: string
+  error?: string
+}
+
 const timestampColumns = new Set(['starts_at', 'ends_at', 'submitted_at'])
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 250, 500, 1000, 1500] as const
 const FILTER_EMPTY_TOKEN = '__none__'
@@ -390,6 +400,12 @@ const toDateValue = (value: unknown) => {
 const rowKeyFor = (row: Record<string, unknown>, editorConfig?: EditorConfig) => {
   if (!editorConfig?.primaryKey.length) return ''
   return editorConfig.primaryKey.map(key => String(row[key] ?? '')).join('::')
+}
+
+const attendanceRowKey = (row: Record<string, unknown>) => {
+  const classId = typeof row.class_id === 'string' ? row.class_id : ''
+  const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+  return classId && profileId ? `${classId}::${profileId}` : ''
 }
 
 const personLinkForCell = (
@@ -715,6 +731,10 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
   const filterRequestCounterRef = useRef(0)
   const openFilterCacheKeyRef = useRef<string | null>(null)
   const [openFilterCacheEntry, setOpenFilterCacheEntry] = useState<FilterOptionsCacheEntry | null>(null)
+  const [attendanceJoinUrlOverrides, setAttendanceJoinUrlOverrides] = useState<Record<string, string>>({})
+  const [attendanceRegisterFeedback, setAttendanceRegisterFeedback] = useState<
+    Record<string, { type: 'success' | 'error'; message: string }>
+  >({})
   const isWorkshopEnrollmentTable = tableName === 'class-enrollment'
   const isFederalDistrictTable = tableName === 'federal-electoral-district'
   const debugPerf = searchParams.get('debugPerf') === '1'
@@ -1631,6 +1651,28 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
   const canInlineInsert = Boolean(editorConfig?.allowInsert)
   const canInlineUpdate = Boolean(editorConfig?.allowUpdate)
 
+  useEffect(() => {
+    if (!isClassAttendance) return
+    const result = statusFetcher.data as RegisterStudentActionResult | undefined
+    if (!result || result.intent !== 'register-student') return
+    const key = `${result.class_id}::${result.profile_id}`
+    if (!key) return
+
+    if (result.ok && typeof result.zoom_join_url === 'string' && result.zoom_join_url) {
+      setAttendanceJoinUrlOverrides(prev => ({ ...prev, [key]: result.zoom_join_url as string }))
+      setAttendanceRegisterFeedback(prev => ({
+        ...prev,
+        [key]: { type: 'success', message: result.message ?? 'Zoom join link created.' },
+      }))
+      return
+    }
+
+    setAttendanceRegisterFeedback(prev => ({
+      ...prev,
+      [key]: { type: 'error', message: result.error ?? result.message ?? 'Register failed.' },
+    }))
+  }, [isClassAttendance, statusFetcher.data])
+
   const tableWidth = useMemo(() => {
     const totalColumnWidth = columns.reduce(
       (sum, column) => sum + (columnWidths[column] ?? (columnMeta[column]?.numeric ? DEFAULT_NUMERIC_COLUMN_WIDTH : DEFAULT_COLUMN_WIDTH)),
@@ -2196,6 +2238,66 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                     }
                   >
                     {columns.map(column => {
+                      if (isClassAttendance && column === 'student_join_url') {
+                        const classId = typeof row.class_id === 'string' ? row.class_id : ''
+                        const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+                        const key = attendanceRowKey(row)
+                        const fetchedOverride = key ? attendanceJoinUrlOverrides[key] : ''
+                        const rowJoinUrl = typeof row.student_join_url === 'string' ? row.student_join_url : ''
+                        const effectiveJoinUrl = fetchedOverride || rowJoinUrl
+                        const isRegistering =
+                          statusFetcher.state === 'submitting' &&
+                          statusFetcher.formData?.get('intent') === 'register-student' &&
+                          statusFetcher.formData?.get('class_id') === classId &&
+                          statusFetcher.formData?.get('profile_id') === profileId
+                        const feedback = key ? attendanceRegisterFeedback[key] : null
+
+                        return (
+                          <td key={`cell-${absoluteRowIndex}-${column}`} className="px-4 py-2 font-mono" title={effectiveJoinUrl || '(empty)'}>
+                            {effectiveJoinUrl ? (
+                              <a
+                                href={effectiveJoinUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                onClick={event => event.stopPropagation()}
+                                className="block max-w-full truncate underline decoration-dotted underline-offset-2 hover:text-primary"
+                              >
+                                {effectiveJoinUrl}
+                              </a>
+                            ) : canEditStatus ? (
+                              <div className="space-y-1">
+                                <button
+                                  type="button"
+                                  disabled={!classId || !profileId || isRegistering}
+                                  onClick={event => {
+                                    event.stopPropagation()
+                                    if (key) {
+                                      setAttendanceRegisterFeedback(prev => {
+                                        if (!prev[key]) return prev
+                                        const next = { ...prev }
+                                        delete next[key]
+                                        return next
+                                      })
+                                    }
+                                    registerAttendanceStudent(row)
+                                  }}
+                                  className="rounded border border-input px-2 py-1 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                  {isRegistering ? 'Registering...' : 'Register'}
+                                </button>
+                                {feedback ? (
+                                  <p className={`max-w-64 whitespace-normal text-[11px] ${feedback.type === 'error' ? 'text-destructive' : 'text-emerald-700'}`}>
+                                    {feedback.message}
+                                  </p>
+                                ) : null}
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">(empty)</span>
+                            )}
+                          </td>
+                        )
+                      }
+
                       if (isClassAttendance && column === 'status' && canEditStatus) {
                         const statusValue = typeof row.status === 'string' ? row.status : ''
                         return (
@@ -2261,39 +2363,6 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                               <option value="true">true</option>
                               <option value="false">false</option>
                             </select>
-                          </td>
-                        )
-                      }
-
-                      if (isClassAttendance && column === 'register_student_action') {
-                        const classId = typeof row.class_id === 'string' ? row.class_id : ''
-                        const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
-                        const showButton =
-                          typeof row.register_student_action === 'string' &&
-                          row.register_student_action === 'Register'
-                        const isRegistering =
-                          statusFetcher.state === 'submitting' &&
-                          statusFetcher.formData?.get('intent') === 'register-student' &&
-                          statusFetcher.formData?.get('class_id') === classId &&
-                          statusFetcher.formData?.get('profile_id') === profileId
-
-                        return (
-                          <td key={`cell-${absoluteRowIndex}-${column}`} className="px-4 py-2" title="Create missing registrant and join link">
-                            {showButton ? (
-                              <button
-                                type="button"
-                                disabled={!classId || !profileId || isRegistering}
-                                onClick={event => {
-                                  event.stopPropagation()
-                                  registerAttendanceStudent(row)
-                                }}
-                                className="rounded border border-input px-2 py-1 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-                              >
-                                {isRegistering ? 'Registering...' : 'Register'}
-                              </button>
-                            ) : (
-                              <span className="text-xs text-muted-foreground">-</span>
-                            )}
                           </td>
                         )
                       }


### PR DESCRIPTION
## What changed
- show Register inline in the empty student join link cell (no separate register column)
- show register success/error feedback inline per row
- update row immediately with returned zoom join link after register (no refresh required)
- add per-step detail columns and latest sync payload/error visibility for class attendance rows
- return structured register-student action results with provisioning diagnostics

## Verification
- npm run typecheck (web/)