### PR TITLE
Use root callback for password reset links

### DIFF
--- a/web/app/routes/forgot-password.tsx
+++ b/web/app/routes/forgot-password.tsx
@@ -29,7 +29,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   // Send the actual reset password email
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${origin}/auth/confirm?next=/update-password`,
+    redirectTo: `${origin}/?next=${encodeURIComponent('/update-password')}`,
   })
 
   if (error) {


### PR DESCRIPTION
## What changed
- update forgot-password reset email redirect target to root callback with next=/update-password
- this aligns with hosted Supabase redirect handling and preserves recovery destination through the app callback flow

## Verification
- npm run typecheck