### PR TITLE
Add class attendance row delete action

### DIFF
--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -375,6 +375,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       'class_id',
       'profile_id',
       'id',
+      'delete_row',
     ],
     rows,
     columnMeta: {
@@ -409,6 +410,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       class_id: { label: 'Class ID', filterable: true },
       profile_id: { label: 'Profile ID', filterable: true },
       id: { label: 'Attendance ID', filterable: true },
+      delete_row: { label: 'Delete', filterable: false },
     },
     canEditStatus: isRoleAtLeast(auth.claims.role, 'staff'),
   }
@@ -641,6 +643,28 @@ export async function action({ request }: Route.ActionArgs) {
         profile_id: profileId,
         error: error instanceof Error ? error.message : 'Failed to register student.',
       }
+    }
+  }
+
+  if (intent === 'delete-attendance-row') {
+    const classId = formData.get('class_id') as string
+    const profileId = formData.get('profile_id') as string
+    if (!classId || !profileId) {
+      return new Response('Missing identifiers', { status: 400, headers: auth.headers })
+    }
+
+    const { supabase } = createClient(request)
+    const { error } = await supabase.from('class_attendance').delete().eq('class_id', classId).eq('profile_id', profileId)
+
+    if (error) {
+      return new Response(error.message, { status: 500, headers: auth.headers })
+    }
+
+    return {
+      ok: true,
+      intent: 'delete-attendance-row',
+      class_id: classId,
+      profile_id: profileId,
     }
   }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -1793,6 +1793,18 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     statusFetcher.submit(formData, { method: 'post' })
   }
 
+  const deleteAttendanceRow = (row: Record<string, unknown>) => {
+    if (!isClassAttendance || !canEditStatus) return
+    const classId = typeof row.class_id === 'string' ? row.class_id : ''
+    const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+    if (!classId || !profileId) return
+    const formData = new FormData()
+    formData.set('intent', 'delete-attendance-row')
+    formData.set('class_id', classId)
+    formData.set('profile_id', profileId)
+    statusFetcher.submit(formData, { method: 'post' })
+  }
+
   const updateWorkshopEnrollmentStatus = (row: Record<string, unknown>, value: string) => {
     if (!isWorkshopEnrollment || !canEditStatus || !value) return
     const enrollmentId = typeof row.id === 'string' ? row.id : ''
@@ -2382,6 +2394,33 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                                 </option>
                               ))}
                             </select>
+                          </td>
+                        )
+                      }
+
+                      if (isClassAttendance && column === 'delete_row' && canEditStatus) {
+                        const classId = typeof row.class_id === 'string' ? row.class_id : ''
+                        const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+                        const isDeleting =
+                          statusFetcher.state === 'submitting' &&
+                          statusFetcher.formData?.get('intent') === 'delete-attendance-row' &&
+                          statusFetcher.formData?.get('class_id') === classId &&
+                          statusFetcher.formData?.get('profile_id') === profileId
+
+                        return (
+                          <td key={`cell-${absoluteRowIndex}-${column}`} className="px-4 py-2" title="Delete attendance row">
+                            <button
+                              type="button"
+                              disabled={!classId || !profileId || isDeleting}
+                              onClick={event => {
+                                event.stopPropagation()
+                                if (!window.confirm('Delete this class attendance row?')) return
+                                deleteAttendanceRow(row)
+                              }}
+                              className="rounded border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {isDeleting ? 'Deleting...' : 'Delete'}
+                            </button>
                           </td>
                         )
                       }


### PR DESCRIPTION
## What changed
- add a per-row Delete button as the rightmost column on the class attendance table
- wire a new class-attendance action intent (delete-attendance-row) to delete by class_id + profile_id
- show a delete confirmation prompt and in-flight deleting state in the table UI

## Verification
- npm run typecheck (web/)