### PR TITLE
Separate gift card release visibility from reminders

### DIFF
--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -28,10 +28,18 @@ const torontoDateTimeFormatter = new Intl.DateTimeFormat('en-CA', {
   hourCycle: 'h23',
 })
 
-const RELEASE_HOUR_TORONTO = 11
-const RELEASE_MINUTE_TORONTO = 45
-const REMINDER_HOUR_TORONTO = 12
-const REMINDER_MINUTE_TORONTO = 0
+const parseHourMinuteEnv = (name: string, fallback: number) => {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const isProductionRuntime = process.env.NODE_ENV === 'production'
+const RELEASE_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_HOUR_TORONTO', 11)
+const RELEASE_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_MINUTE_TORONTO', isProductionRuntime ? 45 : 0)
+const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
+const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
 
 const torontoPartsForDate = (date: Date) => {
   const parts = torontoDateTimeFormatter.formatToParts(date)
@@ -94,8 +102,8 @@ const currentTorontoReminderSlotIso = (now: Date) => {
   return slot ? slot.toISOString() : null
 }
 
-const releaseSlotIsoForTorontoDate = (year: number, month: number, day: number) => {
-  const slot = torontoTimeUtcForDate(year, month, day, RELEASE_HOUR_TORONTO, RELEASE_MINUTE_TORONTO)
+const reminderSlotIsoForTorontoDate = (year: number, month: number, day: number) => {
+  const slot = torontoTimeUtcForDate(year, month, day, REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)
   return slot ? slot.toISOString() : null
 }
 
@@ -390,7 +398,7 @@ const sendDueReminders = async (appOrigin: string) => {
     }
 
     const releaseToronto = torontoPartsForDate(releaseDate)
-    const reminderSlotForReleaseDate = releaseSlotIsoForTorontoDate(
+    const reminderSlotForReleaseDate = reminderSlotIsoForTorontoDate(
       releaseToronto.year,
       releaseToronto.month,
       releaseToronto.day

--- a/web/app/routes/glr.$token.ts
+++ b/web/app/routes/glr.$token.ts
@@ -25,7 +25,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const tokenHash = hashGlrToken(token)
   const { data: allocationByHash, error: allocationError } = await adminClient
     .from('gift_card_allocation')
-    .select('id, profile_id, blocked, status, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
+    .select('id, profile_id, blocked, status, metadata, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
     .eq('glr_token_hash', tokenHash)
     .maybeSingle()
 
@@ -42,13 +42,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (!allocation && isUuidToken) {
     const { data: allocationById } = await adminClient
       .from('gift_card_allocation')
-      .select('id, profile_id, blocked, status, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
+      .select('id, profile_id, blocked, status, metadata, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
       .eq('id', token)
       .maybeSingle()
     allocation = allocationById
   }
 
-  if (!allocation || allocation.blocked || allocation.status === 'allocated') {
+  const releaseAt = (allocation?.metadata?.release_at ?? '').trim()
+  const releaseAtMs = Date.parse(releaseAt)
+  const released = Number.isFinite(releaseAtMs) && releaseAtMs <= Date.now()
+
+  if (!allocation || allocation.blocked || (allocation.status === 'allocated' && !released)) {
     return invalidLink({ request })
   }
 

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -350,7 +350,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { data: allocationRowsRaw } = classIds.length
     ? await adminClient
         .from('gift_card_allocation')
-        .select('id, class_id, profile_id, status, blocked, reminder_sent_at')
+        .select('id, class_id, profile_id, status, blocked, reminder_sent_at, metadata')
         .in('class_id', classIds)
         .in('profile_id', family.familyProfileIds)
     : { data: [] }
@@ -362,10 +362,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     status: 'allocated' | 'sent' | 'opened'
     blocked: boolean
     reminder_sent_at: string | null
+    metadata: { release_at?: string | null } | null
   }>).reduce<Record<string, string>>((acc, row) => {
     if (row.blocked) return acc
-    if (!row.reminder_sent_at) return acc
-    if (row.status !== 'sent' && row.status !== 'opened') return acc
+    const releaseAt = (row.metadata?.release_at ?? '').trim()
+    const releaseAtMs = Date.parse(releaseAt)
+    const released = Number.isFinite(releaseAtMs) && releaseAtMs <= Date.now()
+    const availableByReminder = Boolean(row.reminder_sent_at && (row.status === 'sent' || row.status === 'opened'))
+    if (!released && !availableByReminder) return acc
     const selectedProfileId = selectedProfileIdByClass[row.class_id]
     if (!selectedProfileId || selectedProfileId !== row.profile_id) return acc
     acc[row.class_id] = `/glr/${row.id}`


### PR DESCRIPTION
## What changed
- decouple family gift-card availability from reminder delivery by using allocation metadata.release_at on home page
- allow GLR links in allocated state once release_at has passed
- keep reminders in a separate slot-gated step and align reminder-slot mapping to reminder time

## Timing behavior
- production defaults remain release 11:45 and reminder 12:00 (America/Toronto)
- local defaults remain release 11:00 and reminder 11:15 (America/Toronto)
