### PR TITLE
Restore default workshop enrollment sort priority

### DIFF
--- a/web/app/lib/exports/workshop-enrollment-query.server.ts
+++ b/web/app/lib/exports/workshop-enrollment-query.server.ts
@@ -8,12 +8,40 @@ import { createTableLoader } from '@/routes/manage/table-loader'
 
 const baseLoader = createTableLoader('class-enrollment')
 
+const ENROLLMENT_STATUS_ORDER: Record<string, number> = {
+  pending: 0,
+  waitlisted: 1,
+  revoked: 2,
+  approved: 3,
+  rejected: 4,
+}
+
+const toTime = (value: unknown) => {
+  if (typeof value !== 'string' || !value) return Number.POSITIVE_INFINITY
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed
+}
+
 export async function loadWorkshopEnrollmentData(request: Request) {
+  const url = new URL(request.url)
+  const hasExplicitSort = Boolean((url.searchParams.get('sort') ?? '').trim())
   const auth = await requireAuth(request)
   const canManageEnrollments = isRoleAtLeast(auth.claims.role, 'admin')
 
+  const loaderRequest = hasExplicitSort
+    ? request
+    : new Request(
+        (() => {
+          const next = new URL(request.url)
+          next.searchParams.set('sort', 'requested_at')
+          next.searchParams.set('dir', 'desc')
+          return next.toString()
+        })(),
+        request
+      )
+
   const base = await baseLoader(
-    { request } as LoaderFunctionArgs,
+    { request: loaderRequest } as LoaderFunctionArgs,
     { includeForeignKeyOptions: canManageEnrollments }
   )
 
@@ -140,6 +168,28 @@ export async function loadWorkshopEnrollmentData(request: Request) {
       _row_signal_summary: `Concern ${concernScore} (${concernBand}) · ${countLabel}: ${primarySignal.summary}`,
     }
   })
+
+  if (!hasExplicitSort) {
+    enrichedRows.sort((left, right) => {
+      const leftStatus = typeof left.status === 'string' ? left.status : ''
+      const rightStatus = typeof right.status === 'string' ? right.status : ''
+      const leftRank = ENROLLMENT_STATUS_ORDER[leftStatus] ?? Number.MAX_SAFE_INTEGER
+      const rightRank = ENROLLMENT_STATUS_ORDER[rightStatus] ?? Number.MAX_SAFE_INTEGER
+
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank
+      }
+
+      const timeDiff = toTime(right.requested_at) - toTime(left.requested_at)
+      if (timeDiff !== 0) {
+        return timeDiff
+      }
+
+      const leftId = typeof left.id === 'string' ? left.id : ''
+      const rightId = typeof right.id === 'string' ? right.id : ''
+      return leftId.localeCompare(rightId)
+    })
+  }
 
   let columns = base.columns.includes('enrolled_capacity')
     ? base.columns

--- a/web/app/routes/manage/table-filter-options.ts
+++ b/web/app/routes/manage/table-filter-options.ts
@@ -1,10 +1,17 @@
 import { createClient } from '@/lib/supabase/server'
 import { TABLE_DEFINITIONS } from './table-definitions'
 import { createTableLoader } from './table-loader'
+import { loadWorkshopEnrollmentEnrichment } from './workshop-enrollment-enrichment.server'
 import type { LoaderFunctionArgs } from 'react-router'
 
 const FETCH_BATCH_SIZE = 1000
 const FILTER_EMPTY_TOKEN = '__none__'
