### PR TITLE
Restore full manage filter option behavior

### DIFF
--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -68,6 +68,7 @@ export default [
     route("class-zoom-participant", "routes/manage/class-zoom-participant.tsx"),
     route("zlr-click-event", "routes/manage/zlr-click-event.tsx"),
     route("workshop-enrollment", "routes/manage/workshop-enrollment.tsx"),
+    route("table-filter-options", "routes/manage/table-filter-options.ts"),
     route("workshop-enrollment/enrichment", "routes/manage/workshop-enrollment.enrichment.ts"),
     route("form", "routes/manage/form.tsx"),
     route("form/:formID/answers", "routes/manage/form.$id.answers.tsx"),

--- a/web/app/routes/forgot-password.tsx
+++ b/web/app/routes/forgot-password.tsx
@@ -26,10 +26,20 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const { supabase, headers } = createClient(request)
   const origin = new URL(request.url).origin
+  const redirectTo = `${origin}/update-password`
+
+  console.info('[auth] forgot-password reset redirect', {
+    requestUrl: request.url,
+    origin,
+    redirectTo,
+    host: request.headers.get('host'),
+    xForwardedHost: request.headers.get('x-forwarded-host'),
+    xForwardedProto: request.headers.get('x-forwarded-proto'),
+  })
 
   // Send the actual reset password email
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${origin}/update-password`,
+    redirectTo,
   })
 
   if (error) {

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -299,6 +299,18 @@ const getCellValue = (column: string, row: Record<string, unknown>, tableName?: 
   return (value ?? '').toString()
 }
 
+const getFilterQueryValue = (column: string, row: Record<string, unknown>, tableName?: string) => {
+  const value = row[column]
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value)
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'object') {
+    return getCellValue(column, row, tableName)
+  }
+  return String(value)
+}
+
 const normalizeHoverCardValue = (value: unknown) => {
   if (value === null || value === undefined) return ''
   if (typeof value === 'string') return value.trim()
@@ -1096,12 +1108,14 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
   const filterDataRevision = useMemo(
     () =>
-      [
-        rowsWithEnrichment.length,
-        Object.keys(enrichmentByProfileId).length,
-        Object.keys(districtCountsByRiding).length,
-      ].join(':'),
-    [districtCountsByRiding, enrichmentByProfileId, rowsWithEnrichment.length]
+      serverSideQuery
+        ? 'server'
+        : [
+            rowsWithEnrichment.length,
+            Object.keys(enrichmentByProfileId).length,
+            Object.keys(districtCountsByRiding).length,
+          ].join(':'),
+    [districtCountsByRiding, enrichmentByProfileId, rowsWithEnrichment.length, serverSideQuery]
   )
 
   const openFilterCacheKey = useMemo(() => {
@@ -1180,6 +1194,82 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
       updatedAt: Date.now(),
     }
     setOpenFilterCacheEntry(loadingEntry)
+
+    if (serverSideQuery) {
+      void (async () => {
+        const activeRequestId = filterActiveRequestRef.current.get(openFilterCacheKey)
+        if (activeRequestId !== requestId) return
+
+        const query = new URLSearchParams()
+        query.set('table', tableName)
+        query.set('column', openFilterColumn)
+        for (const column of columns) {
+          if (!hasOwn(filters, column)) continue
+          const values = filters[column] ?? []
+          if (!values.length) {
+            query.append(`f_${column}`, FILTER_EMPTY_TOKEN)
+            continue
+          }
+          for (const value of values) {
+            query.append(`f_${column}`, value)
+          }
+        }
+
+        try {
+          const response = await fetch(`/manage/table-filter-options?${query.toString()}`)
+          if (!response.ok) {
+            throw new Error(`Failed to load filter options (${response.status})`)
+          }
+
+          const payload = (await response.json()) as {
+            status?: string
+            allOptions?: string[]
+            totalCount?: number
+          }
+
+          const activeAfterFetch = filterActiveRequestRef.current.get(openFilterCacheKey)
+          if (activeAfterFetch !== requestId) return
+
+          if (payload.status === 'loaded') {
+            const allOptions = sortFilterOptions(payload.allOptions ?? [])
+            const loadedEntry: FilterOptionsCacheEntry = {
+              status: 'loaded',
+              allOptions,
+              totalCount: typeof payload.totalCount === 'number' ? payload.totalCount : allOptions.length,
+              updatedAt: Date.now(),
+            }
+            writeFilterCache(openFilterCacheKey, loadedEntry)
+            if (openFilterCacheKeyRef.current === openFilterCacheKey) {
+              setOpenFilterCacheEntry(loadedEntry)
+            }
+            filterActiveRequestRef.current.delete(openFilterCacheKey)
+            return
+          }
+        } catch (error) {
+          console.error('[table display] server filter options fetch failed', error)
+        }
+
+        const localOptions = computeAllOptionsForColumn(openFilterColumn, filters)
+        const fallbackEntry: FilterOptionsCacheEntry = {
+          status: 'loaded',
+          allOptions: localOptions,
+          totalCount: localOptions.length,
+          updatedAt: Date.now(),
+        }
+        writeFilterCache(openFilterCacheKey, fallbackEntry)
+        if (openFilterCacheKeyRef.current === openFilterCacheKey) {
+          setOpenFilterCacheEntry(fallbackEntry)
+        }
+        filterActiveRequestRef.current.delete(openFilterCacheKey)
+      })()
+
+      return () => {
+        const activeRequestId = filterActiveRequestRef.current.get(openFilterCacheKey)
+        if (activeRequestId === requestId) {
+          filterActiveRequestRef.current.delete(openFilterCacheKey)
+        }
+      }
+    }
 
     void (async () => {
       const activeRequestId = filterActiveRequestRef.current.get(openFilterCacheKey)
@@ -1315,7 +1405,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
         filterActiveRequestRef.current.delete(openFilterCacheKey)
       }
     }
-  }, [filters, openFilterCacheKey, openFilterColumn, rowsWithEnrichment, tableName])
+  }, [columns, filters, openFilterCacheKey, openFilterColumn, rowsWithEnrichment, serverSideQuery, tableName])
 
   const derivedRows = useMemo(() => {
     let adjustedRows = serverSideQuery
@@ -1600,7 +1690,10 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     })
   }
 
-  const appendFilter = (column: string, value: string) => {
+  const appendFilter = (column: string, row: Record<string, unknown>) => {
+    const value = serverSideQuery
+      ? getFilterQueryValue(column, row, tableName)
+      : getCellValue(column, row, tableName)
     const current = filters[column] ?? []
     if (current.includes(value)) return
     const allOptionsForColumn = computeAllOptionsForColumn(column, filters)
@@ -2834,7 +2927,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                             }
 
                             if (!canClickFilter) return
-                            appendFilter(column, cellValue)
+                            appendFilter(column, row)
                           }}
                           onMouseEnter={() => {
                             if (!isWorkshopEnrollment || column !== 'profile_display') return

--- a/web/app/routes/manage/table-filter-options.ts
+++ b/web/app/routes/manage/table-filter-options.ts
@@ -1,0 +1,185 @@
+import { createClient } from '@/lib/supabase/server'
+import { TABLE_DEFINITIONS } from './table-definitions'
+import type { LoaderFunctionArgs } from 'react-router'
+
+const FETCH_BATCH_SIZE = 1000
+const FILTER_EMPTY_TOKEN = '__none__'
+
+type ParsedFilter = {
+  values: string[]
+  includeEmpty: boolean
+}
+
+const parseTopLevelSelectColumns = (select: string) => {
+  const columns: string[] = []
+  let depth = 0
+  let token = ''
+
+  const pushToken = () => {
+    const trimmed = token.trim()
+    token = ''
+    if (!trimmed) return
+    if (trimmed.includes('(')) return
+    const [left] = trimmed.split(':')
+    const column = left.trim()
+    if (!column || column === '*') return
+    columns.push(column)
+  }
+
+  for (const char of select) {
+    if (char === '(') {
+      depth += 1
+      token += char
+      continue
+    }
+    if (char === ')') {
+      depth = Math.max(0, depth - 1)
+      token += char
+      continue
+    }
+    if (char === ',' && depth === 0) {
+      pushToken()
+      continue
+    }
+    token += char
+  }
+  pushToken()
+
+  return Array.from(new Set(columns))
+}
+
+const parseFiltersFromSearch = (columns: string[], searchParams: URLSearchParams): Record<string, ParsedFilter> => {
+  return columns.reduce<Record<string, ParsedFilter>>((acc, column) => {
+    const values = Array.from(new Set(searchParams.getAll(`f_${column}`)))
+    if (!values.length) return acc
+
+    const includeEmpty = values.includes(FILTER_EMPTY_TOKEN)
+    const explicitValues = values.filter(value => value !== FILTER_EMPTY_TOKEN)
+    acc[column] = {
+      values: explicitValues,
+      includeEmpty,
+    }
+    return acc
+  }, {})
+}
+
+const fromQualifiedTable = (supabase: ReturnType<typeof createClient>['supabase'], qualifiedTable: string) => {
+  const [schema, table, ...rest] = qualifiedTable.split('.')
+  if (schema && table && rest.length === 0) {
+    return supabase.schema(schema).from(table)
+  }
+  return supabase.from(qualifiedTable)
+}
+
+const toOptionValue = (value: unknown) => {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value)
+  if (value instanceof Date) return value.toISOString()
+  return JSON.stringify(value)
+}
+
+const filterOptionPriority = (value: string) => {
+  if (value === '') return 0
+  if (value === 'NULL') return 1
+  if (value === '...') return 2
+  return 3
+}
+
+const sortFilterOptions = (values: string[]) => {
+  const deduped = Array.from(new Set(values))
+  deduped.sort((left, right) => {
+    const leftPriority = filterOptionPriority(left)
+    const rightPriority = filterOptionPriority(right)
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority
+    return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' })
+  })
+  return deduped
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url)
+  const tableName = (url.searchParams.get('table') ?? '').trim()
+  const column = (url.searchParams.get('column') ?? '').trim()
+
+  if (!tableName || !column) {
+    return Response.json({ status: 'invalid', allOptions: [], totalCount: 0 }, { status: 400 })
+  }
+
+  const definition = TABLE_DEFINITIONS[tableName]
+  if (!definition) {
+    return Response.json({ status: 'not_found', allOptions: [], totalCount: 0 }, { status: 404 })
+  }
+
+  if (!definition.columns.includes(column)) {
+    return Response.json({ status: 'invalid_column', allOptions: [], totalCount: 0 }, { status: 400 })
+  }
+
+  const { supabase, headers } = createClient(request)
+  const selectableColumns = new Set(parseTopLevelSelectColumns(definition.select))
+  const parsedFilters = parseFiltersFromSearch(definition.columns, url.searchParams)
+
+  const hasUnsupportedFilter = Object.keys(parsedFilters).some(
+    filterColumn => filterColumn !== column && !selectableColumns.has(filterColumn)
+  )
+  const hasMixedEmptyAndExplicit = Object.values(parsedFilters).some(
+    filter => filter.includeEmpty && filter.values.length > 0
+  )
+  const isSelectableColumn = selectableColumns.has(column)
+
+  if (hasUnsupportedFilter || hasMixedEmptyAndExplicit || !isSelectableColumn) {
+    return Response.json(
+      { status: 'unsupported', allOptions: [], totalCount: 0 },
+      { headers }
+    )
+  }
+
+  const unique = new Set<string>()
+
+  for (let offset = 0; ; offset += FETCH_BATCH_SIZE) {
+    let query = fromQualifiedTable(supabase, definition.table)
+      .select(column)
+      .order(column, { ascending: true })
+      .range(offset, offset + FETCH_BATCH_SIZE - 1)
+
+    for (const [filterColumn, filter] of Object.entries(parsedFilters)) {
+      if (filterColumn === column) continue
+      if (!selectableColumns.has(filterColumn)) continue
+      if (filter.includeEmpty && filter.values.length === 0) {
+        query = query.is(filterColumn, null)
+        continue
+      }
+      if (filter.values.length === 1) {
+        query = query.eq(filterColumn, filter.values[0])
+        continue
+      }
+      if (filter.values.length > 1) {
+        query = query.in(filterColumn, filter.values)
+      }
+    }
+
+    const { data, error } = await query
+    if (error) {
+      return Response.json({ status: 'error', allOptions: [], totalCount: 0, error: error.message }, { status: 500, headers })
+    }
+
+    const rows = (data ?? []) as unknown as Record<string, unknown>[]
+    for (const row of rows) {
+      unique.add(toOptionValue(row[column]))
+    }
+
+    if (rows.length < FETCH_BATCH_SIZE) {
+      break
+    }
+  }
+
+  const allOptions = sortFilterOptions(Array.from(unique))
+  return Response.json(
+    {
+      status: 'loaded',
+      allOptions,
+      totalCount: allOptions.length,
+    },
+    { headers }
+  )
+}


### PR DESCRIPTION
## What\n- add a dedicated  loader endpoint for async, full-dataset filter option loading\n- rewire table filter popovers to fetch option lists from that endpoint when server-side query mode is active\n- keep existing local async option computation for fallback/client-side modes\n- preserve raw query values for click-to-filter in server query mode so filters and server sorting stay consistent\n\n## Why\n- filter popovers regressed to showing values only from the current page after moving table data to server-side pagination\n- sorting/filtering should operate against the full query, not page-local values\n\n## Validation\n- npm run typecheck (web)