### PR TITLE
Remove class start time from reminder email copy

### DIFF
--- a/supabase/migrations/20260702130000_update_class_reminder_login_email_copy.sql
+++ b/supabase/migrations/20260702130000_update_class_reminder_login_email_copy.sql
@@ -1,0 +1,110 @@
+create or replace function public.update_class_reminder_login_email_copy()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_draft_id uuid;
+  v_version_id uuid;
+  v_next_version integer;
+  v_subject constant text := 'Reminder: {{workshopName}} starts soon';
+  v_body constant text := E'Hi,\n\nYour {{workshopName}} class starts soon.\n\nPlease sign in to SummerLunch+ to join your class:\n\n[Log in to join class]({{loginUrl}})\n\nIf you have trouble accessing your account, reply to this email and our team will help.\n\n- The SummerLunch+ Team';
+begin
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    'class_reminder_login_v1',
+    'Class reminder login prompt',
+    'Class reminder prompting users to log in before joining class.',
+    'Sent up to 2 hours before class start for unsent registrants.',
+    'class_zoom_registrant.reminder_login',
+    'web/app/lib/zoom-jobs/runner.server.ts',
+    'transactional',
+    'published',
+    true,
+    '{"required": ["workshopName", "loginUrl"]}'::jsonb,
+    v_subject,
+    v_body
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      status = 'published',
+      is_system = true,
+      variables_schema = excluded.variables_schema,
+      current_subject_markdown = excluded.current_subject_markdown,
+      current_body_markdown = excluded.current_body_markdown
+  returning id into v_draft_id;
+
+  select version.id
+    into v_version_id
+  from public.email_draft_version as version
+  where version.email_draft_id = v_draft_id
+    and version.subject_markdown = v_subject
+    and version.body_markdown = v_body
+  order by version.version_number desc
+  limit 1;
+
+  if v_version_id is null then
+    select coalesce(max(version.version_number), 0) + 1
+      into v_next_version
+    from public.email_draft_version as version
+    where version.email_draft_id = v_draft_id;
+
+    insert into public.email_draft_version (
+      email_draft_id,
+      version_number,
+      subject_markdown,
+      body_markdown,
+      subject_rendered,
+      html_rendered,
+      text_rendered,
+      variables_schema,
+      change_note,
+      published_at
+    )
+    values (
+      v_draft_id,
+      v_next_version,
+      v_subject,
+      v_body,
+      'Reminder: {{workshopName}} starts soon',
+      '<p>Hi,</p><p>Your {{workshopName}} class starts soon.</p><p>Please sign in to SummerLunch+ to join your class:</p><p><a href="{{loginUrl}}">Log in to join class</a></p><p>If you have trouble accessing your account, reply to this email and our team will help.</p><p>- The SummerLunch+ Team</p>',
+      E'Hi,\n\nYour {{workshopName}} class starts soon.\n\nPlease sign in to SummerLunch+ to join your class:\n\n{{loginUrl}}\n\nIf you have trouble accessing your account, reply to this email and our team will help.\n\n- The SummerLunch+ Team',
+      '{"required": ["workshopName", "loginUrl"]}'::jsonb,
+      'Remove class start timestamp from reminder copy and keep login prompt.',
+      now()
+    )
+    returning id into v_version_id;
+  end if;
+
+  update public.email_draft
+  set
+    published_version_id = v_version_id,
+    status = 'published',
+    current_subject_markdown = v_subject,
+    current_body_markdown = v_body
+  where id = v_draft_id;
+end;
+$$;
+
+select public.update_class_reminder_login_email_copy();

