### PR TITLE
Update class photo followup email upload instructions

### DIFF
--- a/supabase/migrations/20260702104500_update_class_camera_or_photo_followup_email_copy.sql
+++ b/supabase/migrations/20260702104500_update_class_camera_or_photo_followup_email_copy.sql
@@ -1,0 +1,110 @@
+create or replace function public.update_class_camera_or_photo_followup_email_copy()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_draft_id uuid;
+  v_version_id uuid;
+  v_next_version integer;
+  v_subject constant text := 'Please upload your class recipe photo in the SummerLunch+ Hub';
+  v_body constant text := E'Hi {{guardianName}},\n\nThanks for being part of today''s summerlunch+ class.\n\nTo confirm participation for today''s session, please upload a photo of your completed recipe in the SummerLunch+ Hub:\n\n1. Log in to your SummerLunch+ account\n2. Go to the Workshops section\n3. Find today''s class and click Upload Images\n4. Select your photo(s) and submit\n\nPlease do not reply to this email, as this inbox is not monitored.\n\nThank you!\n\n- The summerlunch+ Team';
+begin
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    'class_camera_or_photo_followup_v1',
+    'Class follow-up: camera/photo confirmation',
+    '24-hour post-class follow-up for participants missing camera-on or photo status.',
+    'Sent 24 hours after class end when camera was off/missing and no photo status exists.',
+    'class_attendance.post_class_camera_or_photo_followup',
+    'web/app/lib/zoom-jobs/runner.server.ts',
+    'transactional',
+    'published',
+    true,
+    '{"required": ["guardianName"]}'::jsonb,
+    v_subject,
+    v_body
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      status = 'published',
+      is_system = true,
+      variables_schema = excluded.variables_schema,
+      current_subject_markdown = excluded.current_subject_markdown,
+      current_body_markdown = excluded.current_body_markdown
+  returning id into v_draft_id;
+
+  select version.id
+    into v_version_id
+  from public.email_draft_version as version
+  where version.email_draft_id = v_draft_id
+    and version.subject_markdown = v_subject
+    and version.body_markdown = v_body
+  order by version.version_number desc
+  limit 1;
+
+  if v_version_id is null then
+    select coalesce(max(version.version_number), 0) + 1
+      into v_next_version
+    from public.email_draft_version as version
+    where version.email_draft_id = v_draft_id;
+
+    insert into public.email_draft_version (
+      email_draft_id,
+      version_number,
+      subject_markdown,
+      body_markdown,
+      subject_rendered,
+      html_rendered,
+      text_rendered,
+      variables_schema,
+      change_note,
+      published_at
+    )
+    values (
+      v_draft_id,
+      v_next_version,
+      v_subject,
+      v_body,
+      v_subject,
+      '<p>Hi {{guardianName}},</p><p>Thanks for being part of today''s summerlunch+ class.</p><p>To confirm participation for today''s session, please upload a photo of your completed recipe in the SummerLunch+ Hub:</p><ol><li>Log in to your SummerLunch+ account</li><li>Go to the Workshops section</li><li>Find today''s class and click Upload Images</li><li>Select your photo(s) and submit</li></ol><p>Please do not reply to this email, as this inbox is not monitored.</p><p>Thank you!</p><p>- The summerlunch+ Team</p>',
+      E'Hi {{guardianName}},\n\nThanks for being part of today''s summerlunch+ class.\n\nTo confirm participation for today''s session, please upload a photo of your completed recipe in the SummerLunch+ Hub:\n\n1. Log in to your SummerLunch+ account\n2. Go to the Workshops section\n3. Find today''s class and click Upload Images\n4. Select your photo(s) and submit\n\nPlease do not reply to this email, as this inbox is not monitored.\n\nThank you!\n\n- The summerlunch+ Team',
+      '{"required": ["guardianName"]}'::jsonb,
+      'Clarify no-reply mailbox and direct families to upload in Hub Workshops section.',
+      now()
+    )
+    returning id into v_version_id;
+  end if;
+
+  update public.email_draft
+  set
+    published_version_id = v_version_id,
+    status = 'published',
+    current_subject_markdown = v_subject,
+    current_body_markdown = v_body
+  where id = v_draft_id;
+end;
+$$;
+
+select public.update_class_camera_or_photo_followup_email_copy();

