### PR TITLE
Adjust sticky manage bar and gift card column order

### DIFF
--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -1083,8 +1083,8 @@ export default function Home() {
                                   <TableHead>Starts</TableHead>
                                   <TableHead>Ends</TableHead>
                                   <TableHead>Join</TableHead>
-                                  <TableHead>Gift card</TableHead>
                                   <TableHead>Photos</TableHead>
+                                  <TableHead>Gift card</TableHead>
                                 </TableRow>
                               </TableHeader>
                               <TableBody>
@@ -1093,7 +1093,6 @@ export default function Home() {
                                     <TableCell>{formatDateTime(classRow.starts_at)}</TableCell>
                                     <TableCell>{formatDateTime(classRow.ends_at)}</TableCell>
                                     <TableCell>{renderJoinControl({ enrollmentStatus: enrollment.status, classRow })}</TableCell>
-                                    <TableCell>{renderGiftCardControl({ enrollmentStatus: enrollment.status, classRow })}</TableCell>
                                     <TableCell>
                                       {renderPhotoControl({
                                         enrollmentStatus: enrollment.status,
@@ -1101,6 +1100,7 @@ export default function Home() {
                                         workshopLabel: workshop?.description ?? 'Workshop',
                                       })}
                                     </TableCell>
+                                    <TableCell>{renderGiftCardControl({ enrollmentStatus: enrollment.status, classRow })}</TableCell>
                                   </TableRow>
                                 ))}
                               </TableBody>
@@ -1123,10 +1123,6 @@ export default function Home() {
                                   {renderJoinControl({ enrollmentStatus: enrollment.status, classRow })}
                                 </div>
                                 <div className="space-y-2">
-                                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Gift card</p>
-                                  {renderGiftCardControl({ enrollmentStatus: enrollment.status, classRow })}
-                                </div>
-                                <div className="space-y-2">
                                   <p className="text-xs uppercase tracking-wide text-muted-foreground">Photos</p>
                                   {renderPhotoControl({
                                     enrollmentStatus: enrollment.status,
@@ -1134,6 +1130,10 @@ export default function Home() {
                                     workshopLabel: workshop?.description ?? 'Workshop',
                                     mobile: true,
                                   })}
+                                </div>
+                                <div className="space-y-2">
+                                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Gift card</p>
+                                  {renderGiftCardControl({ enrollmentStatus: enrollment.status, classRow })}
                                 </div>
                               </article>
                             ))}

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -731,6 +731,7 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     editorConfig,
     foreignKeyOptions = {},
   } = source ?? ({} as LoaderData)
+  const hasStickyTopBar = tableName === 'class-enrollment' || tableName === 'class-attendance'
   const location = useLocation()
 
   const statusFetcher = useFetcher()
@@ -2443,7 +2444,13 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
 
       {editorFetcher.data?.error ? <p className="px-6 text-sm text-destructive">{editorFetcher.data.error}</p> : null}
 
-      <div className="flex flex-wrap items-center justify-between gap-3 px-6">
+      <div
+        className={`flex flex-wrap items-center justify-between gap-3 px-6 ${
+          hasStickyTopBar
+            ? 'sticky top-16 z-20 border-y bg-background/95 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/80'
+            : ''
+        }`}
+      >
         <p className="text-xs text-muted-foreground">
           Page {effectivePage} of {totalPages}
         </p>


### PR DESCRIPTION
## What
- make the top pagination/action bar sticky for manage workshop enrollment and class attendance tables
- keep sticky behavior scoped to class-enrollment and class-attendance only
- move the gift card column to render after photos on home table

## Validation
- npm run typecheck (currently fails due to existing unrelated generated route type/import issues in manage table-data files)