--- a/web/app/lib/email/templates/class-reminder-login.ts
+++ b/web/app/lib/email/templates/class-reminder-login.ts
@@ -8,22 +8,19 @@ const escapeHtml = (value: string) =>
 
 export type ClassReminderLoginTemplateData = {
   workshopName: string
-  classStartsAt: string
   loginUrl: string
 }
 
 export const renderClassReminderLoginEmail = ({
   workshopName,
-  classStartsAt,
   loginUrl,
 }: ClassReminderLoginTemplateData) => {
   const safeWorkshopName = escapeHtml(workshopName)
-  const safeStartsAt = escapeHtml(classStartsAt)
   const safeLoginUrl = escapeHtml(loginUrl)
 
   return {
     subject: `Reminder: ${workshopName} starts soon`,
-    text: `Reminder: ${workshopName} starts at ${classStartsAt}. Log in to join your class: ${loginUrl}`,
+    text: `Reminder: ${workshopName} starts soon. Log in to join your class: ${loginUrl}`,
     html: `<!doctype html>
 <html>
   <body style="margin:0;padding:0;background-color:#f6f8fb;">
@@ -38,7 +35,7 @@ export const renderClassReminderLoginEmail = ({
             </tr>
             <tr>
               <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
-                <p style="margin:0 0 16px 0;"><strong>${safeWorkshopName}</strong> starts at <strong>${safeStartsAt}</strong>.</p>
+                <p style="margin:0 0 16px 0;"><strong>${safeWorkshopName}</strong> starts soon.</p>
                 <p style="margin:0 0 16px 0;">Please log in to SummerLunch+ to join your class.</p>
                 <p style="margin:0;"><a href="${safeLoginUrl}">Log in to join class</a></p>
               </td>

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -28,35 +28,6 @@ const resolvePublicAppOrigin = (fallbackOrigin: string) => {
   return ensureOrigin(explicitOrigin || fallbackOrigin)
 }
 
-const formatClassStartsAtForWorkshopTimezone = ({
-  startsAt,
-  workshopTimezone,
-}: {
-  startsAt: string
-  workshopTimezone: string | null | undefined
-}) => {
-  const date = new Date(startsAt)
-  if (Number.isNaN(date.getTime())) {
-    return startsAt
-  }
-
-  const timezone = typeof workshopTimezone === 'string' ? workshopTimezone.trim() : ''
-  const options: Intl.DateTimeFormatOptions = {
-    dateStyle: 'full',
-    timeStyle: 'short',
-    ...(timezone ? { timeZone: timezone } : {}),
-  }
-
-  try {
-    return new Intl.DateTimeFormat('en-US', options).format(date)
-  } catch {
-    return new Intl.DateTimeFormat('en-US', {
-      dateStyle: 'full',
-      timeStyle: 'short',
-    }).format(date)
-  }
-}
-
 const REPROVISION_HORIZON_MINUTES = 36 * 60
 const REMINDER_WINDOW_MINUTES = 2 * 60
 const POST_CLASS_FOLLOWUP_DELAY_HOURS = 24
@@ -490,22 +461,8 @@ const sendReminderCoverage = async ({ now, appOrigin, onlyClassId }: { now: Date
           ? workshopRelation.description.trim()
           : 'your class'
 
-      const workshopTimezone =
-        workshopRelation &&
-        typeof workshopRelation === 'object' &&
-        'timezone' in workshopRelation &&
-        typeof workshopRelation.timezone === 'string'
-          ? workshopRelation.timezone
-          : null
-
-      const startsAtText = formatClassStartsAtForWorkshopTimezone({
-        startsAt: classRow.starts_at,
-        workshopTimezone,
-      })
-
-      const templateData: { workshopName: string; classStartsAt: string; loginUrl: string } = {
+      const templateData: { workshopName: string; loginUrl: string } = {
         workshopName,
-        classStartsAt: startsAtText,
         loginUrl,
       }
 


### PR DESCRIPTION
- Updates `class_reminder_login_v1` legacy renderer to remove the "starts at ..." phrasing and keep the workshop-starts-soon + login prompt message.
- Updates reminder sender payload to stop passing `classStartsAt` for this template.
- Adds migration `20260702130000_update_class_reminder_login_email_copy.sql` to publish updated draft copy and variables schema (`workshopName`, `loginUrl`).

## Verification
- `npm run typecheck` in `web/` ✅