### PR TITLE
Deterministic reset-password redirect and recovery listener

### DIFF
--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -22,7 +22,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const hasAuthCode = Boolean(url.searchParams.get('code'))
   const hasOtpToken = Boolean(url.searchParams.get('token_hash') && url.searchParams.get('type'))
 
-  if (pathname !== '/auth/confirm' && (hasAuthCode || hasOtpToken)) {
+  if (pathname !== '/auth/confirm' && pathname !== '/update-password' && (hasAuthCode || hasOtpToken)) {
     throw redirect(`/auth/confirm${url.search}`, { status: 302 })
   }
 

--- a/web/app/routes/auth/update-password.tsx
+++ b/web/app/routes/auth/update-password.tsx
@@ -1,4 +1,4 @@
-
+import { createClient as createBrowserClient } from '@/lib/supabase/client'
 import { createClient } from '@/lib/supabase/server'
 import AuthStickerBackground from '@/components/auth/sticker-background'
 import { Button } from '@/components/ui/button'
@@ -11,7 +11,35 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { type ActionFunctionArgs, redirect, useFetcher } from 'react-router'
+import { type EmailOtpType } from '@supabase/supabase-js'
+import { useEffect, useState } from 'react'
+import { Link, type ActionFunctionArgs, type LoaderFunctionArgs, redirect, useFetcher } from 'react-router'
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const requestUrl = new URL(request.url)
+  const code = requestUrl.searchParams.get('code')
+  const token_hash = requestUrl.searchParams.get('token_hash')
+  const type = requestUrl.searchParams.get('type') as EmailOtpType | null
+  const { supabase, headers } = createClient(request)
+
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (error) {
+      return redirect(`/auth/error?error=${encodeURIComponent(error.message)}`)
+    }
+    return redirect('/update-password', { headers })
+  }
+
+  if (token_hash && type) {
+    const { error } = await supabase.auth.verifyOtp({ type, token_hash })
+    if (error) {
+      return redirect(`/auth/error?error=${encodeURIComponent(error.message)}`)
+    }
+    return redirect('/update-password', { headers })
+  }
+
+  return null
+}
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { supabase, headers } = createClient(request)
@@ -36,9 +64,67 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
 export default function Page() {
   const fetcher = useFetcher<typeof action>()
+  const [ready, setReady] = useState(false)
+  const [authError, setAuthError] = useState<string | null>(null)
 
   const error = fetcher.data?.error
   const loading = fetcher.state === 'submitting'
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const supabase = createBrowserClient()
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(event => {
+      if (event === 'PASSWORD_RECOVERY') {
+        setReady(true)
+        setAuthError(null)
+      }
+    })
+
+    const hash = window.location.hash
+    const hashParams = new URLSearchParams(hash.replace(/^#/, ''))
+    const access_token = hashParams.get('access_token')
+    const refresh_token = hashParams.get('refresh_token')
+
+    if (access_token && refresh_token) {
+      supabase.auth
+        .signOut({ scope: 'local' })
+        .then(() => supabase.auth.setSession({ access_token, refresh_token }))
+        .then(({ error: sessionError }) => {
+          if (sessionError) {
+            setAuthError(sessionError.message)
+            return
+          }
+
+          setReady(true)
+          setAuthError(null)
+          const cleanUrl = window.location.pathname + window.location.search
+          window.history.replaceState({}, '', cleanUrl)
+        })
+      return () => subscription.unsubscribe()
+    }
+
+    supabase.auth.getSession().then(({ data, error: sessionError }) => {
+      if (sessionError) {
+        setAuthError(sessionError.message)
+        setReady(false)
+        return
+      }
+
+      if (data.session) {
+        setReady(true)
+        setAuthError(null)
+        return
+      }
+
+      setReady(false)
+      setAuthError('This reset link is invalid or expired. Please request a new password reset email.')
+    })
+
+    return () => subscription.unsubscribe()
+  }, [])
 
   return (
     <AuthStickerBackground dense>
@@ -47,27 +133,43 @@ export default function Page() {
           <Card>
             <CardHeader>
               <CardTitle className="text-2xl">Reset Your Password</CardTitle>
-              <CardDescription>Please enter your new password below.</CardDescription>
+              <CardDescription>
+                {ready
+                  ? 'Please enter your new password below.'
+                  : 'Verifying your recovery link...'}
+              </CardDescription>
             </CardHeader>
             <CardContent>
-              <fetcher.Form method="post">
-                <div className="flex flex-col gap-6">
-                  <div className="grid gap-2">
-                    <Label htmlFor="password">New password</Label>
-                    <Input
-                      id="password"
-                      name="password"
-                      type="password"
-                      placeholder="New password"
-                      required
-                    />
+              {authError ? (
+                <div className="space-y-4">
+                  <p className="text-sm text-red-500">{authError}</p>
+                  <div className="text-sm">
+                    <Link to="/forgot-password" className="underline underline-offset-4">
+                      Request a new reset link
+                    </Link>
                   </div>
-                  {error && <p className="text-sm text-red-500">{error}</p>}
-                  <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? 'Saving...' : 'Save new password'}
-                  </Button>
                 </div>
-              </fetcher.Form>
+              ) : (
+                <fetcher.Form method="post">
+                  <div className="flex flex-col gap-6">
+                    <div className="grid gap-2">
+                      <Label htmlFor="password">New password</Label>
+                      <Input
+                        id="password"
+                        name="password"
+                        type="password"
+                        placeholder="New password"
+                        required
+                        disabled={!ready}
+                      />
+                    </div>
+                    {error && <p className="text-sm text-red-500">{error}</p>}
+                    <Button type="submit" className="w-full" disabled={loading || !ready}>
+                      {loading ? 'Saving...' : 'Save new password'}
+                    </Button>
+                  </div>
+                </fetcher.Form>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/web/app/routes/forgot-password.tsx
+++ b/web/app/routes/forgot-password.tsx
@@ -29,7 +29,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   // Send the actual reset password email
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${origin}/?next=${encodeURIComponent('/update-password')}`,
+    redirectTo: `${origin}/update-password`,
   })
 
   if (error) {


### PR DESCRIPTION
What changed:\n- Forgot-password now sends users to /update-password directly via redirectTo.\n- Root auth callback redirect no longer forces /auth/confirm for /update-password callbacks.\n- /update-password now handles code and token_hash callbacks server-side, and hash-token callbacks client-side.\n- Added PASSWORD_RECOVERY auth-state listener to keep recovery flow aligned with Supabase guidance.\n\nWhy:\n- Production links were dropping query params and behaving like magic-link login.\n- This flow no longer depends on next query params to land on reset-password UI.\n\nVerification:\n- Ran npm run typecheck in web/.