### PR TITLE
Use hub sign-in link in gift card reminders

### DIFF
--- a/web/app/lib/email/templates/gift-card-reminder.ts
+++ b/web/app/lib/email/templates/gift-card-reminder.ts
@@ -9,21 +9,21 @@ const escapeHtml = (value: string) =>
 export type GiftCardReminderTemplateData = {
   provider: 'PC' | 'Sobeys'
   amount: number
-  redemptionUrl: string
+  hubUrl: string
 }
 
 export const renderGiftCardReminderEmail = ({
   provider,
   amount,
-  redemptionUrl,
+  hubUrl,
 }: GiftCardReminderTemplateData) => {
   const safeProvider = escapeHtml(provider)
-  const safeUrl = escapeHtml(redemptionUrl)
+  const safeUrl = escapeHtml(hubUrl)
   const amountLabel = Number.isFinite(amount) ? amount.toFixed(2) : '0.00'
 
   return {
     subject: `Your ${safeProvider} gift card is ready`,
-    text: `Your ${safeProvider} gift card ($${amountLabel}) is now available. Open your gift card link: ${redemptionUrl}`,
+    text: `Your ${safeProvider} gift card ($${amountLabel}) is now available. Sign in to SummerLunch Plus Hub to view your gift card: ${hubUrl}`,
     html: `<!doctype html>
 <html>
   <body style="margin:0;padding:0;background-color:#f6f8fb;">
@@ -40,7 +40,8 @@ export const renderGiftCardReminderEmail = ({
               <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
                 <p style="margin:0 0 12px 0;">Your <strong>${safeProvider}</strong> gift card is ready.</p>
                 <p style="margin:0 0 16px 0;">Card value: <strong>$${amountLabel}</strong></p>
-                <p style="margin:0;"><a href="${safeUrl}">Open gift card</a></p>
+                <p style="margin:0 0 12px 0;">Sign in to SummerLunch Plus Hub to view your gift card.</p>
+                <p style="margin:0;"><a href="${safeUrl}">Sign in to hub.summerlunchplus.com</a></p>
               </td>
             </tr>
           </table>

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -37,6 +37,26 @@ const parseHourMinuteEnv = (name: string, fallback: number) => {
 }
 
 const isProductionRuntime = process.env.NODE_ENV === 'production'
+const ensureOrigin = (origin: string) => origin.replace(/\/+$/, '')
+
+const resolvePublicHubOrigin = (fallbackOrigin: string) => {
+  const railwayPublicDomain = (process.env.RAILWAY_PUBLIC_DOMAIN ?? '').trim()
+  const railwayPublicOrigin = railwayPublicDomain ? `https://${railwayPublicDomain}` : ''
+  const explicitOrigin = [
+    process.env.SITE_ORIGIN,
+    process.env.PUBLIC_APP_ORIGIN,
+    process.env.APP_BASE_URL,
+    railwayPublicOrigin,
+    process.env.VITE_PUBLIC_APP_ORIGIN,
+    process.env.VITE_APP_ORIGIN,
+  ]
+    .map(value => (value ?? '').trim())
+    .find(Boolean)
+  if (explicitOrigin) return ensureOrigin(explicitOrigin)
+  if (isProductionRuntime) return 'https://hub.summerlunchplus.com'
+  return ensureOrigin(fallbackOrigin)
+}
+
 const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
 const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
 
@@ -300,6 +320,8 @@ const allocateGiftCards = async () => {
 const sendDueReminders = async (appOrigin: string) => {
   const now = new Date()
   const nowIso = now.toISOString()
+  const publicHubOrigin = resolvePublicHubOrigin(appOrigin)
+  const hubUrl = `${publicHubOrigin}/home`
   const reminderSlotIso = currentTorontoReminderSlotIso(now)
   if (!reminderSlotIso) {
     return {
@@ -376,7 +398,6 @@ const sendDueReminders = async (appOrigin: string) => {
 
     const token = newGlrToken()
     const tokenHash = hashGlrToken(token)
-    const glrUrl = `${appOrigin}/glr/${token}`
     const eventKey = `gift-card-reminder:${row.id}`
     const assetRelation = Array.isArray(row.asset) ? row.asset[0] : row.asset
 
@@ -386,7 +407,7 @@ const sendDueReminders = async (appOrigin: string) => {
       templateData: {
         provider: assetRelation?.provider ?? 'PC',
         amount: Number(assetRelation?.value ?? 0),
-        redemptionUrl: glrUrl,
+        hubUrl,
       },
       profileId: row.profile_id,
       eventKey,


### PR DESCRIPTION
## What
- stop using request-origin GLR links in gift-card reminder emails
- resolve a public hub origin (env-based, production fallback to `https://hub.summerlunchplus.com`)
- send reminder template CTA to `/home` on the hub instead
- update reminder copy to tell families to sign in to the hub to view their gift card

## Why
- internal job requests can resolve to `web.railway.internal`, which leaked into production email links
- reminders should direct users to sign in at the public hub domain

## Testing
- `npm run typecheck` *(fails on existing unrelated table-route files already present in working tree)*