### PR TITLE
Add 24h class camera/photo followup emails

### DIFF
--- a/supabase/migrations/20260701123000_class_camera_or_photo_followup_email_draft.sql
+++ b/supabase/migrations/20260701123000_class_camera_or_photo_followup_email_draft.sql
@@ -1,0 +1,111 @@
+create or replace function public.ensure_class_camera_or_photo_followup_email_draft()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_draft_id uuid;
+  v_version_id uuid;
+begin
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    'class_camera_or_photo_followup_v1',
+    'Class follow-up: camera/photo confirmation',
+    '24-hour post-class follow-up for participants missing camera-on or photo status.',
+    'Sent 24 hours after class end when camera was off/missing and no photo status exists.',
+    'class_attendance.post_class_camera_or_photo_followup',
+    'web/app/lib/zoom-jobs/runner.server.ts',
+    'transactional',
+    'draft',
+    true,
+    '{"required": ["guardianName"]}'::jsonb,
+    'Photo needed to confirm class participation',
+    E'Hi {{guardianName}},\n\nThanks for being part of today''s summerlunch+ class!\n\nIt seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today''s session.\n\nYou can reply directly to this email with your photo attached.\n\nThank you, and we hope you enjoyed cooking with us!\n\n- The summerlunch+ Team'
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      is_system = true,
+      variables_schema = case
+        when public.email_draft.variables_schema = '{}'::jsonb then excluded.variables_schema
+        else public.email_draft.variables_schema
+      end,
+      current_subject_markdown = case
+        when char_length(btrim(public.email_draft.current_subject_markdown)) = 0 then excluded.current_subject_markdown
+        else public.email_draft.current_subject_markdown
+      end,
+      current_body_markdown = case
+        when char_length(btrim(public.email_draft.current_body_markdown)) = 0 then excluded.current_body_markdown
+        else public.email_draft.current_body_markdown
+      end
+  returning id into v_draft_id;
+
+  insert into public.email_draft_version (
+    email_draft_id,
+    version_number,
+    subject_markdown,
+    body_markdown,
+    subject_rendered,
+    html_rendered,
+    text_rendered,
+    variables_schema,
+    change_note,
+    published_at
+  )
+  values (
+    v_draft_id,
+    1,
+    'Photo needed to confirm class participation',
+    E'Hi {{guardianName}},\n\nThanks for being part of today''s summerlunch+ class!\n\nIt seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today''s session.\n\nYou can reply directly to this email with your photo attached.\n\nThank you, and we hope you enjoyed cooking with us!\n\n- The summerlunch+ Team',
+    'Photo needed to confirm class participation',
+    '<p>Hi {{guardianName}},</p><p>Thanks for being part of today''s summerlunch+ class!</p><p>It seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today''s session.</p><p>You can reply directly to this email with your photo attached.</p><p>Thank you, and we hope you enjoyed cooking with us!</p><p>- The summerlunch+ Team</p>',
+    E'Hi {{guardianName}},\n\nThanks for being part of today''s summerlunch+ class!\n\nIt seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today''s session.\n\nYou can reply directly to this email with your photo attached.\n\nThank you, and we hope you enjoyed cooking with us!\n\n- The summerlunch+ Team',
+    '{"required": ["guardianName"]}'::jsonb,
+    'Seeded class camera/photo follow-up draft content.',
+    now()
+  )
+  on conflict (email_draft_id, version_number) do nothing;
+
+  if exists (
+    select 1
+    from public.email_draft
+    where id = v_draft_id
+      and published_version_id is null
+  ) then
+    select version.id
+      into v_version_id
+    from public.email_draft_version as version
+    where version.email_draft_id = v_draft_id
+    order by version.version_number desc
+    limit 1;
+
+    update public.email_draft
+    set
+      published_version_id = v_version_id,
+      status = 'published'
+    where id = v_draft_id;
+  end if;
+end;
+$$;
+
+select public.ensure_class_camera_or_photo_followup_email_draft();

