### PR TITLE
Point raw attendance page at raw class_attendance rows

### DIFF
--- a/web/app/routes/manage/class-attendance-raw.tsx
+++ b/web/app/routes/manage/class-attendance-raw.tsx
@@ -2,8 +2,8 @@ import TableDisplay from './table-display'
 import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
 
-export const loader = createTableLoader('class-zoom-participant')
-export const action = createTableAction('class-zoom-participant')
+export const loader = createTableLoader('class-attendance-raw')
+export const action = createTableAction('class-attendance-raw')
 
 export default function ClassAttendanceRawTablePage() {
   return <TableDisplay />

--- a/web/app/routes/manage/nav.ts
+++ b/web/app/routes/manage/nav.ts
@@ -29,7 +29,7 @@ export const manageSections: ManageNavSection[] = [
       {
         to: '/manage/class-attendance-raw',
         label: 'Raw attendance',
-        description: 'Raw Zoom participant rows used to derive class attendance status.',
+        description: 'Raw class_attendance rows before enrichment and derived debug fields.',
       },
       { to: '/manage/class-attendance-photo-upload-attempt', label: 'Photo upload attempts', description: 'Debug class photo upload failures and retries.' },
       { to: '/manage/workshop-enrollment', label: 'Workshop enrollments', description: 'Pending, waitlisted, approved, and rejected workshop enrollments.' },

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -268,6 +268,20 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
       },
     ],
   },
+  'class-attendance-raw': {
+    label: 'Raw Class Attendance',
+    table: 'class_attendance',
+    select: 'id, class_id, profile_id, status, photo_status, camera_on, recorded_by, created_at, updated_at',
+    columns: ['class_id', 'profile_id', 'status', 'photo_status', 'camera_on', 'recorded_by', 'created_at', 'updated_at', 'id'],
+    order: 'created_at',
+    orderAscending: false,
+    editor: {
+      primaryKey: ['id'],
+      allowInsert: false,
+      allowUpdate: false,
+      fields: {},
+    },
+  },
   'class-attendance-photo-upload-attempt': {
     label: 'Class Attendance Photo Upload Attempts',
     table: 'class_attendance_photo_upload_attempt',


### PR DESCRIPTION
- Updates `/manage/class-attendance-raw` to use a dedicated raw `class_attendance` table definition.
- Shows raw columns (`id`, `class_id`, `profile_id`, `status`, `photo_status`, `camera_on`, `recorded_by`, timestamps) without enrichment fields.
- Updates nav description to clarify this is raw `class_attendance` data.