### PR TITLE
Show gift card system timing at top of assets page

### DIFF
--- a/web/app/routes/manage/gift-cards.tsx
+++ b/web/app/routes/manage/gift-cards.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router'
+import { Link, useLoaderData } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
@@ -21,22 +21,19 @@ type GiftCardAssetRow = {
   created_at: string
 }
 
-type GiftCardAllocationRow = {
-  gift_card_asset_id: string
-  reminder_sent_at: string | null
-  metadata: { release_at?: string | null } | null
-}
-
 const TORONTO_TIME_ZONE = 'America/Toronto'
 
 const parseHourMinuteEnv = (name: string, fallback: number) => {
+  if (typeof process === 'undefined') return fallback
   const raw = process.env[name]
   if (!raw) return fallback
   const parsed = Number.parseInt(raw, 10)
   return Number.isFinite(parsed) ? parsed : fallback
 }
 
-const isProductionRuntime = process.env.NODE_ENV === 'production'
+const isProductionRuntime = typeof process !== 'undefined' && process.env.NODE_ENV === 'production'
+const RELEASE_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_HOUR_TORONTO', 11)
+const RELEASE_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_MINUTE_TORONTO', isProductionRuntime ? 45 : 0)
 const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
 const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
 
@@ -53,70 +50,14 @@ const mask = (value: string, visibleDigits = 4) => {
   return `${'•'.repeat(Math.max(0, trimmed.length - visibleDigits))}${trimmed.slice(-visibleDigits)}`
 }
 
-const torontoPartsForDate = (date: Date) => {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: TORONTO_TIME_ZONE,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hourCycle: 'h23',
-  }).formatToParts(date)
-  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? ''
-  return {
-    year: Number.parseInt(get('year'), 10),
-    month: Number.parseInt(get('month'), 10),
-    day: Number.parseInt(get('day'), 10),
-  }
-}
-
-const torontoTimeUtcForDate = (year: number, month: number, day: number, hour: number, minute: number) => {
-  for (const utcHour of [16, 17, 15, 18]) {
-    const candidate = new Date(Date.UTC(year, month - 1, day, utcHour, minute, 0, 0))
-    const parts = new Intl.DateTimeFormat('en-CA', {
-      timeZone: TORONTO_TIME_ZONE,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      hourCycle: 'h23',
-    }).formatToParts(candidate)
-
-    const get = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? ''
-    const localYear = Number.parseInt(get('year'), 10)
-    const localMonth = Number.parseInt(get('month'), 10)
-    const localDay = Number.parseInt(get('day'), 10)
-    const localHour = Number.parseInt(get('hour'), 10)
-    const localMinute = Number.parseInt(get('minute'), 10)
-    if (
-      localYear === year &&
-      localMonth === month &&
-      localDay === day &&
-      localHour === hour &&
-      localMinute === minute
-    ) {
-      return candidate.toISOString()
-    }
-  }
-
-  return null
-}
-
-const formatTorontoDateTime = (value: string | null) => {
-  if (!value) return ''
-  const parsed = new Date(value)
-  if (!Number.isFinite(parsed.getTime())) return ''
+const formatTorontoClock = (hour: number, minute: number) => {
+  const probe = new Date(Date.UTC(2026, 0, 2, hour + 5, minute, 0, 0))
   return new Intl.DateTimeFormat(undefined, {
     timeZone: TORONTO_TIME_ZONE,
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
-    timeZoneName: 'short',
-  }).format(parsed)
+    hour12: true,
+  }).format(probe)
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -135,23 +76,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw new Response(error.message, { status: 500 })
   }
 