--- a/web/app/lib/email/templates/class-camera-or-photo-followup.ts
+++ b/web/app/lib/email/templates/class-camera-or-photo-followup.ts
@@ -1,0 +1,61 @@
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+export type ClassCameraOrPhotoFollowupTemplateData = {
+  guardianName: string
+}
+
+export const renderClassCameraOrPhotoFollowupEmail = ({
+  guardianName,
+}: ClassCameraOrPhotoFollowupTemplateData) => {
+  const safeGuardianName = escapeHtml(guardianName)
+
+  return {
+    subject: 'Please share your class recipe photo',
+    text:
+      `Hi ${guardianName},\n` +
+      '\n' +
+      "Thanks for being part of today's summerlunch+ class!\n" +
+      '\n' +
+      'It seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today\'s session.\n' +
+      '\n' +
+      'You can reply directly to this email with your photo attached.\n' +
+      '\n' +
+      'Thank you, and we hope you enjoyed cooking with us!\n' +
+      '\n' +
+      '- The summerlunch+ Team',
+    html: `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background-color:#f6f8fb;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0;padding:24px;background-color:#f6f8fb;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background-color:#ffffff;border-radius:12px;overflow:hidden;">
+            <tr>
+              <td style="padding:24px 24px 8px 24px;text-align:center;">
+                <img src="https://cdn.summerlunchplus.com/summerlunch%2B.png" alt="SummerLunch Plus" width="180" style="display:block;margin:0 auto;border:0;outline:none;text-decoration:none;height:auto;" />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
+                <p style="margin:0 0 16px 0;">Hi ${safeGuardianName},</p>
+                <p style="margin:0 0 16px 0;">Thanks for being part of today's summerlunch+ class!</p>
+                <p style="margin:0 0 16px 0;">It seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today's session.</p>
+                <p style="margin:0 0 16px 0;">You can reply directly to this email with your photo attached.</p>
+                <p style="margin:0 0 16px 0;">Thank you, and we hope you enjoyed cooking with us!</p>
+                <p style="margin:0;">- The summerlunch+ Team</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`,
+  }
+}

--- a/web/app/lib/email/templates/index.ts
+++ b/web/app/lib/email/templates/index.ts
@@ -1,4 +1,8 @@
 import {
+  renderClassCameraOrPhotoFollowupEmail,
+  type ClassCameraOrPhotoFollowupTemplateData,
+} from '@/lib/email/templates/class-camera-or-photo-followup'
+import {
   renderClassReminderLoginEmail,
   type ClassReminderLoginTemplateData,
 } from '@/lib/email/templates/class-reminder-login'
@@ -15,6 +19,7 @@ export type EmailTemplateMap = {
   family_enrollment_requested_v1: FamilyEnrollmentRequestedTemplateData
   family_enrollment_accepted_v1: FamilyEnrollmentAcceptedTemplateData
   class_reminder_login_v1: ClassReminderLoginTemplateData
+  class_camera_or_photo_followup_v1: ClassCameraOrPhotoFollowupTemplateData
 }
 
 export type EmailTemplateKey = keyof EmailTemplateMap
@@ -32,6 +37,9 @@ export const emailTemplates: {
   },
   class_reminder_login_v1: {
     render: renderClassReminderLoginEmail,
+  },
+  class_camera_or_photo_followup_v1: {
+    render: renderClassCameraOrPhotoFollowupEmail,
   },
 }
 

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -30,6 +30,7 @@ const resolvePublicAppOrigin = (fallbackOrigin: string) => {
 
 const REPROVISION_HORIZON_MINUTES = 36 * 60
 const REMINDER_WINDOW_MINUTES = 2 * 60
+const POST_CLASS_FOLLOWUP_DELAY_HOURS = 24
 const RUNNING_SYNC_TIMEOUT_MINUTES = 20
 const FAILED_SYNC_RETRY_COOLDOWN_MINUTES = 10
 const IN_CLAUSE_BATCH_SIZE = 150
@@ -314,6 +315,88 @@ const resolveReminderRecipientEmail = async (profileId: string) => {
   }
 }
 
