### PR TITLE
Revert heavy enrollment loader sort logic

### DIFF
--- a/web/app/routes/manage/table-loader.ts
+++ b/web/app/routes/manage/table-loader.ts
@@ -12,7 +12,6 @@ const FETCH_BATCH_SIZE = 1000
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 250, 500, 1000, 1500] as const
 const DEFAULT_PAGE_SIZE = 50
 const FILTER_EMPTY_TOKEN = '__none__'
-const CLASS_ENROLLMENT_STATUS_PRIORITY = ['pending', 'waitlisted', 'revoked', 'approved', 'rejected'] as const
 
 type ParsedFilter = {
   values: string[]
@@ -125,36 +124,6 @@ const fetchAllRowsInBatches = async ({
   }
 
   return rows
-}
-
-const applyParsedFilters = ({
-  query,
-  parsedFilters,
-  selectableColumns,
-  excludedColumns,
-}: {
-  query: any
-  parsedFilters: Record<string, ParsedFilter>
-  selectableColumns: Set<string>
-  excludedColumns?: Set<string>
-}) => {
-  let nextQuery = query
-  for (const [column, filter] of Object.entries(parsedFilters)) {
-    if (excludedColumns?.has(column)) continue
-    if (!selectableColumns.has(column)) continue
-    if (filter.includeEmpty && filter.values.length === 0) {
-      nextQuery = nextQuery.is(column, null)
-      continue
-    }
-    if (filter.values.length === 1) {
-      nextQuery = nextQuery.eq(column, filter.values[0])
-      continue
-    }
-    if (filter.values.length > 1) {
-      nextQuery = nextQuery.in(column, filter.values)
-    }
-  }
-  return nextQuery
 }
 
 const fromQualifiedTable = (supabase: ReturnType<typeof createClient>['supabase'], qualifiedTable: string) => {
@@ -643,143 +612,43 @@ export function createTableLoader(tableName: string) {
     let totalRows = 0
 
     if (useServerSideQuery) {
-      const canUseClassEnrollmentPriorityDefault =
-        tableName === 'class-enrollment' &&
-        !requestedSortColumn &&
-        (!parsedFilters.status || !parsedFilters.status.includeEmpty)
+      let query = fromQualifiedTable(supabase, definition.table)
+        .select(definition.select, { count: 'exact' })
 
-      if (canUseClassEnrollmentPriorityDefault) {
-        const statusFilter = parsedFilters.status
-        const allowedStatuses = statusFilter?.values.length
-          ? CLASS_ENROLLMENT_STATUS_PRIORITY.filter(status => statusFilter.values.includes(status))
-          : [...CLASS_ENROLLMENT_STATUS_PRIORITY]
-
-        const excludedStatus = new Set<string>(['status'])
-        let remainingOffset = (page - 1) * pageSize
-        let remainingLimit = pageSize
-        const orderedRows: Record<string, unknown>[] = []
-
-        const totalCountQueryBase = fromQualifiedTable(supabase, definition.table).select('id', { count: 'planned', head: true })
-        const totalCountQuery = applyParsedFilters({
-          query: totalCountQueryBase,
-          parsedFilters,
-          selectableColumns,
-        })
-        const { count: totalCount, error: totalCountError } = await totalCountQuery
-        if (totalCountError) {
-          console.error('[table-loader] class-enrollment total count failed', {
-            tableName,
-            error: totalCountError.message,
-          })
-          totalRows = 0
-        } else {
-          totalRows = totalCount ?? 0
+      for (const [column, filter] of Object.entries(parsedFilters)) {
+        if (!selectableColumns.has(column)) continue
+        if (filter.includeEmpty && filter.values.length === 0) {
+          query = query.is(column, null)
+          continue
         }
-
-        for (const status of allowedStatuses) {
-          let statusCursor = 0
-
-          while (remainingOffset > 0) {
-            const consumeSize = Math.min(remainingOffset, FETCH_BATCH_SIZE)
-            const consumeQueryBase = fromQualifiedTable(supabase, definition.table).select('id')
-            const consumeQuery = applyParsedFilters({
-              query: consumeQueryBase,
-              parsedFilters,
-              selectableColumns,
-              excludedColumns: excludedStatus,
-            })
-              .eq('status', status)
-              .order('requested_at', { ascending: false })
-              .range(statusCursor, statusCursor + consumeSize - 1)
-
-            const { data: consumeRows, error: consumeError } = await consumeQuery
-            if (consumeError) {
-              throw new Response(consumeError.message, { status: 500 })
-            }
-
-            const consumed = ((consumeRows ?? []) as unknown as Record<string, unknown>[]).length
-            if (consumed === 0) {
-              break
-            }
-
-            remainingOffset -= consumed
-            statusCursor += consumed
-            if (consumed < consumeSize) {
-              break
-            }
-          }
-
-          if (remainingLimit <= 0) continue
-          if (remainingOffset > 0) {
-            continue
-          }
-
-          while (remainingLimit > 0) {
-            const fetchSize = Math.min(remainingLimit, FETCH_BATCH_SIZE)
-            const rowQueryBase = fromQualifiedTable(supabase, definition.table).select(definition.select)
-            const rowQuery = applyParsedFilters({
-              query: rowQueryBase,
-              parsedFilters,
-              selectableColumns,
-              excludedColumns: excludedStatus,
-            })
-              .eq('status', status)
-              .order('requested_at', { ascending: false })
-              .range(statusCursor, statusCursor + fetchSize - 1)
-
-            const { data: statusRows, error: rowError } = await rowQuery
-            if (rowError) {
-              throw new Response(rowError.message, { status: 500 })
-            }
-
-            const chunk = (statusRows ?? []) as unknown as Record<string, unknown>[]
-            if (!chunk.length) {
-              break
-            }
-
-            orderedRows.push(...chunk)
-            remainingLimit -= chunk.length
-            statusCursor += chunk.length
-            if (chunk.length < fetchSize) {
-              break
-            }
-          }
+        if (filter.values.length === 1) {
+          query = query.eq(column, filter.values[0])
+          continue
         }
-
-        rows = orderedRows
-        if (totalRows <= 0) {
-          const inferredTotal = (page - 1) * pageSize + orderedRows.length
-          totalRows = inferredTotal + (orderedRows.length === pageSize ? 1 : 0)
+        if (filter.values.length > 1) {
+          query = query.in(column, filter.values)
         }
-      } else {
-        const queryBase = fromQualifiedTable(supabase, definition.table)
-          .select(definition.select, { count: 'exact' })
-        const queryWithFilters = applyParsedFilters({
-          query: queryBase,
-          parsedFilters,
-          selectableColumns,
-        })
-
-        const orderColumn =
-          requestedSortColumn && selectableColumns.has(requestedSortColumn)
-            ? requestedSortColumn
-            : definition.order
-        const ascending = requestedSortColumn
-          ? requestedSortAscending
-          : orderAscending
-
-        const from = (page - 1) * pageSize
-        const to = from + pageSize - 1
-
-        const { data, error, count } = await queryWithFilters.order(orderColumn, { ascending }).range(from, to)
-
-        if (error) {
-          throw new Response(error.message, { status: 500 })
-        }
-
-        rows = (data ?? []) as unknown as Record<string, unknown>[]
-        totalRows = count ?? rows.length
       }
+
+      const orderColumn =
+        requestedSortColumn && selectableColumns.has(requestedSortColumn)
+          ? requestedSortColumn
+          : definition.order
+      const ascending = requestedSortColumn
+        ? requestedSortAscending
+        : orderAscending
+
+      const from = (page - 1) * pageSize
+      const to = from + pageSize - 1
+
+      const { data, error, count } = await query.order(orderColumn, { ascending }).range(from, to)
+
+      if (error) {
+        throw new Response(error.message, { status: 500 })
+      }
+
+      rows = (data ?? []) as unknown as Record<string, unknown>[]
+      totalRows = count ?? rows.length
     } else {
       rows = await fetchAllRowsInBatches({
         supabase,


### PR DESCRIPTION
## What\n- remove the class-enrollment grouped default sorting branch from \n- restore standard server-side filtered/sorted paged query path\n- remove the extra per-status query fanout that caused statement timeout risk\n\n## Why\n-  was returning 500 in production after recent sorting changes\n- reverting to the simpler loader query path avoids timeout-driven failures\n\n## Validation\n- npm run typecheck (web)