-  const assetIds = (assets ?? []).map(asset => asset.id)
-  const { data: allocations, error: allocationError } = assetIds.length
-    ? await supabase
-        .from('gift_card_allocation')
-        .select('gift_card_asset_id, reminder_sent_at, metadata')
-        .in('gift_card_asset_id', assetIds)
-    : { data: [], error: null }
-
-  if (allocationError) {
-    throw new Response(allocationError.message, { status: 500 })
-  }
-
-  const allocationByAssetId = new Map<string, GiftCardAllocationRow>()
-  for (const allocation of (allocations ?? []) as GiftCardAllocationRow[]) {
-    allocationByAssetId.set(allocation.gift_card_asset_id, allocation)
-  }
-
   const rows = ((assets ?? []) as GiftCardAssetRow[]).map(asset => ({
     provider: asset.provider,
     account_number: mask(asset.account_number),
@@ -161,43 +85,18 @@ export async function loader({ request }: Route.LoaderArgs) {
     asset_url: asset.asset_url,
     assigned_profile_id: asset.assigned_profile_id ? asset.assigned_profile_id.slice(0, 8) : '',
     upload_id: asset.upload_id.slice(0, 8),
-    system_available_at: formatTorontoDateTime((allocationByAssetId.get(asset.id)?.metadata?.release_at ?? '').trim() || null),
-    system_reminder_at: (() => {
-      const allocation = allocationByAssetId.get(asset.id)
-      if (allocation?.reminder_sent_at) return formatTorontoDateTime(allocation.reminder_sent_at)
-      const releaseAt = (allocation?.metadata?.release_at ?? '').trim()
-      if (!releaseAt) return ''
-      const releaseDate = new Date(releaseAt)
-      if (!Number.isFinite(releaseDate.getTime())) return ''
-      const releaseToronto = torontoPartsForDate(releaseDate)
-      const reminderIso = torontoTimeUtcForDate(
-        releaseToronto.year,
-        releaseToronto.month,
-        releaseToronto.day,
-        REMINDER_HOUR_TORONTO,
-        REMINDER_MINUTE_TORONTO
-      )
-      return formatTorontoDateTime(reminderIso)
-    })(),
     created_at: asset.created_at,
   }))
 
   return {
     label: 'Gift card assets',
     tableName: 'gift-cards',
-    columns: [
-      'provider',
-      'account_number',
-      'pin',
-      'value',
-      'status',
-      'asset_url',
-      'assigned_profile_id',
-      'upload_id',
-      'system_available_at',
-      'system_reminder_at',
-      'created_at',
-    ],
+    systemTiming: {
+      timezone: TORONTO_TIME_ZONE,
+      release: `Mon/Fri ${formatTorontoClock(RELEASE_HOUR_TORONTO, RELEASE_MINUTE_TORONTO)}`,
+      reminder: `Mon/Fri ${formatTorontoClock(REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)}`,
+    },
+    columns: ['provider', 'account_number', 'pin', 'value', 'status', 'asset_url', 'assigned_profile_id', 'upload_id', 'created_at'],
     rows,
     columnMeta: {
       provider: { label: 'Provider' },
@@ -208,20 +107,26 @@ export async function loader({ request }: Route.LoaderArgs) {
       asset_url: { label: 'Link' },
       assigned_profile_id: { label: 'Assigned profile' },
       upload_id: { label: 'Upload ID' },
-      system_available_at: { label: 'System available' },
-      system_reminder_at: { label: 'System reminder' },
       created_at: { label: 'Created' },
     },
   }
 }
 
 export default function GiftCardsPage() {
+  const data = useLoaderData<typeof loader>()
+
   return (
     <TableDisplay
       headerActions={
-        <Button asChild>
-          <Link to="/manage/gift-cards/upload">Upload gift cards</Link>
-        </Button>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="rounded border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">System timing</span>{' '}
+            (timezone: {data.systemTiming.timezone}) - Available: {data.systemTiming.release} - Reminder: {data.systemTiming.reminder}
+          </div>
+          <Button asChild>
+            <Link to="/manage/gift-cards/upload">Upload gift cards</Link>
+          </Button>
+        </div>
       }
     />
   )


### PR DESCRIPTION
## What changed
- replace per-row system timing columns in manage gift-cards with a single live system timing banner in header actions
- show timezone, release schedule, and reminder schedule together for quick operational visibility

## Timing shown
- production defaults: availability Mon/Fri 11:45 AM Toronto, reminders Mon/Fri 12:00 PM Toronto
- local defaults: availability Mon/Fri 11:00 AM Toronto, reminders Mon/Fri 11:15 AM Toronto
