### PR TITLE
Fix recovery redirect fallback and related updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,42 @@
 # AGENTS.md
 
 ## Repo boundaries
-- Product app is `web/` (React Router v7 SSR + Vite + TypeScript + Supabase). Run Node commands in `web/`; repo-root `package.json` has no scripts.
-- `zoom-api/` is a separate FastAPI service; follow `zoom-api/CLAUDE.md` when working there.
-- `scheduler/` is a separate cron service that triggers `web` internal routes; treat it as its own deployable.
+- Product app is `web/` (React Router v7 SSR). Run Node commands in `web/`; root `package.json` has no scripts.
+- `scheduler/` (cron worker) and `zoom-api/` (FastAPI) are separate deployables with their own run/test flows.
+- When touching `zoom-api/`, follow `zoom-api/CLAUDE.md`.
 
-## High-signal wiring details
-- Routes are manually declared in `web/app/routes.ts`; new route files 404 until added there.
-- `web/app/root.tsx` applies onboarding redirects to every path not in its allowlist; if you add a public/auth route, update that allowlist or it will be gated unexpectedly.
-- Auth/onboarding flow is split across `web/app/root.tsx`, `web/app/lib/auth.server.ts`, and `web/app/routes/auth/sign-up-details.tsx`; keep redirect logic consistent across all three.
-- Signup details path is `/auth/sign-up-details` (not `/auth/signup-details`).
-- `web/app/lib/supabase/server.ts#createClient` returns `{ supabase, headers }`; forward `headers` on redirects/responses or auth cookies are dropped.
-- `~/` and `@/` both map to `web/app/*` (`web/tsconfig.json`).
+## Web app wiring that causes regressions
+- Routes are manually declared in `web/app/routes.ts`; new route files 404 until registered.
+- `npm run typecheck` runs `react-router typegen` + `tsc`; run it after route edits to refresh generated route types.
+- `web/app/root.tsx` enforces onboarding redirects on almost every path; add new public/auth paths to its allowlist or they will be gated.
+- Keep onboarding logic aligned across `web/app/root.tsx`, `web/app/lib/auth.server.ts`, and `web/app/routes/auth/sign-up-details.tsx`.
+- Signup details route is `/auth/sign-up-details` (with hyphen).
+- `createClient` in `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; propagate `headers` on redirects/responses or auth cookies are lost.
+- Path aliases `~/` and `@/` both resolve to `web/app/*` (`web/tsconfig.json`).
 
-## Local setup and commands
-- Initial app env: from repo root run `cp web/.env.template web/.env.local`, then `supabase start --debug`, then copy values from `supabase status -o json` into `web/.env.local`.
-- `ONBOARDING_MODE` defaults to `role`; only `permission` enables permission-gated onboarding (`web/.env.template`, `web/app/lib/auth.server.ts`).
-- App commands (in `web/`): `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, `npm run test`.
-- There is no lint/format script configured in `web/package.json`; do not assume `npm run lint` exists.
-- Focused Playwright runs: `npm run test:e2e -- tests/e2e/<spec>.spec.ts --grep "..."` and `npm run test:unit -- tests/unit/<spec>.spec.ts`.
+## Local setup and verification
+- First-time local app setup (repo root): `cp web/.env.template web/.env.local` -> `supabase start --debug` -> copy values from `supabase status -o json` into `web/.env.local`.
+- `ONBOARDING_MODE` falls back to `role`; only `permission` enables permission-gated onboarding.
+- Key commands in `web/`: `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, `npm run test`.
+- There is no lint/format script in `web/package.json`; do not invent `npm run lint`.
+- Focused tests: `npm run test:e2e -- tests/e2e/<spec>.spec.ts --grep "..."` and `npm run test:unit -- tests/unit/<spec>.spec.ts`.
+- CI (`.github/workflows/tests.yml`) boots Supabase and runs only `npm run test`; typecheck is not part of CI.
 
-## Testing quirks
-- `npm run test` is Playwright for both e2e and unit directories (`web/package.json`); there is no separate Jest/Vitest suite.
-- If `PLAYWRIGHT_BASE_URL` is unset, Playwright starts `npm run dev -- --port 5173` automatically (`web/playwright.config.ts`).
-- Some admin e2e specs skip unless `SUPABASE_URL` and `SUPABASE_SECRET_KEY` are available (env or `web/.env.local`) (`web/tests/e2e/helpers/admin-account.ts`).
+## Test behavior gotchas
+- `npm run test` is Playwright over both `web/tests/e2e` and `web/tests/unit`; there is no Jest/Vitest suite.
+- If `PLAYWRIGHT_BASE_URL` is unset, Playwright auto-starts `npm run dev -- --port 5173`.
+- Admin e2e helpers skip/fail without `SUPABASE_URL` and `SUPABASE_SECRET_KEY` (env or `web/.env.local`).
 
-## Database workflow and guardrails
-- Declarative SQL in `supabase/schemas/` is source of truth. Do not manually edit existing `supabase/migrations/*`.
-- Schema change flow (repo root): edit `supabase/schemas/*` -> `supabase db diff -f <name>` -> `supabase migration up`.
-- Regenerate DB types after schema changes:
+## Database and auth guardrails
+- Treat declarative SQL in `supabase/schemas/` as source of truth; do not hand-edit existing `supabase/migrations/*`.
+- Schema flow (repo root): edit `supabase/schemas/*` -> `supabase db diff -f <name>` -> `supabase migration up`.
+- After schema changes, regenerate `web/app/lib/database.types.ts` with:
   `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
-- New DB-backed features must include permission seeds (`app_permissions`/`role_permission`) and RLS updates in the same change (`CODE_STANDARDS.md`).
-- Use `public.user_roles` + JWT claims as auth truth; `auth.users.raw_user_meta_data.role` can drift.
+- DB-backed features must ship permissions + RLS together (`app_permissions`, `role_permission`, policies) per `CODE_STANDARDS.md`.
+- Auth truth is `public.user_roles` + JWT claims; `auth.users.raw_user_meta_data.role` can drift.
 
-## Service integration gotchas
-- `scheduler` auth depends on matching `INTERNAL_RUNNER_SECRET` between `scheduler` and `web` (`scheduler/README.md`, `web/app/lib/internal-runner-auth.server.ts`).
-- Cron schedules are defined in `scheduler/crontab`; update that file (not docs) when changing job frequency.
-- Default Supabase seed mode is app bootstrap + sanitized prod snapshot (`supabase/config.toml` uses `./seeds/prod-data/*-sanitized.sql`, not dummy fixtures).
-- Auth email templates are configured in `supabase/config.toml` and loaded from `supabase/templates/*.html`.
+## Scheduler/Supabase integration gotchas
+- Internal cron auth requires matching `INTERNAL_RUNNER_SECRET` in `scheduler` and `web`.
+- Job timing source of truth is `scheduler/crontab` (not README text).
+- Default seed mode in `supabase/config.toml` uses bootstrap + sanitized prod snapshot (`./seeds/prod-data/*-sanitized.sql`).
+- Supabase auth email templates are configured in `supabase/config.toml` and loaded from `supabase/templates/*.html`.

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -28,6 +28,35 @@ const resolvePublicAppOrigin = (fallbackOrigin: string) => {
   return ensureOrigin(explicitOrigin || fallbackOrigin)
 }
 
+const formatClassStartsAtForWorkshopTimezone = ({
+  startsAt,
+  workshopTimezone,
+}: {
+  startsAt: string
+  workshopTimezone: string | null | undefined
+}) => {
+  const date = new Date(startsAt)
+  if (Number.isNaN(date.getTime())) {
+    return startsAt
+  }
+
+  const timezone = typeof workshopTimezone === 'string' ? workshopTimezone.trim() : ''
+  const options: Intl.DateTimeFormatOptions = {
+    dateStyle: 'full',
+    timeStyle: 'short',
+    ...(timezone ? { timeZone: timezone } : {}),
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en-US', options).format(date)
+  } catch {
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'full',
+      timeStyle: 'short',
+    }).format(date)
+  }
+}
+
 const REPROVISION_HORIZON_MINUTES = 36 * 60
 const REMINDER_WINDOW_MINUTES = 2 * 60
 const POST_CLASS_FOLLOWUP_DELAY_HOURS = 24
@@ -414,7 +443,7 @@ const sendReminderCoverage = async ({ now, appOrigin, onlyClassId }: { now: Date
 
     const { data: classRow } = await adminClient
       .from('class')
-      .select('id, starts_at, workshop:workshop_id ( description )')
+      .select('id, starts_at, workshop:workshop_id ( description, timezone )')
       .eq('id', classId)
       .single()
 
@@ -461,10 +490,18 @@ const sendReminderCoverage = async ({ now, appOrigin, onlyClassId }: { now: Date
           ? workshopRelation.description.trim()
           : 'your class'
 
-      const startsAtText = new Intl.DateTimeFormat('en-US', {
-        dateStyle: 'full',
-        timeStyle: 'short',
-      }).format(new Date(classRow.starts_at))
+      const workshopTimezone =
+        workshopRelation &&
+        typeof workshopRelation === 'object' &&
+        'timezone' in workshopRelation &&
+        typeof workshopRelation.timezone === 'string'
+          ? workshopRelation.timezone
+          : null
+
+      const startsAtText = formatClassStartsAtForWorkshopTimezone({
+        startsAt: classRow.starts_at,
+        workshopTimezone,
+      })
 
       const templateData: { workshopName: string; classStartsAt: string; loginUrl: string } = {
         workshopName,

--- a/web/app/routes/auth/confirm.tsx
+++ b/web/app/routes/auth/confirm.tsx
@@ -8,7 +8,18 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, type LoaderFunctionArgs, redirect, useLoaderData } from 'react-router'
 
 type LoaderData = {
-  next: string
+  next: string | null
+}
+
+const resolveDestination = ({
+  next,
+  type,
+}: {
+  next: string | null
+  type: EmailOtpType | null
+}) => {
+  if (next?.startsWith('/')) return next
+  return type === 'recovery' ? '/update-password' : '/'
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -17,7 +28,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const code = requestUrl.searchParams.get('code')
   const type = requestUrl.searchParams.get('type') as EmailOtpType | null
   const _next = requestUrl.searchParams.get('next')
-  const next = _next?.startsWith('/') ? _next : '/'
+  const next = _next?.startsWith('/') ? _next : null
   const { supabase, headers } = createClient(request)
 
   if (code) {
@@ -33,7 +44,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
           loginMethod: 'otp:code',
         })
       }
-      return redirect(next, { headers })
+      const destination = resolveDestination({ next, type })
+      return redirect(destination, { headers })
     }
     return redirect(`/auth/error?error=${error.message}`)
   }
@@ -54,7 +66,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
           loginMethod: `otp:${type}`,
         })
       }
-      return redirect(next, { headers })
+      const destination = resolveDestination({ next, type })
+      return redirect(destination, { headers })
     }
     return redirect(`/auth/error?error=${error.message}`)
   }
@@ -67,8 +80,8 @@ export default function ConfirmPage() {
   const [error, setError] = useState<string | null>(null)
 
   const destination = useMemo(() => {
-    if (next.startsWith('/')) return next
-    return '/'
+    if (next?.startsWith('/')) return next
+    return null
   }, [next])
 
   useEffect(() => {
@@ -114,7 +127,7 @@ export default function ConfirmPage() {
           return
         }
         const fallbackDestination = type === 'recovery' ? '/update-password' : '/login'
-        window.location.replace(destination || fallbackDestination)
+        window.location.replace(destination ?? fallbackDestination)
       })
   }, [destination])
 

--- a/web/app/routes/manage/nav.ts
+++ b/web/app/routes/manage/nav.ts
@@ -26,12 +26,6 @@ export const manageSections: ManageNavSection[] = [
     defaultCollapsed: false,
     items: [
       { to: '/manage/class-attendance', label: 'Class attendance', description: 'Attendance by class and student.' },
-      {
-        to: '/manage/class-attendance-raw',
-        label: 'Raw attendance',
-        description: 'Raw class_attendance rows before enrichment and derived debug fields.',
-      },
-      { to: '/manage/class-attendance-photo-upload-attempt', label: 'Photo upload attempts', description: 'Debug class photo upload failures and retries.' },
       { to: '/manage/workshop-enrollment', label: 'Workshop enrollments', description: 'Pending, waitlisted, approved, and rejected workshop enrollments.' },
       { to: '/manage/class', label: 'Classes', description: 'Individual class schedule entries.' },
       { to: '/manage/gift-cards', label: 'Gift cards', description: 'Upload and process gift card batches.' },
@@ -111,6 +105,12 @@ export const manageSections: ManageNavSection[] = [
     defaultCollapsed: true,
     items: [
       { to: '/manage/login-event', label: 'Login events', description: 'Successful sign-in metadata and source context.' },
+      {
+        to: '/manage/class-attendance-raw',
+        label: 'Raw attendance',
+        description: 'Raw class_attendance rows before enrichment and derived debug fields.',
+      },
+      { to: '/manage/class-attendance-photo-upload-attempt', label: 'Photo upload attempts', description: 'Debug class photo upload failures and retries.' },
       { to: '/manage/ip-org-policy', label: 'IP org policy', description: 'Classify network org strings for proxy, ISP, and greylist discrepancy handling.' },
       { to: '/manage/semester-form-requirement', label: 'Semester surveys', description: 'Map one pre/post survey form per semester.' },
       { to: '/manage/role-permission', label: 'Role permissions', description: 'Permissions assigned to each role.' },

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -966,6 +966,7 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
       'resend',
     ],
     order: 'created_at',
+    orderAscending: false,
     lookupMappings: [
       {
         keyColumn: 'triggered_by_user_id',

--- a/web/app/routes/manage/table-definitions.ts
+++ b/web/app/routes/manage/table-definitions.ts
@@ -76,7 +76,7 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
     label: 'Families',
     table: 'person_guardian_child',
     select: 'guardian_profile_id, child_profile_id, primary_child',
-    columns: ['guardian_display', 'child_display', 'primary_child'],
+    columns: ['guardian_display', 'guardian_email', 'child_display', 'primary_child'],
     lookupMappings: [
       {
         keyColumn: 'guardian_profile_id',
@@ -84,6 +84,13 @@ export const TABLE_DEFINITIONS: Record<string, TableDefinition> = {
         resultColumn: 'guardian_display',
         select: 'id, firstname, surname, email',
         format: 'profile_display',
+      },
+      {
+        keyColumn: 'guardian_profile_id',
+        table: 'profile',
+        resultColumn: 'guardian_email',
+        select: 'id, email',
+        valueColumn: 'email',
       },
       {
         keyColumn: 'child_profile_id',


### PR DESCRIPTION
## What this PR includes
- Default recovery confirmations to /update-password when next is missing
- Update AGENTS.md with current high-signal repo guidance
- Improve Zoom reminder class time formatting with workshop timezone support
- Add guardian email to families table definitions and navigation updates
- Default email messages table sorting to newest first

## Why
- Production recovery links may arrive without next, causing reset flow to behave like a magic login.

## Verification
- Ran npm run typecheck in web/ for the confirm route changes.
