### PR TITLE
Backfill gift card release gating

### DIFF
--- a/web/app/lib/gift-cards/release.server.ts
+++ b/web/app/lib/gift-cards/release.server.ts
@@ -1,0 +1,111 @@
+const TORONTO_TIME_ZONE = 'America/Toronto'
+
+const torontoDateTimeFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: TORONTO_TIME_ZONE,
+  weekday: 'short',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hourCycle: 'h23',
+})
+
+const parseHourMinuteEnv = (name: string, fallback: number) => {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const isProductionRuntime = process.env.NODE_ENV === 'production'
+const RELEASE_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_HOUR_TORONTO', 11)
+const RELEASE_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_MINUTE_TORONTO', isProductionRuntime ? 45 : 0)
+
+const torontoPartsForDate = (date: Date) => {
+  const parts = torontoDateTimeFormatter.formatToParts(date)
+  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? ''
+  return {
+    year: Number.parseInt(get('year'), 10),
+    month: Number.parseInt(get('month'), 10),
+    day: Number.parseInt(get('day'), 10),
+    hour: Number.parseInt(get('hour'), 10),
+    minute: Number.parseInt(get('minute'), 10),
+  }
+}
+
+const addDaysToDateParts = (year: number, month: number, day: number, daysAhead: number) => {
+  const next = new Date(Date.UTC(year, month - 1, day + daysAhead))
+  return {
+    year: next.getUTCFullYear(),
+    month: next.getUTCMonth() + 1,
+    day: next.getUTCDate(),
+  }
+}
+
+const torontoTimeUtcForDate = (year: number, month: number, day: number, hour: number, minute: number) => {
+  for (const utcHour of [16, 17, 15, 18]) {
+    const candidate = new Date(Date.UTC(year, month - 1, day, utcHour, minute, 0, 0))
+    const toronto = torontoPartsForDate(candidate)
+    if (
+      toronto.year === year &&
+      toronto.month === month &&
+      toronto.day === day &&
+      toronto.hour === hour &&
+      toronto.minute === minute
+    ) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+export const nextReleaseAtIso = (classEndsAt: string | null) => {
+  if (!classEndsAt) return null
+  const end = new Date(classEndsAt)
+  if (!Number.isFinite(end.getTime())) return null
+
+  const torontoEnd = torontoPartsForDate(end)
+  if (!Number.isFinite(torontoEnd.year) || !Number.isFinite(torontoEnd.month) || !Number.isFinite(torontoEnd.day)) {
+    return null
+  }
+
+  for (let daysAhead = 0; daysAhead <= 21; daysAhead += 1) {
+    const localDate = addDaysToDateParts(torontoEnd.year, torontoEnd.month, torontoEnd.day, daysAhead)
+    const weekday = new Date(Date.UTC(localDate.year, localDate.month - 1, localDate.day)).getUTCDay()
+    if (weekday !== 1 && weekday !== 5) continue
+
+    const candidate = torontoTimeUtcForDate(
+      localDate.year,
+      localDate.month,
+      localDate.day,
+      RELEASE_HOUR_TORONTO,
+      RELEASE_MINUTE_TORONTO
+    )
+    if (!candidate) continue
+    if (candidate.getTime() < end.getTime()) continue
+    return candidate.toISOString()
+  }
+
+  return null
+}
+
+export const isGiftCardReleasedNow = ({
+  releaseAt,
+  classEndsAt,
+  now = Date.now(),
+}: {
+  releaseAt: string | null | undefined
+  classEndsAt: string | null
+  now?: number
+}) => {
+  const parsedReleaseAt = Date.parse((releaseAt ?? '').trim())
+  if (Number.isFinite(parsedReleaseAt)) {
+    return parsedReleaseAt <= now
+  }
+
+  const fallbackReleaseAt = nextReleaseAtIso(classEndsAt)
+  const fallbackReleaseAtMs = Date.parse((fallbackReleaseAt ?? '').trim())
+  return Number.isFinite(fallbackReleaseAtMs) && fallbackReleaseAtMs <= now
+}

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -1,4 +1,5 @@
 import { sendTemplateEmail } from '@/lib/email/send-email.server'
+import { nextReleaseAtIso } from '@/lib/gift-cards/release.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
 
@@ -36,8 +37,6 @@ const parseHourMinuteEnv = (name: string, fallback: number) => {
 }
 
 const isProductionRuntime = process.env.NODE_ENV === 'production'
-const RELEASE_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_HOUR_TORONTO', 11)
-const RELEASE_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_RELEASE_MINUTE_TORONTO', isProductionRuntime ? 45 : 0)
 const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
 const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
 
@@ -51,15 +50,6 @@ const torontoPartsForDate = (date: Date) => {
     day: Number.parseInt(get('day'), 10),
     hour: Number.parseInt(get('hour'), 10),
     minute: Number.parseInt(get('minute'), 10),
-  }
-}
-
-const addDaysToDateParts = (year: number, month: number, day: number, daysAhead: number) => {
-  const next = new Date(Date.UTC(year, month - 1, day + daysAhead))
-  return {
-    year: next.getUTCFullYear(),
-    month: next.getUTCMonth() + 1,
-    day: next.getUTCDate(),
   }
 }
 
@@ -105,36 +95,6 @@ const currentTorontoReminderSlotIso = (now: Date) => {
 const reminderSlotIsoForTorontoDate = (year: number, month: number, day: number) => {
   const slot = torontoTimeUtcForDate(year, month, day, REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)
   return slot ? slot.toISOString() : null
-}
-
-const nextReleaseAtIso = (classEndsAt: string | null) => {
-  if (!classEndsAt) return null
-  const end = new Date(classEndsAt)
-  if (!Number.isFinite(end.getTime())) return null
-
-  const torontoEnd = torontoPartsForDate(end)
-  if (!Number.isFinite(torontoEnd.year) || !Number.isFinite(torontoEnd.month) || !Number.isFinite(torontoEnd.day)) {
-    return null
-  }
-
-  for (let daysAhead = 0; daysAhead <= 21; daysAhead += 1) {
-    const localDate = addDaysToDateParts(torontoEnd.year, torontoEnd.month, torontoEnd.day, daysAhead)
-    const weekday = new Date(Date.UTC(localDate.year, localDate.month - 1, localDate.day)).getUTCDay()
-    if (weekday !== 1 && weekday !== 5) continue
-
-    const candidate = torontoTimeUtcForDate(
-      localDate.year,
-      localDate.month,
-      localDate.day,
-      RELEASE_HOUR_TORONTO,
-      RELEASE_MINUTE_TORONTO
-    )
-    if (!candidate) continue
-    if (candidate.getTime() < end.getTime()) continue
-    return candidate.toISOString()
-  }
-
-  return null
 }
 
 const resolveRecipientEmail = async (profileId: string, fallbackEmail: string | null) => {

--- a/web/app/routes/glr.$token.ts
+++ b/web/app/routes/glr.$token.ts
@@ -3,6 +3,7 @@ import { redirect, type LoaderFunctionArgs } from 'react-router'
 import { extractRequestMetadata } from '@/lib/request-metadata.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 
+import { isGiftCardReleasedNow } from '@/lib/gift-cards/release.server'
 import { hashGlrToken } from '@/lib/gift-cards/token.server'
 
 const homeMessageRedirect = ({ request, message }: { request: Request; message: string }) => {
@@ -25,7 +26,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const tokenHash = hashGlrToken(token)
   const { data: allocationByHash, error: allocationError } = await adminClient
     .from('gift_card_allocation')
-    .select('id, profile_id, blocked, status, metadata, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
+    .select('id, profile_id, blocked, status, metadata, class_id, gift_card_asset_id, asset:gift_card_asset_id(asset_url), class:class_id(ends_at)')
     .eq('glr_token_hash', tokenHash)
     .maybeSingle()
 
@@ -42,15 +43,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (!allocation && isUuidToken) {
     const { data: allocationById } = await adminClient
       .from('gift_card_allocation')
-      .select('id, profile_id, blocked, status, metadata, gift_card_asset_id, asset:gift_card_asset_id(asset_url)')
+      .select('id, profile_id, blocked, status, metadata, class_id, gift_card_asset_id, asset:gift_card_asset_id(asset_url), class:class_id(ends_at)')
       .eq('id', token)
       .maybeSingle()
     allocation = allocationById
   }
 
-  const releaseAt = (allocation?.metadata?.release_at ?? '').trim()
-  const releaseAtMs = Date.parse(releaseAt)
-  const released = Number.isFinite(releaseAtMs) && releaseAtMs <= Date.now()
+  const classRelation = allocation?.class
+  const released = isGiftCardReleasedNow({
+    releaseAt: allocation?.metadata?.release_at,
+    classEndsAt: (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ?? null,
+  })
 
   if (!allocation || allocation.blocked || (allocation.status === 'allocated' && !released)) {
     return invalidLink({ request })

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { enforceOnboardingGuard } from '@/lib/auth.server'
+import { isGiftCardReleasedNow } from '@/lib/gift-cards/release.server'
 import { resolveFamilyGraph } from '@/lib/family.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
@@ -251,6 +252,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     acc[classRow.workshop_id].push(classRow)
     return acc
   }, {})
+  const classEndsAtById = Object.fromEntries(classes.map(classRow => [classRow.id, classRow.ends_at])) as Record<string, string>
 
   const classIds = classes.map(classRow => classRow.id)
 
@@ -365,9 +367,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     metadata: { release_at?: string | null } | null
   }>).reduce<Record<string, string>>((acc, row) => {
     if (row.blocked) return acc
-    const releaseAt = (row.metadata?.release_at ?? '').trim()
-    const releaseAtMs = Date.parse(releaseAt)
-    const released = Number.isFinite(releaseAtMs) && releaseAtMs <= Date.now()
+    const released = isGiftCardReleasedNow({
+      releaseAt: row.metadata?.release_at,
+      classEndsAt: classEndsAtById[row.class_id] ?? null,
+      now,
+    })
     const availableByReminder = Boolean(row.reminder_sent_at && (row.status === 'sent' || row.status === 'opened'))
     if (!released && !availableByReminder) return acc
     const selectedProfileId = selectedProfileIdByClass[row.class_id]

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -731,7 +731,10 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     editorConfig,
     foreignKeyOptions = {},
   } = source ?? ({} as LoaderData)
-  const hasStickyTopBar = tableName === 'class-enrollment' || tableName === 'class-attendance'
+  const hasStickyTopBar =
+    tableName === 'class-enrollment' ||
+    tableName === 'workshop-enrollment' ||
+    tableName === 'class-attendance'
   const location = useLocation()
 
   const statusFetcher = useFetcher()


### PR DESCRIPTION
## What
- add a shared gift-card release helper that calculates the Toronto release slot from class end time
- use fallback release calculation on `/home` when allocation `metadata.release_at` is missing
- use the same fallback on `/glr/:token` so allocated links open once the computed release time passes
- keep runner allocation using the same shared release-time helper

## Why
- some prod allocations can be `allocated` without `metadata.release_at`, which keeps links hidden/invalid until reminders
- this restores expected post-release visibility (11:45 Toronto) for those rows

## Testing
- `npm run typecheck` *(fails due existing unrelated table route files in working tree, same pre-existing errors)*