### PR TITLE
Fix gift card upload button navigation

### DIFF
--- a/web/app/routes/manage/gift-cards.tsx
+++ b/web/app/routes/manage/gift-cards.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from 'react-router'
+import { useLoaderData } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
@@ -74,7 +74,7 @@ export default function GiftCardsPage() {
           <p className="text-sm text-muted-foreground">Inventory of uploaded gift cards and current lifecycle status.</p>
         </div>
         <Button asChild>
-          <Link to="/manage/gift-cards/upload">Upload gift cards</Link>
+          <a href="/manage/gift-cards/upload">Upload gift cards</a>
         </Button>
       </header>
 

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -16,6 +16,8 @@ const STAFF_ALLOWED_MANAGE_PATHS = new Set([
   '/manage/class',
   '/manage/workshop',
   '/manage/workshop/setup',
+  '/manage/gift-cards',
+  '/manage/gift-cards/upload',
 ])
 
 export async function loader({ request }: Route.LoaderArgs) {


### PR DESCRIPTION
## What changed
- update the manage gift-cards page upload CTA to use a direct anchor href () for reliable local navigation
- allow staff access to  and  in manage route guard

## Why
- the upload button appeared non-responsive locally

## Notes
- this branch currently includes prior gift-card timing/upload hardening commit(s) that are part of the same branch history.