--- a/web/app/lib/email/templates/class-camera-or-photo-followup.ts
+++ b/web/app/lib/email/templates/class-camera-or-photo-followup.ts
@@ -16,17 +16,22 @@ export const renderClassCameraOrPhotoFollowupEmail = ({
   const safeGuardianName = escapeHtml(guardianName)
 
   return {
-    subject: 'Please share your class recipe photo',
+    subject: 'Please upload your class recipe photo in the SummerLunch+ Hub',
     text:
       `Hi ${guardianName},\n` +
       '\n' +
-      "Thanks for being part of today's summerlunch+ class!\n" +
+      "Thanks for being part of today's summerlunch+ class.\n" +
       '\n' +
-      'It seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today\'s session.\n' +
+      "To confirm participation for today's session, please upload a photo of your completed recipe in the SummerLunch+ Hub:\n" +
       '\n' +
-      'You can reply directly to this email with your photo attached.\n' +
+      '1. Log in to your SummerLunch+ account\n' +
+      '2. Go to the Workshops section\n' +
+      '3. Find today\'s class and click Upload Images\n' +
+      '4. Select your photo(s) and submit\n' +
       '\n' +
-      'Thank you, and we hope you enjoyed cooking with us!\n' +
+      'Please do not reply to this email, as this inbox is not monitored.\n' +
+      '\n' +
+      'Thank you!\n' +
       '\n' +
       '- The summerlunch+ Team',
     html: `<!doctype html>
@@ -44,10 +49,16 @@ export const renderClassCameraOrPhotoFollowupEmail = ({
             <tr>
               <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
                 <p style="margin:0 0 16px 0;">Hi ${safeGuardianName},</p>
-                <p style="margin:0 0 16px 0;">Thanks for being part of today's summerlunch+ class!</p>
-                <p style="margin:0 0 16px 0;">It seems like your camera was turned off during class if you experienced any connectivity issues, please send us a photo of your completed recipe so we can confirm participation for today's session.</p>
-                <p style="margin:0 0 16px 0;">You can reply directly to this email with your photo attached.</p>
-                <p style="margin:0 0 16px 0;">Thank you, and we hope you enjoyed cooking with us!</p>
+                <p style="margin:0 0 16px 0;">Thanks for being part of today's summerlunch+ class.</p>
+                <p style="margin:0 0 16px 0;">To confirm participation for today's session, please upload a photo of your completed recipe in the SummerLunch+ Hub:</p>
+                <ol style="margin:0 0 16px 24px;padding:0;">
+                  <li style="margin:0 0 8px 0;">Log in to your SummerLunch+ account</li>
+                  <li style="margin:0 0 8px 0;">Go to the Workshops section</li>
+                  <li style="margin:0 0 8px 0;">Find today's class and click Upload Images</li>
+                  <li style="margin:0;">Select your photo(s) and submit</li>
+                </ol>
+                <p style="margin:0 0 16px 0;">Please do not reply to this email, as this inbox is not monitored.</p>
+                <p style="margin:0 0 16px 0;">Thank you!</p>
                 <p style="margin:0;">- The summerlunch+ Team</p>
               </td>
             </tr>


### PR DESCRIPTION
- Rewords `class_camera_or_photo_followup_v1` email content to remove reply-by-email guidance for no-reply mailbox.
- Adds explicit Hub upload steps, including going to the Workshops section and using Upload Images.
- Adds migration `20260702104500_update_class_camera_or_photo_followup_email_copy.sql` to update/publish the draft copy in `email_draft` and `email_draft_version` so draft-mode sends also use the new wording.

## Verification
- `npm run typecheck` (in `web/`) ✅