+const resolveGuardianRecipientForFollowup = async (profileId: string) => {
+  const { data: profile, error: profileError } = await adminClient
+    .from('profile')
+    .select('id, role, firstname, surname, email')
+    .eq('id', profileId)
+    .maybeSingle<{ id: string; role: string | null; firstname: string | null; surname: string | null; email: string | null }>()
+
+  if (profileError || !profile) {
+    return null
+  }
+
+  const guardianNameForEmail = (row: { firstname: string | null; surname: string | null; email: string | null }) => {
+    const full = [row.firstname ?? '', row.surname ?? '']
+      .map(value => value.trim())
+      .filter(Boolean)
+      .join(' ')
+      .trim()
+    if (full) return full
+    const email = normalizeEmail(row.email)
+    if (email) return email
+    return 'Parent/Guardian'
+  }
+
+  if (profile.role === 'guardian') {
+    const email = normalizeEmail(profile.email)
+    if (email) {
+      return {
+        recipientProfileId: profile.id,
+        email,
+        guardianName: guardianNameForEmail(profile),
+      }
+    }
+  }
+
+  const { data: guardianEdges, error: guardianEdgeError } = await adminClient
+    .from('person_guardian_child')
+    .select('guardian_profile_id, primary_child')
+    .eq('child_profile_id', profileId)
+
+  if (guardianEdgeError) {
+    return null
+  }
+
+  const prioritizedGuardianIds = (guardianEdges ?? [])
+    .slice()
+    .sort((left, right) => Number(right.primary_child) - Number(left.primary_child))
+    .map(edge => edge.guardian_profile_id)
+    .filter((id): id is string => Boolean(id))
+
+  if (prioritizedGuardianIds.length) {
+    const { data: guardians, error: guardianError } = await adminClient
+      .from('profile')
+      .select('id, firstname, surname, email')
+      .in('id', prioritizedGuardianIds)
+
+    if (!guardianError && guardians?.length) {
+      const guardianById = new Map(guardians.map(guardian => [guardian.id, guardian]))
+      for (const guardianId of prioritizedGuardianIds) {
+        const guardian = guardianById.get(guardianId)
+        if (!guardian) continue
+        const email = normalizeEmail(guardian.email)
+        if (!email) continue
+
+        return {
+          recipientProfileId: guardian.id,
+          email,
+          guardianName: guardianNameForEmail(guardian),
+        }
+      }
+    }
+  }
+
+  const fallbackEmail = normalizeEmail(profile.email)
+  if (!fallbackEmail) return null
+
+  return {
+    recipientProfileId: profile.id,
+    email: fallbackEmail,
+    guardianName: guardianNameForEmail(profile),
+  }
+}
+
 const sendReminderCoverage = async ({ now, appOrigin, onlyClassId }: { now: Date; appOrigin: string; onlyClassId?: string }) => {
   const publicAppOrigin = resolvePublicAppOrigin(appOrigin)
   const reminderStart = now
@@ -419,6 +502,72 @@ const sendReminderCoverage = async ({ now, appOrigin, onlyClassId }: { now: Date
   }
 
   return { scannedClasses: classIds.length, sent, failed, skipped }
+}
+
+const sendPostClassCameraOrPhotoFollowupCoverage = async ({ now, onlyClassId }: { now: Date; onlyClassId?: string }) => {
+  const followupThreshold = new Date(now.getTime() - POST_CLASS_FOLLOWUP_DELAY_HOURS * 60 * 60_000).toISOString()
+  const attendanceQuery = adminClient
+    .from('class_attendance')
+    .select('class_id, profile_id, camera_on, photo_status, class:class_id ( ends_at )')
+
+  if (onlyClassId) {
+    attendanceQuery.eq('class_id', onlyClassId)
+  }
+
+  const { data: attendanceRows, error } = await attendanceQuery
+
+  if (error) {
+    return { scanned: 0, eligible: 0, sent: 0, failed: 1, skipped: 0, error: error.message }
+  }
+
+  const candidates = (attendanceRows ?? []).filter(row => {
+    const classRow = relationRow<{ ends_at: string }>(row.class)
+    if (!classRow?.ends_at) return false
+    if (new Date(classRow.ends_at).toISOString() > followupThreshold) return false
+
+    const cameraMissingOrOff = row.camera_on !== true
+    const photoStatusMissing = row.photo_status == null
+    return cameraMissingOrOff && photoStatusMissing
+  })
+
+  let sent = 0
+  let failed = 0
+  let skipped = 0
+
+  for (const row of candidates) {
+    const recipient = await resolveGuardianRecipientForFollowup(row.profile_id)
+    if (!recipient?.email) {
+      skipped += 1
+      continue
+    }
+
+    const result = await sendTemplateEmail({
+      toEmail: recipient.email,
+      templateKey: 'class_camera_or_photo_followup_v1',
+      templateData: {
+        guardianName: recipient.guardianName,
+      },
+      eventKey: `class:${row.class_id}:profile:${row.profile_id}:camera_or_photo_followup_v1`,
+      profileId: row.profile_id,
+      familyProfileId: recipient.recipientProfileId,
+    })
+
+    if (result.status === 'sent') {
+      sent += 1
+    } else if (result.status === 'skipped') {
+      skipped += 1
+    } else {
+      failed += 1
+    }
+  }
+
+  return {
+    scanned: (attendanceRows ?? []).length,
+    eligible: candidates.length,
+    sent,
+    failed,
+    skipped,
+  }
 }
 
 const isRecent = ({ now, value, windowMinutes }: { now: Date; value: string | null; windowMinutes: number }) => {
@@ -799,6 +948,7 @@ export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?
   const within36h = await provisionWithin36h({ now })
   const hostReconciliation = await reconcileHostOverlaps({ now })
   const reminders = await sendReminderCoverage({ now, appOrigin })
+  const postClassCameraOrPhotoFollowup = await sendPostClassCameraOrPhotoFollowupCoverage({ now })
   const attendanceSync = await syncPostClassAttendance({ now })
 
   console.info('[zoom-jobs] run completed', {
@@ -807,6 +957,8 @@ export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?
     within36hScanned: within36h.scanned,
     hostConflictsDetected: hostReconciliation.detected,
     reminderScanned: reminders.scannedClasses,
+    postClassFollowupEligible: postClassCameraOrPhotoFollowup.eligible,
+    postClassFollowupSent: postClassCameraOrPhotoFollowup.sent,
     attendanceScanned: attendanceSync.scanned,
     attendanceFailed: attendanceSync.failed,
     attendanceAbsentMarked: attendanceSync.absentMarked,
@@ -821,6 +973,7 @@ export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?
     provisionWithin36h: within36h,
     hostOverlapReconciliation: hostReconciliation,
     reminderCoverage: reminders,
+    postClassCameraOrPhotoFollowup,
     attendanceRowBackfill,
     attendanceSync,
   }
@@ -841,6 +994,7 @@ export const runZoomJobsForClass = async ({
   const provision = await provisionClassById(classId)
   const hostReconciliation = await reconcileHostOverlaps({ now, onlyClassIds: new Set([classId]) })
   const reminderCoverage = await sendReminderCoverage({ now, appOrigin, onlyClassId: classId })
+  const postClassCameraOrPhotoFollowup = await sendPostClassCameraOrPhotoFollowupCoverage({ now, onlyClassId: classId })
   const attendanceSync = await syncPostClassAttendance({ now, onlyClassId: classId })
 
   return {
@@ -852,6 +1006,7 @@ export const runZoomJobsForClass = async ({
     provision,
     hostOverlapReconciliation: hostReconciliation,
     reminderCoverage,
+    postClassCameraOrPhotoFollowup,
     attendanceSync,
   }
 }


### PR DESCRIPTION
- Adds `class_camera_or_photo_followup_v1` email template wiring and renderer.
- Adds zoom-jobs coverage that scans post-class attendance (24h after class end) and sends follow-up emails when `camera_on` is off/missing and `photo_status` is missing.
- Resolves guardian recipient with guardian-first fallback and logs deterministic `event_key` sends into `email_message` via existing sender path.
- Seeds/publishes markdown draft content in new migration `20260701123000_class_camera_or_photo_followup_email_draft.sql`.

## Verification
- `npm run typecheck` (in `web/`) ✅
- `supabase migration up` could not run locally because local Supabase/Postgres was not running (`127.0.0.1:54322 connection refused`).