### PR TITLE
Align workshop enrollment with full-row filter behavior

### DIFF
--- a/web/app/lib/exports/workshop-enrollment-query.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-query.server.ts
@@ -26,8 +26,16 @@ const toTime = (value: unknown) => {
 export async function loadWorkshopEnrollmentData(request: Request) {
   const auth = await requireAuth(request)
   const canManageEnrollments = isRoleAtLeast(auth.claims.role, 'admin')
+
+  // Keep workshop enrollment on the full-row path so custom derived columns
+  // and filter options are computed from the full dataset, like class attendance.
+  const loaderUrl = new URL(request.url)
+  loaderUrl.searchParams.set('sort', '__full_scan__')
+  loaderUrl.searchParams.delete('dir')
+  const loaderRequest = new Request(loaderUrl.toString(), request)
+
   const base = await baseLoader(
-    { request } as LoaderFunctionArgs,
+    { request: loaderRequest } as LoaderFunctionArgs,
     { includeForeignKeyOptions: canManageEnrollments }
   )
 


### PR DESCRIPTION
## What\n- force  to use the full-row table loader path by issuing an internal unsupported sort key\n- keep workshop-enrollment derived column enrichment and filter option computation based on the complete dataset\n- avoid page-limited sort/filter behavior for workshop-enrollment rows\n\n## Why\n- workshop-enrollment was diverging from class-attendance behavior and showing page-scoped filter options\n- this route has custom derived columns and enrichment that require full-row context\n\n## Validation\n- npm run typecheck (web)