+const WORKSHOP_ENRICHMENT_COLUMNS = new Set([
+  'riding_display',
+  'geo_locations_display',
+  'giftcard_display',
+  'prior_participation_display',
+])
 
 type ParsedFilter = {
   values: string[]
@@ -49,19 +56,26 @@ const parseTopLevelSelectColumns = (select: string) => {
   return Array.from(new Set(columns))
 }
 
-const parseFiltersFromSearch = (columns: string[], searchParams: URLSearchParams): Record<string, ParsedFilter> => {
-  return columns.reduce<Record<string, ParsedFilter>>((acc, column) => {
-    const values = Array.from(new Set(searchParams.getAll(`f_${column}`)))
-    if (!values.length) return acc
+const parseFiltersFromSearch = (searchParams: URLSearchParams): Record<string, ParsedFilter> => {
+  const parsed: Record<string, ParsedFilter> = {}
+
+  for (const key of Array.from(new Set(Array.from(searchParams.keys())))) {
+    if (!key.startsWith('f_')) continue
+    const column = key.slice(2)
+    if (!column) continue
+
+    const values = Array.from(new Set(searchParams.getAll(key)))
+    if (!values.length) continue
 
     const includeEmpty = values.includes(FILTER_EMPTY_TOKEN)
     const explicitValues = values.filter(value => value !== FILTER_EMPTY_TOKEN)
-    acc[column] = {
+    parsed[column] = {
       values: explicitValues,
       includeEmpty,
     }
-    return acc
-  }, {})
+  }
+
+  return parsed
 }
 
 const fromQualifiedTable = (supabase: ReturnType<typeof createClient>['supabase'], qualifiedTable: string) => {
@@ -141,6 +155,37 @@ const loadAllRowsViaTableLoader = async (
   return payload.rows as Record<string, unknown>[]
 }
 
+const maybeEnrichWorkshopEnrollmentRows = async ({
+  tableName,
+  rows,
+  requiredColumns,
+}: {
+  tableName: string
+  rows: Record<string, unknown>[]
+  requiredColumns: Set<string>
+}) => {
+  if (tableName !== 'class-enrollment') return rows
+  const needsEnrichment = Array.from(requiredColumns).some(column => WORKSHOP_ENRICHMENT_COLUMNS.has(column))
+  if (!needsEnrichment) return rows
+
+  const profileIds = Array.from(
+    new Set(
+      rows
+        .map(row => (typeof row.profile_id === 'string' ? row.profile_id : ''))
+        .filter(Boolean)
+    )
+  )
+  if (!profileIds.length) return rows
+
+  const byProfileId = await loadWorkshopEnrollmentEnrichment(profileIds)
+  return rows.map(row => {
+    const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+    if (!profileId) return row
+    const enrichment = byProfileId[profileId]
+    return enrichment ? { ...row, ...enrichment } : row
+  })
+}
+
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url)
   const tableName = (url.searchParams.get('table') ?? '').trim()
@@ -155,13 +200,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return Response.json({ status: 'not_found', allOptions: [], totalCount: 0 }, { status: 404 })
   }
 
-  if (!definition.columns.includes(column)) {
+  const validBaseColumn = definition.columns.includes(column)
+  const validWorkshopDerivedColumn = tableName === 'class-enrollment' && WORKSHOP_ENRICHMENT_COLUMNS.has(column)
+
+  if (!validBaseColumn && !validWorkshopDerivedColumn) {
     return Response.json({ status: 'invalid_column', allOptions: [], totalCount: 0 }, { status: 400 })
   }
 
   const { supabase, headers } = createClient(request)
   const selectableColumns = new Set(parseTopLevelSelectColumns(definition.select))
-  const parsedFilters = parseFiltersFromSearch(definition.columns, url.searchParams)
+  const parsedFilters = parseFiltersFromSearch(url.searchParams)
 
   const hasUnsupportedFilter = Object.keys(parsedFilters).some(
     filterColumn => filterColumn !== column && !selectableColumns.has(filterColumn)
@@ -174,8 +222,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (hasUnsupportedFilter || hasMixedEmptyAndExplicit || !isSelectableColumn) {
     try {
       const rows = await loadAllRowsViaTableLoader(request, tableName)
+      const requiredColumns = new Set<string>([column, ...Object.keys(parsedFilters)])
+      const enrichedRows = await maybeEnrichWorkshopEnrollmentRows({
+        tableName,
+        rows,
+        requiredColumns,
+      })
       const options = sortFilterOptions(
-        rows
+        enrichedRows
           .filter(row => rowMatchesFilters(row, parsedFilters, column))
           .map(row => toOptionValue(row[column]))
       )


### PR DESCRIPTION
## What\n- restore workshop-enrollment default sort when no explicit URL sort is provided\n- default ordering now ranks status as: pending, waitlisted, revoked, approved, rejected\n- within each status bucket, rows are reverse chronological by \n- keep explicit user sort params intact (do not override / when present)\n\n## Why\n- bring back the intended default triage order while preserving fast paged route loading\n\n## Validation\n- npm run typecheck (web)