### PR TITLE
Sync gift card release visibility and admin timing display

### DIFF
--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -28,10 +28,18 @@ const torontoDateTimeFormatter = new Intl.DateTimeFormat('en-CA', {
   hourCycle: 'h23',
 })
 
-const RELEASE_HOUR_TORONTO = 11
-const RELEASE_MINUTE_TORONTO = 45
-const REMINDER_HOUR_TORONTO = 12
-const REMINDER_MINUTE_TORONTO = 0
+const parseHourMinuteEnv = (name: string, fallback: number) => {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const isProductionRuntime = process.env.NODE_ENV === 'production'
+const RELEASE_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_HOUR_TORONTO', 11)
+const RELEASE_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_MINUTE_TORONTO', isProductionRuntime ? 45 : 0)
+const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
+const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
 
 const torontoPartsForDate = (date: Date) => {
   const parts = torontoDateTimeFormatter.formatToParts(date)
@@ -94,8 +102,8 @@ const currentTorontoReminderSlotIso = (now: Date) => {
   return slot ? slot.toISOString() : null
 }
 
-const releaseSlotIsoForTorontoDate = (year: number, month: number, day: number) => {
-  const slot = torontoTimeUtcForDate(year, month, day, RELEASE_HOUR_TORONTO, RELEASE_MINUTE_TORONTO)
+const reminderSlotIsoForTorontoDate = (year: number, month: number, day: number) => {
+  const slot = torontoTimeUtcForDate(year, month, day, REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)
   return slot ? slot.toISOString() : null
 }
 
@@ -390,7 +398,7 @@ const sendDueReminders = async (appOrigin: string) => {
     }
 
     const releaseToronto = torontoPartsForDate(releaseDate)
-    const reminderSlotForReleaseDate = releaseSlotIsoForTorontoDate(
+    const reminderSlotForReleaseDate = reminderSlotIsoForTorontoDate(
       releaseToronto.year,
       releaseToronto.month,
       releaseToronto.day

--- a/web/app/routes/glr.$token.ts
+++ b/web/app/routes/glr.$token.ts
@@ -25,7 +25,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const tokenHash = hashGlrToken(token)
   const { data: allocationByHash, error: allocationError } = await adminClient
     .from('gift_card_allocation')
-    .select('id, profile_id, blocked, status, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
+    .select('id, profile_id, blocked, status, metadata, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
     .eq('glr_token_hash', tokenHash)
     .maybeSingle()
 
@@ -42,13 +42,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (!allocation && isUuidToken) {
     const { data: allocationById } = await adminClient
       .from('gift_card_allocation')
-      .select('id, profile_id, blocked, status, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
+      .select('id, profile_id, blocked, status, metadata, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
       .eq('id', token)
       .maybeSingle()
     allocation = allocationById
   }
 
-  if (!allocation || allocation.blocked || allocation.status === 'allocated') {
+  const releaseAt = (allocation?.metadata?.release_at ?? '').trim()
+  const releaseAtMs = Date.parse(releaseAt)
+  const released = Number.isFinite(releaseAtMs) && releaseAtMs <= Date.now()
+
+  if (!allocation || allocation.blocked || (allocation.status === 'allocated' && !released)) {
     return invalidLink({ request })
   }
 

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -350,7 +350,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { data: allocationRowsRaw } = classIds.length
     ? await adminClient
         .from('gift_card_allocation')
-        .select('id, class_id, profile_id, status, blocked, reminder_sent_at')
+        .select('id, class_id, profile_id, status, blocked, reminder_sent_at, metadata')
         .in('class_id', classIds)
         .in('profile_id', family.familyProfileIds)
     : { data: [] }
@@ -362,10 +362,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     status: 'allocated' | 'sent' | 'opened'
     blocked: boolean
     reminder_sent_at: string | null
+    metadata: { release_at?: string | null } | null
   }>).reduce<Record<string, string>>((acc, row) => {
     if (row.blocked) return acc
-    if (!row.reminder_sent_at) return acc
-    if (row.status !== 'sent' && row.status !== 'opened') return acc
+    const releaseAt = (row.metadata?.release_at ?? '').trim()
+    const releaseAtMs = Date.parse(releaseAt)
+    const released = Number.isFinite(releaseAtMs) && releaseAtMs <= Date.now()
+    const availableByReminder = Boolean(row.reminder_sent_at && (row.status === 'sent' || row.status === 'opened'))
+    if (!released && !availableByReminder) return acc
     const selectedProfileId = selectedProfileIdByClass[row.class_id]
     if (!selectedProfileId || selectedProfileId !== row.profile_id) return acc
     acc[row.class_id] = `/glr/${row.id}`

--- a/web/app/routes/manage/gift-cards.tsx
+++ b/web/app/routes/manage/gift-cards.tsx
@@ -1,9 +1,10 @@
-import { useLoaderData } from 'react-router'
+import { Link } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
+import TableDisplay from './table-display'
 
 import type { Route } from './+types/gift-cards'
 
@@ -33,15 +34,6 @@ const mask = (value: string, visibleDigits = 4) => {
   return `${'•'.repeat(Math.max(0, trimmed.length - visibleDigits))}${trimmed.slice(-visibleDigits)}`
 }
 
-const formatDateTime = (value: string) =>
-  new Intl.DateTimeFormat(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  }).format(new Date(value))
-
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!isRoleAtLeast(auth.claims.role, 'staff')) {
@@ -58,72 +50,45 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw new Response(error.message, { status: 500 })
   }
 
+  const rows = ((assets ?? []) as GiftCardAssetRow[]).map(asset => ({
+    provider: asset.provider,
+    account_number: mask(asset.account_number),
+    pin: mask(asset.pin),
+    value: formatMoney(asset.value),
+    status: asset.status,
+    asset_url: asset.asset_url,
+    assigned_profile_id: asset.assigned_profile_id ? asset.assigned_profile_id.slice(0, 8) : '',
+    upload_id: asset.upload_id.slice(0, 8),
+    created_at: asset.created_at,
+  }))
+
   return {
-    assets: (assets ?? []) as GiftCardAssetRow[],
+    label: 'Gift card assets',
+    tableName: 'gift-cards',
+    columns: ['provider', 'account_number', 'pin', 'value', 'status', 'asset_url', 'assigned_profile_id', 'upload_id', 'created_at'],
+    rows,
+    columnMeta: {
+      provider: { label: 'Provider' },
+      account_number: { label: 'Account' },
+      pin: { label: 'PIN' },
+      value: { label: 'Value' },
+      status: { label: 'Status' },
+      asset_url: { label: 'Link' },
+      assigned_profile_id: { label: 'Assigned profile' },
+      upload_id: { label: 'Upload ID' },
+      created_at: { label: 'Created' },
+    },
   }
 }
 
 export default function GiftCardsPage() {
-  const { assets } = useLoaderData<typeof loader>()
-
   return (
-    <div className="space-y-6">
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-semibold">Gift card assets</h1>
-          <p className="text-sm text-muted-foreground">Inventory of uploaded gift cards and current lifecycle status.</p>
-        </div>
+    <TableDisplay
+      headerActions={
         <Button asChild>
-          <a href="/manage/gift-cards/upload">Upload gift cards</a>
+          <Link to="/manage/gift-cards/upload">Upload gift cards</Link>
         </Button>
-      </header>
-
-      <div className="rounded-lg border bg-card">
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
-              <tr>
-                <th className="px-6 py-3 text-left">Provider</th>
-                <th className="px-6 py-3 text-left">Account</th>
-                <th className="px-6 py-3 text-left">PIN</th>
-                <th className="px-6 py-3 text-left">Value</th>
-                <th className="px-6 py-3 text-left">Status</th>
-                <th className="px-6 py-3 text-left">Link</th>
-                <th className="px-6 py-3 text-left">Assigned profile</th>
-                <th className="px-6 py-3 text-left">Upload ID</th>
-                <th className="px-6 py-3 text-left">Created</th>
-              </tr>
-            </thead>
-            <tbody>
-              {assets.length === 0 ? (
-                <tr>
-                  <td colSpan={9} className="px-6 py-6 text-center text-sm text-muted-foreground">
-                    No gift card assets yet.
-                  </td>
-                </tr>
-              ) : (
-                assets.map(asset => (
-                  <tr key={asset.id} className="border-b last:border-b-0">
-                    <td className="px-6 py-3">{asset.provider}</td>
-                    <td className="px-6 py-3 font-mono">{mask(asset.account_number)}</td>
-                    <td className="px-6 py-3 font-mono">{mask(asset.pin)}</td>
-                    <td className="px-6 py-3">{formatMoney(asset.value)}</td>
-                    <td className="px-6 py-3 capitalize">{asset.status}</td>
-                    <td className="px-6 py-3">
-                      <a href={asset.asset_url} target="_blank" rel="noreferrer" className="underline decoration-dotted underline-offset-2 hover:text-primary">
-                        Open
-                      </a>
-                    </td>
-                    <td className="px-6 py-3 font-mono">{asset.assigned_profile_id ? asset.assigned_profile_id.slice(0, 8) : '—'}</td>
-                    <td className="px-6 py-3 font-mono">{asset.upload_id.slice(0, 8)}</td>
-                    <td className="px-6 py-3">{formatDateTime(asset.created_at)}</td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
+      }
+    />
   )
 }

--- a/web/app/routes/manage/gift-cards.tsx
+++ b/web/app/routes/manage/gift-cards.tsx
@@ -21,6 +21,25 @@ type GiftCardAssetRow = {
   created_at: string
 }
 
+type GiftCardAllocationRow = {
+  gift_card_asset_id: string
+  reminder_sent_at: string | null
+  metadata: { release_at?: string | null } | null
+}
+
+const TORONTO_TIME_ZONE = 'America/Toronto'
+
+const parseHourMinuteEnv = (name: string, fallback: number) => {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const isProductionRuntime = process.env.NODE_ENV === 'production'
+const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
+const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
+
 const formatMoney = (value: number) =>
   new Intl.NumberFormat('en-CA', {
     style: 'currency',
@@ -32,6 +51,72 @@ const mask = (value: string, visibleDigits = 4) => {
   const trimmed = value.trim()
   if (trimmed.length <= visibleDigits) return trimmed
   return `${'•'.repeat(Math.max(0, trimmed.length - visibleDigits))}${trimmed.slice(-visibleDigits)}`
+}
+
+const torontoPartsForDate = (date: Date) => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: TORONTO_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date)
+  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? ''
+  return {
+    year: Number.parseInt(get('year'), 10),
+    month: Number.parseInt(get('month'), 10),
+    day: Number.parseInt(get('day'), 10),
+  }
+}
+
+const torontoTimeUtcForDate = (year: number, month: number, day: number, hour: number, minute: number) => {
+  for (const utcHour of [16, 17, 15, 18]) {
+    const candidate = new Date(Date.UTC(year, month - 1, day, utcHour, minute, 0, 0))
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: TORONTO_TIME_ZONE,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(candidate)
+
+    const get = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? ''
+    const localYear = Number.parseInt(get('year'), 10)
+    const localMonth = Number.parseInt(get('month'), 10)
+    const localDay = Number.parseInt(get('day'), 10)
+    const localHour = Number.parseInt(get('hour'), 10)
+    const localMinute = Number.parseInt(get('minute'), 10)
+    if (
+      localYear === year &&
+      localMonth === month &&
+      localDay === day &&
+      localHour === hour &&
+      localMinute === minute
+    ) {
+      return candidate.toISOString()
+    }
+  }
+
+  return null
+}
+
+const formatTorontoDateTime = (value: string | null) => {
+  if (!value) return ''
+  const parsed = new Date(value)
+  if (!Number.isFinite(parsed.getTime())) return ''
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: TORONTO_TIME_ZONE,
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(parsed)
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -50,6 +135,23 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw new Response(error.message, { status: 500 })
   }
 
+  const assetIds = (assets ?? []).map(asset => asset.id)
+  const { data: allocations, error: allocationError } = assetIds.length
+    ? await supabase
+        .from('gift_card_allocation')
+        .select('gift_card_asset_id, reminder_sent_at, metadata')
+        .in('gift_card_asset_id', assetIds)
+    : { data: [], error: null }
+
+  if (allocationError) {
+    throw new Response(allocationError.message, { status: 500 })
+  }
+
+  const allocationByAssetId = new Map<string, GiftCardAllocationRow>()
+  for (const allocation of (allocations ?? []) as GiftCardAllocationRow[]) {
+    allocationByAssetId.set(allocation.gift_card_asset_id, allocation)
+  }
+
   const rows = ((assets ?? []) as GiftCardAssetRow[]).map(asset => ({
     provider: asset.provider,
     account_number: mask(asset.account_number),
@@ -59,13 +161,43 @@ export async function loader({ request }: Route.LoaderArgs) {
     asset_url: asset.asset_url,
     assigned_profile_id: asset.assigned_profile_id ? asset.assigned_profile_id.slice(0, 8) : '',
     upload_id: asset.upload_id.slice(0, 8),
+    system_available_at: formatTorontoDateTime((allocationByAssetId.get(asset.id)?.metadata?.release_at ?? '').trim() || null),
+    system_reminder_at: (() => {
+      const allocation = allocationByAssetId.get(asset.id)
+      if (allocation?.reminder_sent_at) return formatTorontoDateTime(allocation.reminder_sent_at)
+      const releaseAt = (allocation?.metadata?.release_at ?? '').trim()
+      if (!releaseAt) return ''
+      const releaseDate = new Date(releaseAt)
+      if (!Number.isFinite(releaseDate.getTime())) return ''
+      const releaseToronto = torontoPartsForDate(releaseDate)
+      const reminderIso = torontoTimeUtcForDate(
+        releaseToronto.year,
+        releaseToronto.month,
+        releaseToronto.day,
+        REMINDER_HOUR_TORONTO,
+        REMINDER_MINUTE_TORONTO
+      )
+      return formatTorontoDateTime(reminderIso)
+    })(),
     created_at: asset.created_at,
   }))
 
   return {
     label: 'Gift card assets',
     tableName: 'gift-cards',
-    columns: ['provider', 'account_number', 'pin', 'value', 'status', 'asset_url', 'assigned_profile_id', 'upload_id', 'created_at'],
+    columns: [
+      'provider',
+      'account_number',
+      'pin',
+      'value',
+      'status',
+      'asset_url',
+      'assigned_profile_id',
+      'upload_id',
+      'system_available_at',
+      'system_reminder_at',
+      'created_at',
+    ],
     rows,
     columnMeta: {
       provider: { label: 'Provider' },
@@ -76,6 +208,8 @@ export async function loader({ request }: Route.LoaderArgs) {
       asset_url: { label: 'Link' },
       assigned_profile_id: { label: 'Assigned profile' },
       upload_id: { label: 'Upload ID' },
+      system_available_at: { label: 'System available' },
+      system_reminder_at: { label: 'System reminder' },
       created_at: { label: 'Created' },
     },
   }


### PR DESCRIPTION
## What changed
- bring sai/main gift-card release visibility updates into main
- keep allocation/release/reminder separation in runner + home + glr
- add system timing columns on manage gift-cards page:
  - system available (release slot)
  - system reminder (target/reminder-sent slot)

## Timing defaults
- production: release 11:45 Toronto, reminder 12:00 Toronto
- local/dev: release 11:00 Toronto, reminder 11:15 Toronto
