### PR TITLE
Fix gift card upload flow and post-upload redirect

### DIFF
--- a/web/app/routes/manage/gift-cards.upload.tsx
+++ b/web/app/routes/manage/gift-cards.upload.tsx
@@ -1,12 +1,10 @@
-import { useMemo, useState, type ChangeEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import { Link, useFetcher } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { requireAuth } from '@/lib/auth.server'
-import { type GiftCardCsvColumnMapping } from '@/lib/gift-cards/parse-csv'
-import { processGiftCardUpload } from '@/lib/gift-cards/process-upload.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
 
@@ -14,6 +12,14 @@ import type { Database } from '@/lib/database.types'
 import type { Route } from './+types/gift-cards.upload'
 
 type ExpectedColumnKey = 'url' | 'account_number' | 'pin' | 'value' | 'provider'
+
+type GiftCardCsvColumnMapping = {
+  url: string
+  account_number: string
+  pin: string
+  value: string
+  provider: string
+}
 
 const expectedColumns: Array<{ key: ExpectedColumnKey; label: string; required: boolean }> = [
   { key: 'url', label: 'URL column', required: true },
@@ -108,6 +114,7 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   const { supabase, headers } = createClient(request)
+  const { processGiftCardUpload } = await import('@/lib/gift-cards/process-upload.server')
   const { data: uploadRow, error: uploadError } = await supabase
     .from('gift_card_upload')
     .insert({
@@ -162,7 +169,12 @@ export default function GiftCardsUploadPage() {
   const error = fetcher.data?.error
   const success = Boolean((fetcher.data as { success?: boolean } | undefined)?.success)
   const loading = fetcher.state === 'submitting'
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const uploadProgressTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [csvHeaders, setCsvHeaders] = useState<string[]>([])
+  const [preparingHeaders, setPreparingHeaders] = useState(false)
+  const [prepareProgress, setPrepareProgress] = useState(0)
+  const [uploadProgress, setUploadProgress] = useState(0)
   const [mappingByColumn, setMappingByColumn] = useState<Record<ExpectedColumnKey, string>>({
     url: '',
     account_number: '',
@@ -173,14 +185,55 @@ export default function GiftCardsUploadPage() {
 
   const mappingOptions = useMemo(() => csvHeaders, [csvHeaders])
 
-  const onFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) {
-      setCsvHeaders([])
+  useEffect(() => {
+    if (loading) {
+      if (!uploadProgressTimerRef.current) {
+        uploadProgressTimerRef.current = setInterval(() => {
+          setUploadProgress(prev => (prev >= 90 ? prev : prev + 6))
+        }, 120)
+      }
+      setUploadProgress(prev => (prev >= 10 ? prev : 10))
       return
     }
 
+    if (uploadProgressTimerRef.current) {
+      clearInterval(uploadProgressTimerRef.current)
+      uploadProgressTimerRef.current = null
+    }
+
+    if (uploadProgress > 0) {
+      setUploadProgress(100)
+      const timeout = setTimeout(() => setUploadProgress(0), 350)
+      return () => clearTimeout(timeout)
+    }
+  }, [loading, uploadProgress])
+
+  useEffect(
+    () => () => {
+      if (uploadProgressTimerRef.current) clearInterval(uploadProgressTimerRef.current)
+    },
+    []
+  )
+
+  const loadHeadersFromFile = async (file: File | null | undefined) => {
+    if (!file) {
+      setCsvHeaders([])
+      setMappingByColumn({
+        url: '',
+        account_number: '',
+        pin: '',
+        value: '',
+        provider: '',
+      })
+      setPreparingHeaders(false)
+      setPrepareProgress(0)
+      return
+    }
+
+    setPreparingHeaders(true)
+    setPrepareProgress(15)
     const text = await file.text()
+    setPrepareProgress(65)
     const firstLine = text.split(/\r?\n/).find(line => line.trim()) ?? ''
     const headers = parseCsvHeaderLine(firstLine)
     setCsvHeaders(headers)
@@ -192,6 +245,16 @@ export default function GiftCardsUploadPage() {
       value: autoMatchHeader(headers, 'value'),
       provider: autoMatchHeader(headers, 'provider'),
     })
+    setPrepareProgress(100)
+    setTimeout(() => {
+      setPreparingHeaders(false)
+      setPrepareProgress(0)
+    }, 200)
+  }
+
+  const onFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    await loadHeadersFromFile(file)
   }
 
   return (
@@ -205,67 +268,102 @@ export default function GiftCardsUploadPage() {
       </header>
 
       <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <fetcher.Form method="post" className="grid gap-4" encType="multipart/form-data">
+        <fetcher.Form
+          method="post"
+          className="grid gap-4"
+          encType="multipart/form-data"
+          onSubmit={() => setUploadProgress(prev => (prev >= 10 ? prev : 10))}
+        >
           <div className="grid gap-2">
             <Label htmlFor="file">File</Label>
-            <Input id="file" name="file" type="file" accept=".csv,text/csv" required onChange={onFileChange} />
+            <Input ref={fileInputRef} id="file" name="file" type="file" accept=".csv,text/csv" required onChange={onFileChange} />
           </div>
 
-          <div className="grid gap-2">
-            <Label htmlFor="default_provider">Default provider (optional)</Label>
-            <select
-              id="default_provider"
-              name="default_provider"
-              className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-              defaultValue=""
-            >
-              <option value="">Use mapped provider column</option>
-              <option value="PC">PC</option>
-              <option value="Sobeys">Sobeys</option>
-            </select>
-          </div>
-
-          <div className="grid gap-3 rounded-md border p-3">
-            <p className="text-xs text-muted-foreground">
-              {mappingOptions.length
-                ? 'Map your CSV headers to expected columns.'
-                : 'Choose a CSV file first to load header options.'}
-            </p>
-            {expectedColumns.map(column => (
-              <div key={column.key} className="grid gap-2">
-                <Label htmlFor={`map_${column.key}`}>
-                  {column.label}
-                  {column.required ? ' *' : ''}
-                </Label>
+          {mappingOptions.length ? (
+            <>
+              <div className="grid gap-2">
+                <Label htmlFor="default_provider">Default provider (optional)</Label>
                 <select
-                  id={`map_${column.key}`}
-                  name={`map_${column.key}`}
+                  id="default_provider"
+                  name="default_provider"
                   className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-                  value={mappingByColumn[column.key]}
-                  onChange={event =>
-                    setMappingByColumn(prev => ({
-                      ...prev,
-                      [column.key]: event.target.value,
-                    }))
-                  }
-                  required={column.required}
+                  defaultValue=""
                 >
-                  <option value="">{column.required ? 'Select CSV column' : 'Optional'}</option>
-                  {mappingOptions.map(header => (
-                    <option key={`${column.key}-${header}`} value={header}>
-                      {header}
-                    </option>
-                  ))}
+                  <option value="">Use mapped provider column</option>
+                  <option value="PC">PC</option>
+                  <option value="Sobeys">Sobeys</option>
                 </select>
               </div>
-            ))}
-          </div>
+
+              <div className="grid gap-3 rounded-md border p-3">
+                <p className="text-xs text-muted-foreground">Map your CSV headers to expected columns.</p>
+                {expectedColumns.map(column => (
+                  <div key={column.key} className="grid gap-2">
+                    <Label htmlFor={`map_${column.key}`}>
+                      {column.label}
+                      {column.required ? ' *' : ''}
+                    </Label>
+                    <select
+                      id={`map_${column.key}`}
+                      name={`map_${column.key}`}
+                      className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      value={mappingByColumn[column.key]}
+                      onChange={event =>
+                        setMappingByColumn(prev => ({
+                          ...prev,
+                          [column.key]: event.target.value,
+                        }))
+                      }
+                      required={column.required}
+                    >
+                      <option value="">{column.required ? 'Select CSV column' : 'Optional'}</option>
+                      {mappingOptions.map(header => (
+                        <option key={`${column.key}-${header}`} value={header}>
+                          {header}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="rounded-md border p-3 text-xs text-muted-foreground">
+              Upload a CSV first to load header mappings.
+            </div>
+          )}
 
           {error && <p className="text-sm text-red-500">{error}</p>}
           {success && <p className="text-sm text-emerald-600">Upload complete.</p>}
 
-          <Button type="submit" disabled={loading}>
-            {loading ? 'Uploading...' : 'Upload batch'}
+          {(preparingHeaders || loading || uploadProgress > 0) && (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>{preparingHeaders ? 'Reading CSV headers...' : 'Uploading batch...'}</span>
+                <span>{preparingHeaders ? prepareProgress : uploadProgress}%</span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded bg-muted/40">
+                <div
+                  className="h-full bg-primary transition-[width] duration-200"
+                  style={{ width: `${preparingHeaders ? prepareProgress : uploadProgress}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          <Button
+            type={mappingOptions.length ? 'submit' : 'button'}
+            disabled={loading}
+            className="cursor-pointer"
+            onClick={
+              mappingOptions.length
+                ? undefined
+                : async () => {
+                  await loadHeadersFromFile(fileInputRef.current?.files?.[0] ?? null)
+                }
+            }
+          >
+            {mappingOptions.length ? (loading ? 'Uploading...' : 'Upload batch') : preparingHeaders ? 'Loading headers...' : 'Upload CSV'}
           </Button>
         </fetcher.Form>
       </div>

--- a/web/app/routes/manage/gift-cards.upload.tsx
+++ b/web/app/routes/manage/gift-cards.upload.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
-import { Link, useFetcher } from 'react-router'
+import { Link, redirect, useFetcher } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -159,9 +159,7 @@ export async function action({ request }: Route.ActionArgs) {
     return { error: result.errorMessage }
   }
 
-  return new Response(JSON.stringify({ success: true }), {
-    headers: { ...headers, 'Content-Type': 'application/json' },
-  })
+  return redirect('/manage/gift-cards', { headers })
 }
 
 export default function GiftCardsUploadPage() {


### PR DESCRIPTION
## What changed
- prevent client-side Buffer crash on gift card upload page by keeping server CSV processing import in the action path
- improve upload flow responsiveness on the upload page
- redirect to /manage/gift-cards after a successful upload

## Why
- upload button appeared to do nothing due to client crash and unclear flow
- admins should return to assets list after successful upload
