### PR TITLE
Add admin email change controls with inline editing

### DIFF
--- a/supabase/migrations/20260707172424_email-change-log-real.sql
+++ b/supabase/migrations/20260707172424_email-change-log-real.sql
@@ -1,0 +1,100 @@
+create type public.email_change_status as enum (
+  'pending',
+  'applied',
+  'partial',
+  'failed'
+);
+
+create table public.email_change_log (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profile(id) on update cascade on delete restrict,
+  user_id uuid references auth.users(id) on update cascade on delete set null,
+  old_email text not null,
+  new_email text not null,
+  changed_by uuid not null references auth.users(id) on update cascade on delete restrict,
+  reason text not null,
+  status public.email_change_status not null default 'pending',
+  auth_updated boolean not null default false,
+  profile_updated boolean not null default false,
+  invites_updated boolean not null default false,
+  invite_rows_updated integer not null default 0,
+  zoom_sync_started_at timestamptz,
+  zoom_sync_completed_at timestamptz,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint email_change_log_reason_not_blank_chk check (length(trim(reason)) > 0),
+  constraint email_change_log_invite_rows_non_negative_chk check (invite_rows_updated >= 0)
+);
+
+create index email_change_log_profile_created_idx
+  on public.email_change_log (profile_id, created_at desc);
+
+create index email_change_log_user_created_idx
+  on public.email_change_log (user_id, created_at desc);
+
+create index email_change_log_status_created_idx
+  on public.email_change_log (status, created_at desc);
+
+create index email_change_log_changed_by_created_idx
+  on public.email_change_log (changed_by, created_at desc);
+
+create or replace function public.touch_email_change_log_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists on_email_change_log_updated_set_timestamp on public.email_change_log;
+create trigger on_email_change_log_updated_set_timestamp
+before update on public.email_change_log
+for each row execute function public.touch_email_change_log_updated_at();
+
+alter table public.email_change_log enable row level security;
+
+create policy email_change_log_read_admin
+  on public.email_change_log
+  for select
+  using (public.current_user_role() = 'admin'::public.app_role);
+
+create policy email_change_log_insert_admin
+  on public.email_change_log
+  for insert
+  with check (public.current_user_role() = 'admin'::public.app_role);
+
+create policy email_change_log_update_admin
+  on public.email_change_log
+  for update
+  using (public.current_user_role() = 'admin'::public.app_role)
+  with check (public.current_user_role() = 'admin'::public.app_role);
+
+create policy email_change_log_read_auth_admin
+  on public.email_change_log
+  for select
+  to supabase_auth_admin
+  using (true);
+
+create policy email_change_log_insert_auth_admin
+  on public.email_change_log
+  for insert
+  to supabase_auth_admin
+  with check (true);
+
+create policy email_change_log_update_auth_admin
+  on public.email_change_log
+  for update
+  to supabase_auth_admin
+  using (true)
+  with check (true);
+
+grant usage on type public.email_change_status to authenticated, supabase_auth_admin;
+
+grant all on table public.email_change_log to supabase_auth_admin;
+revoke all on table public.email_change_log from authenticated, anon, public;
+grant select, insert, update on table public.email_change_log to authenticated;

--- a/supabase/migrations/20260707172627_email-change-log-noop.sql
+++ b/supabase/migrations/20260707172627_email-change-log-noop.sql
@@ -1,0 +1,2 @@
+alter table if exists public.email_change_log
+drop constraint if exists email_change_log_old_new_different_chk;

--- a/supabase/schemas/17_email_change_log.sql
+++ b/supabase/schemas/17_email_change_log.sql
@@ -1,0 +1,100 @@
+create type public.email_change_status as enum (
+  'pending',
+  'applied',
+  'partial',
+  'failed'
+);
+
+create table public.email_change_log (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profile(id) on update cascade on delete restrict,
+  user_id uuid references auth.users(id) on update cascade on delete set null,
+  old_email text not null,
+  new_email text not null,
+  changed_by uuid not null references auth.users(id) on update cascade on delete restrict,
+  reason text not null,
+  status public.email_change_status not null default 'pending',
+  auth_updated boolean not null default false,
+  profile_updated boolean not null default false,
+  invites_updated boolean not null default false,
+  invite_rows_updated integer not null default 0,
+  zoom_sync_started_at timestamptz,
+  zoom_sync_completed_at timestamptz,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint email_change_log_reason_not_blank_chk check (length(trim(reason)) > 0),
+  constraint email_change_log_invite_rows_non_negative_chk check (invite_rows_updated >= 0)
+);
+
+create index email_change_log_profile_created_idx
+  on public.email_change_log (profile_id, created_at desc);
+
+create index email_change_log_user_created_idx
+  on public.email_change_log (user_id, created_at desc);
+
+create index email_change_log_status_created_idx
+  on public.email_change_log (status, created_at desc);
+
+create index email_change_log_changed_by_created_idx
+  on public.email_change_log (changed_by, created_at desc);
+
+create or replace function public.touch_email_change_log_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists on_email_change_log_updated_set_timestamp on public.email_change_log;
+create trigger on_email_change_log_updated_set_timestamp
+before update on public.email_change_log
+for each row execute function public.touch_email_change_log_updated_at();
+
+alter table public.email_change_log enable row level security;
+
+create policy email_change_log_read_admin
+  on public.email_change_log
+  for select
+  using (public.current_user_role() = 'admin'::public.app_role);
+
+create policy email_change_log_insert_admin
+  on public.email_change_log
+  for insert
+  with check (public.current_user_role() = 'admin'::public.app_role);
+
+create policy email_change_log_update_admin
+  on public.email_change_log
+  for update
+  using (public.current_user_role() = 'admin'::public.app_role)
+  with check (public.current_user_role() = 'admin'::public.app_role);
+
+create policy email_change_log_read_auth_admin
+  on public.email_change_log
+  for select
+  to supabase_auth_admin
+  using (true);
+
+create policy email_change_log_insert_auth_admin
+  on public.email_change_log
+  for insert
+  to supabase_auth_admin
+  with check (true);
+
+create policy email_change_log_update_auth_admin
+  on public.email_change_log
+  for update
+  to supabase_auth_admin
+  using (true)
+  with check (true);
+
+grant usage on type public.email_change_status to authenticated, supabase_auth_admin;
+
+grant all on table public.email_change_log to supabase_auth_admin;
+revoke all on table public.email_change_log from authenticated, anon, public;
+grant select, insert, update on table public.email_change_log to authenticated;

--- a/web/app/lib/admin/email-change.server.ts
+++ b/web/app/lib/admin/email-change.server.ts
@@ -1,0 +1,733 @@
+import { isAllowedEmailDomain, normalizeEmail } from '@/lib/email-domain'
+import { adminClient } from '@/lib/supabase/adminClient'
+import { runZoomJobsForClass } from '@/lib/zoom-jobs/runner.server'
+
+type EmailChangeStage =
+  | 'validate'
+  | 'preflight'
+  | 'auth_update'
+  | 'profile_update'
+  | 'invite_migration'
+  | 'zoom_sync'
+  | 'finalize'
+
+type EmailChangeStatus = 'pending' | 'applied' | 'partial' | 'failed'
+
+type StageEntry = {
+  stage: EmailChangeStage
+  ok: boolean
+  message?: string
+  error?: string
+  meta?: Record<string, unknown>
+  at: string
+}
+
+type EmailChangeDetails = {
+  stages: StageEntry[]
+  preflight?: {
+    profileConflictId?: string
+    authConflictUserId?: string
+    inviteConflictId?: string
+  }
+  inviteMigration?: {
+    updatedCount: number
+  }
+  zoom?: {
+    impactedClassIds: string[]
+    results: Array<{
+      classId: string
+      ok: boolean
+      error?: string
+      summary?: {
+        meetingCreated?: boolean
+        meetingRecreated?: boolean
+        registrantsCreated?: number
+        registrantsUpdated?: number
+        registrantsRemoved?: number
+        registrantsSkipped?: number
+      }
+    }>
+  }
+  compensation?: {
+    attemptedAuthRevert?: boolean
+    authRevertOk?: boolean
+    authRevertError?: string
+  }
+}
+
+type ProfileRow = {
+  id: string
+  user_id: string | null
+  role: string | null
+  email: string | null
+}
+
+type PreflightResult = {
+  ok: boolean
+  error?: string
+  conflict?: {
+    profileConflictId?: string
+    authConflictUserId?: string
+    inviteConflictId?: string
+  }
+}
+
+type ClassSyncResult = {
+  classId: string
+  ok: boolean
+  error?: string
+  summary?: {
+    meetingCreated?: boolean
+    meetingRecreated?: boolean
+    registrantsCreated?: number
+    registrantsUpdated?: number
+    registrantsRemoved?: number
+    registrantsSkipped?: number
+  }
+}
+
+export type ChangeEmailForProfileByAdminInput = {
+  profileId: string
+  newEmailRaw: string
+  actorUserId: string
+  reason: string
+  appOrigin: string
+  triggerZoomSync?: boolean
+}
+
+export type ChangeEmailForProfileByAdminResult = {
+  ok: boolean
+  error?: string
+  logId: string | null
+  status: 'applied' | 'partial' | 'failed'
+  profileId: string
+  userId: string | null
+  oldEmail: string
+  newEmail: string
+  authUpdated: boolean
+  profileUpdated: boolean
+  invitesUpdated: boolean
+  inviteRowsUpdated: number
+  classSync: {
+    attempted: boolean
+    impactedClassIds: string[]
+    results: ClassSyncResult[]
+  }
+  stages: StageEntry[]
+}
+
+const nowIso = () => new Date().toISOString()
+
+const findAuthUserByEmail = async (email: string) => {
+  let page = 1
+
+  while (true) {
+    const { data, error } = await adminClient.auth.admin.listUsers({ page, perPage: 200 })
+    if (error) {
+      return { userId: null as string | null, error: error.message }
+    }
+
+    const users = data?.users ?? []
+    const matched = users.find(user => normalizeEmail(user.email ?? '') === email)
+    if (matched?.id) {
+      return { userId: matched.id, error: null }
+    }
+
+    if (users.length < 200) {
+      break
+    }
+
+    page += 1
+  }
+
+  return { userId: null as string | null, error: null }
+}
+
+const preflightEmailChange = async ({
+  profileId,
+  oldEmail,
+  newEmail,
+  userId,
+}: {
+  profileId: string
+  oldEmail: string
+  newEmail: string
+  userId: string | null
+}): Promise<PreflightResult> => {
+  const conflict: PreflightResult['conflict'] = {}
+
+  const { data: profileConflict, error: profileConflictError } = await adminClient
+    .from('profile')
+    .select('id')
+    .eq('email', newEmail)
+    .neq('id', profileId)
+    .maybeSingle()
+
+  if (profileConflictError) {
+    return { ok: false, error: profileConflictError.message }
+  }
+
+  if (profileConflict?.id) {
+    conflict.profileConflictId = profileConflict.id
+  }
+
+  const { userId: authConflictUserId, error: authLookupError } = await findAuthUserByEmail(newEmail)
+  if (authLookupError) {
+    return { ok: false, error: authLookupError }
+  }
+
+  if (authConflictUserId && authConflictUserId !== userId) {
+    conflict.authConflictUserId = authConflictUserId
+  }
+
+  const { data: inviteConflict, error: inviteConflictError } = await adminClient
+    .from('invites')
+    .select('id, invitee_user_id')
+    .eq('invitee_email', newEmail)
+    .maybeSingle()
+
+  if (inviteConflictError) {
+    return { ok: false, error: inviteConflictError.message }
+  }
+
+  if (inviteConflict?.id) {
+    const isOwnedInvite = Boolean(userId && inviteConflict.invitee_user_id && inviteConflict.invitee_user_id === userId)
+    if (!isOwnedInvite) {
+      conflict.inviteConflictId = inviteConflict.id
+    }
+  }
+
+  if (conflict.profileConflictId || conflict.authConflictUserId || conflict.inviteConflictId) {
+    return {
+      ok: false,
+      error: 'Email is already in use by another account or invite.',
+      conflict,
+    }
+  }
+
+  if (oldEmail === newEmail) {
+    return {
+      ok: false,
+      error: 'New email matches current email.',
+    }
+  }
+
+  return { ok: true }
+}
+
+const updateAuthEmailIfLinked = async ({ userId, newEmail }: { userId: string | null; newEmail: string }) => {
+  if (!userId) {
+    return { ok: true, updated: false }
+  }
+
+  const { error } = await adminClient.auth.admin.updateUserById(userId, {
+    email: newEmail,
+    email_confirm: true,
+  })
+
+  if (error) {
+    return { ok: false, updated: false, error: error.message }
+  }
+
+  return { ok: true, updated: true }
+}
+
+const migrateInviteEmails = async ({
+  userId,
+  oldEmail,
+  newEmail,
+}: {
+  userId: string | null
+  oldEmail: string
+  newEmail: string
+}) => {
+  const { data: byEmailRows, error: byEmailError } = await adminClient
+    .from('invites')
+    .select('id')
+    .eq('invitee_email', oldEmail)
+
+  if (byEmailError) {
+    return { ok: false, updatedCount: 0, error: byEmailError.message }
+  }
+
+  const ids = new Set((byEmailRows ?? []).map(row => row.id).filter(Boolean))
+
+  if (userId) {
+    const { data: byUserRows, error: byUserError } = await adminClient
+      .from('invites')
+      .select('id')
+      .eq('invitee_user_id', userId)
+
+    if (byUserError) {
+      return { ok: false, updatedCount: 0, error: byUserError.message }
+    }
+
+    for (const row of byUserRows ?? []) {
+      if (row.id) ids.add(row.id)
+    }
+  }
+
+  const rowIds = Array.from(ids)
+  if (!rowIds.length) {
+    return { ok: true, updatedCount: 0 }
+  }
+
+  const { error: updateError } = await adminClient
+    .from('invites')
+    .update({ invitee_email: newEmail })
+    .in('id', rowIds)
+
+  if (updateError) {
+    return { ok: false, updatedCount: 0, error: updateError.message }
+  }
+
+  return { ok: true, updatedCount: rowIds.length }
+}
+
+const resolveImpactedClassIds = async ({
+  profileId,
+  role,
+}: {
+  profileId: string
+  role: string | null
+}) => {
+  const targetProfileIds = new Set<string>()
+
+  if (role === 'student') {
+    targetProfileIds.add(profileId)
+  } else if (role === 'guardian') {
+    const { data: childEdges } = await adminClient
+      .from('person_guardian_child')
+      .select('child_profile_id')
+      .eq('guardian_profile_id', profileId)
+
+    for (const edge of childEdges ?? []) {
+      if (edge.child_profile_id) {
+        targetProfileIds.add(edge.child_profile_id)
+      }
+    }
+  } else {
+    targetProfileIds.add(profileId)
+  }
+
+  if (!targetProfileIds.size) {
+    return [] as string[]
+  }
+
+  const targetIds = Array.from(targetProfileIds)
+  const { data: enrollments, error: enrollmentError } = await adminClient
+    .from('workshop_enrollment')
+    .select('workshop_id')
+    .in('profile_id', targetIds)
+    .eq('status', 'approved')
+    .not('workshop_id', 'is', null)
+
+  if (enrollmentError) {
+    throw new Error(enrollmentError.message)
+  }
+
+  const workshopIds = Array.from(
+    new Set((enrollments ?? []).map(row => row.workshop_id).filter((id): id is string => Boolean(id)))
+  )
+
+  if (!workshopIds.length) {
+    return [] as string[]
+  }
+
+  const { data: classes, error: classError } = await adminClient
+    .from('class')
+    .select('id')
+    .in('workshop_id', workshopIds)
+    .gte('ends_at', new Date(Date.now() - 60 * 60_000).toISOString())
+
+  if (classError) {
+    throw new Error(classError.message)
+  }
+
+  return Array.from(new Set((classes ?? []).map(row => row.id).filter(Boolean)))
+}
+
+const syncImpactedClasses = async ({
+  classIds,
+  appOrigin,
+}: {
+  classIds: string[]
+  appOrigin: string
+}) => {
+  const results: ClassSyncResult[] = []
+
+  for (const classId of classIds) {
+    try {
+      const syncResult = await runZoomJobsForClass({
+        classId,
+        appOrigin,
+        runId: `email-change-${Date.now().toString(36)}`,
+      })
+
+      results.push({
+        classId,
+        ok: true,
+        summary: {
+          meetingCreated: syncResult.provision?.meetingCreated,
+          meetingRecreated: syncResult.provision?.meetingRecreated,
+          registrantsCreated: syncResult.provision?.registrantsCreated,
+          registrantsUpdated: syncResult.provision?.registrantsUpdated,
+          registrantsRemoved: syncResult.provision?.registrantsRemoved,
+          registrantsSkipped: syncResult.provision?.registrantsSkipped,
+        },
+      })
+    } catch (error) {
+      results.push({
+        classId,
+        ok: false,
+        error: error instanceof Error ? error.message : 'Unknown class sync error',
+      })
+    }
+  }
+
+  return results
+}
+
+export async function changeEmailForProfileByAdmin({
+  profileId,
+  newEmailRaw,
+  actorUserId,
+  reason,
+  appOrigin,
+  triggerZoomSync = true,
+}: ChangeEmailForProfileByAdminInput): Promise<ChangeEmailForProfileByAdminResult> {
+  const details: EmailChangeDetails = { stages: [] }
+  const pushStage = (stage: Omit<StageEntry, 'at'>) => {
+    details.stages.push({ ...stage, at: nowIso() })
+  }
+
+  let logId: string | null = null
+  let oldEmail = ''
+  let newEmail = normalizeEmail(newEmailRaw)
+  let userId: string | null = null
+  let authUpdated = false
+  let profileUpdated = false
+  let invitesUpdated = false
+  let inviteRowsUpdated = 0
+  let status: 'applied' | 'partial' | 'failed' = 'failed'
+  let impactedClassIds: string[] = []
+  let classSyncResults: ClassSyncResult[] = []
+
+  const syncLog = async (patch?: {
+    status?: EmailChangeStatus
+    zoomSyncStartedAt?: string | null
+    zoomSyncCompletedAt?: string | null
+  }) => {
+    if (!logId) return
+
+    await adminClient
+      .from('email_change_log' as any)
+      .update({
+        ...(patch?.status ? { status: patch.status } : {}),
+        auth_updated: authUpdated,
+        profile_updated: profileUpdated,
+        invites_updated: invitesUpdated,
+        invite_rows_updated: inviteRowsUpdated,
+        ...(patch?.zoomSyncStartedAt !== undefined
+          ? { zoom_sync_started_at: patch.zoomSyncStartedAt }
+          : {}),
+        ...(patch?.zoomSyncCompletedAt !== undefined
+          ? { zoom_sync_completed_at: patch.zoomSyncCompletedAt }
+          : {}),
+        details,
+      })
+      .eq('id', logId)
+  }
+
+  try {
+    const trimmedReason = reason.trim()
+    if (!newEmail) {
+      pushStage({ stage: 'validate', ok: false, error: 'Email is required.' })
+      throw new Error('Email is required.')
+    }
+    if (!isAllowedEmailDomain(newEmail)) {
+      pushStage({ stage: 'validate', ok: false, error: 'Email domain is not allowed.' })
+      throw new Error('Email domain is not allowed.')
+    }
+    if (!trimmedReason) {
+      pushStage({ stage: 'validate', ok: false, error: 'Reason is required.' })
+      throw new Error('Reason is required.')
+    }
+
+    const { data: profile, error: profileError } = await adminClient
+      .from('profile')
+      .select('id, user_id, role, email')
+      .eq('id', profileId)
+      .maybeSingle<ProfileRow>()
+
+    if (profileError || !profile?.id || !profile.email) {
+      pushStage({ stage: 'validate', ok: false, error: profileError?.message ?? 'Profile not found.' })
+      throw new Error(profileError?.message ?? 'Profile not found.')
+    }
+
+    oldEmail = normalizeEmail(profile.email)
+    userId = profile.user_id ?? null
+
+    const { data: logRow, error: logError } = await adminClient
+      .from('email_change_log' as any)
+      .insert({
+        profile_id: profile.id,
+        user_id: userId,
+        old_email: oldEmail,
+        new_email: newEmail,
+        changed_by: actorUserId,
+        reason: trimmedReason,
+        status: 'pending',
+        auth_updated: false,
+        profile_updated: false,
+        invites_updated: false,
+        invite_rows_updated: 0,
+        details,
+      })
+      .select('id')
+      .single<{ id: string }>()
+
+    if (logError || !logRow?.id) {
+      throw new Error(logError?.message ?? 'Unable to create email change log entry.')
+    }
+
+    logId = logRow.id
+
+    pushStage({
+      stage: 'validate',
+      ok: true,
+      message: 'Validated request and loaded profile.',
+      meta: { profileId, userId },
+    })
+    await syncLog()
+
+    if (oldEmail === newEmail) {
+      pushStage({
+        stage: 'finalize',
+        ok: true,
+        message: 'No-op: email already set to requested value.',
+        meta: { status: 'applied' },
+      })
+      status = 'applied'
+      await syncLog({ status })
+
+      return {
+        ok: true,
+        logId,
+        status,
+        profileId,
+        userId,
+        oldEmail,
+        newEmail,
+        authUpdated,
+        profileUpdated,
+        invitesUpdated,
+        inviteRowsUpdated,
+        classSync: {
+          attempted: false,
+          impactedClassIds: [],
+          results: [],
+        },
+        stages: details.stages,
+      }
+    }
+
+    const preflight = await preflightEmailChange({
+      profileId,
+      oldEmail,
+      newEmail,
+      userId,
+    })
+
+    if (!preflight.ok) {
+      details.preflight = preflight.conflict
+      pushStage({
+        stage: 'preflight',
+        ok: false,
+        error: preflight.error ?? 'Preflight checks failed.',
+        meta: preflight.conflict,
+      })
+      await syncLog({ status: 'failed' })
+      throw new Error(preflight.error ?? 'Preflight checks failed.')
+    }
+
+    pushStage({ stage: 'preflight', ok: true, message: 'Preflight checks passed.' })
+    await syncLog()
+
+    const authUpdate = await updateAuthEmailIfLinked({ userId, newEmail })
+    if (!authUpdate.ok) {
+      pushStage({ stage: 'auth_update', ok: false, error: authUpdate.error ?? 'Auth email update failed.' })
+      await syncLog({ status: 'failed' })
+      throw new Error(authUpdate.error ?? 'Auth email update failed.')
+    }
+
+    authUpdated = authUpdate.updated
+    pushStage({
+      stage: 'auth_update',
+      ok: true,
+      message: authUpdated ? 'Updated auth email.' : 'Skipped auth update (profile has no user_id).',
+    })
+    await syncLog()
+
+    const { error: profileUpdateError } = await adminClient
+      .from('profile')
+      .update({ email: newEmail })
+      .eq('id', profileId)
+
+    if (profileUpdateError) {
+      pushStage({ stage: 'profile_update', ok: false, error: profileUpdateError.message })
+      await syncLog({ status: authUpdated ? 'partial' : 'failed' })
+      throw new Error(profileUpdateError.message)
+    }
+
+    profileUpdated = true
+    pushStage({ stage: 'profile_update', ok: true, message: 'Updated profile email.' })
+    await syncLog()
+
+    const inviteUpdate = await migrateInviteEmails({
+      userId,
+      oldEmail,
+      newEmail,
+    })
+
+    if (!inviteUpdate.ok) {
+      pushStage({
+        stage: 'invite_migration',
+        ok: false,
+        error: inviteUpdate.error ?? 'Invite migration failed.',
+      })
+      await syncLog({ status: 'partial' })
+      throw new Error(inviteUpdate.error ?? 'Invite migration failed.')
+    }
+
+    invitesUpdated = inviteUpdate.updatedCount > 0
+    inviteRowsUpdated = inviteUpdate.updatedCount
+    details.inviteMigration = { updatedCount: inviteRowsUpdated }
+    pushStage({
+      stage: 'invite_migration',
+      ok: true,
+      message: 'Invite migration complete.',
+      meta: { updatedCount: inviteRowsUpdated },
+    })
+    await syncLog()
+
+    if (triggerZoomSync) {
+      await syncLog({ zoomSyncStartedAt: nowIso() })
+      impactedClassIds = await resolveImpactedClassIds({ profileId, role: profile.role ?? null })
+      classSyncResults = await syncImpactedClasses({ classIds: impactedClassIds, appOrigin })
+      details.zoom = {
+        impactedClassIds,
+        results: classSyncResults,
+      }
+      const failedClassSync = classSyncResults.filter(result => !result.ok).length
+      pushStage({
+        stage: 'zoom_sync',
+        ok: failedClassSync === 0,
+        message:
+          failedClassSync === 0
+            ? `Synced ${classSyncResults.length} impacted classes.`
+            : `Synced with ${failedClassSync} class sync failures.`,
+        meta: {
+          impactedClasses: impactedClassIds.length,
+          failedClassSync,
+        },
+      })
+      await syncLog({ zoomSyncCompletedAt: nowIso() })
+    } else {
+      pushStage({ stage: 'zoom_sync', ok: true, message: 'Zoom sync skipped by request.' })
+      await syncLog()
+    }
+
+    const hasClassSyncFailures = classSyncResults.some(result => !result.ok)
+    status = hasClassSyncFailures ? 'partial' : 'applied'
+    pushStage({
+      stage: 'finalize',
+      ok: true,
+      message: status === 'applied' ? 'Email change applied.' : 'Email change applied with follow-up needed.',
+      meta: { status },
+    })
+    await syncLog({ status })
+
+    return {
+      ok: true,
+      logId,
+      status,
+      profileId,
+      userId,
+      oldEmail,
+      newEmail,
+      authUpdated,
+      profileUpdated,
+      invitesUpdated,
+      inviteRowsUpdated,
+      classSync: {
+        attempted: triggerZoomSync,
+        impactedClassIds,
+        results: classSyncResults,
+      },
+      stages: details.stages,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected email change error.'
+
+    if (authUpdated && !profileUpdated && userId && oldEmail) {
+      details.compensation = {
+        ...(details.compensation ?? {}),
+        attemptedAuthRevert: true,
+      }
+
+      const { error: authRevertError } = await adminClient.auth.admin.updateUserById(userId, {
+        email: oldEmail,
+        email_confirm: true,
+      })
+
+      if (authRevertError) {
+        details.compensation = {
+          ...(details.compensation ?? {}),
+          attemptedAuthRevert: true,
+          authRevertOk: false,
+          authRevertError: authRevertError.message,
+        }
+      } else {
+        authUpdated = false
+        details.compensation = {
+          ...(details.compensation ?? {}),
+          attemptedAuthRevert: true,
+          authRevertOk: true,
+        }
+      }
+    }
+
+    if (!details.stages.some(entry => entry.stage === 'finalize')) {
+      pushStage({
+        stage: 'finalize',
+        ok: false,
+        error: message,
+      })
+    }
+
+    status = authUpdated || profileUpdated || invitesUpdated ? 'partial' : 'failed'
+    await syncLog({ status })
+
+    return {
+      ok: false,
+      error: message,
+      logId,
+      status,
+      profileId,
+      userId,
+      oldEmail,
+      newEmail,
+      authUpdated,
+      profileUpdated,
+      invitesUpdated,
+      inviteRowsUpdated,
+      classSync: {
+        attempted: triggerZoomSync,
+        impactedClassIds,
+        results: classSyncResults,
+      },
+      stages: details.stages,
+    }
+  }
+}

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useFetcher, useLocation, useOutletContext } from 'react-router'
+import { Check, Pencil, X } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Combobox } from '@/components/ui/combobox'
@@ -39,15 +40,12 @@ export default function ManagePersonOverviewPage() {
       }
     }
   }>()
-  const [selectedRiding, setSelectedRiding] = useState(profile.federal_electoral_district_name ?? '')
   const [giftcardValue, setGiftcardValue] = useState(familyFormAnswers.giftcard_display === 'N/A' ? '' : familyFormAnswers.giftcard_display)
   const [nextEmail, setNextEmail] = useState(profile.email ?? '')
   const [emailChangeReason, setEmailChangeReason] = useState('')
-  const [isProfileEditOpen, setIsProfileEditOpen] = useState(false)
-
-  useEffect(() => {
-    setSelectedRiding(profile.federal_electoral_district_name ?? '')
-  }, [profile.federal_electoral_district_name, profile.id])
+  const [isEditingEmail, setIsEditingEmail] = useState(false)
+  const [ridingDraft, setRidingDraft] = useState(profile.federal_electoral_district_name ?? '')
+  const [isEditingRiding, setIsEditingRiding] = useState(false)
 
   const familyProfileById = new Map(familyProfiles.map(item => [item.id, item]))
 
@@ -87,14 +85,23 @@ export default function ManagePersonOverviewPage() {
 
   useEffect(() => {
     setNextEmail(profile.email ?? '')
-    setIsProfileEditOpen(false)
+    setRidingDraft(profile.federal_electoral_district_name ?? '')
+    setIsEditingEmail(false)
+    setIsEditingRiding(false)
   }, [profile.email, profile.id])
 
   useEffect(() => {
     if (emailChangeFetcher.state !== 'idle') return
     if (!emailChangeFetcher.data?.success) return
     setEmailChangeReason('')
+    setIsEditingEmail(false)
   }, [emailChangeFetcher.data, emailChangeFetcher.state])
+
+  useEffect(() => {
+    if (selectedRidingFetcher.state !== 'idle') return
+    if (!selectedRidingFetcher.data?.success) return
+    setIsEditingRiding(false)
+  }, [selectedRidingFetcher.data, selectedRidingFetcher.state])
 
   const isChangingEmail = emailChangeFetcher.state !== 'idle'
 
@@ -107,85 +114,134 @@ export default function ManagePersonOverviewPage() {
           <div className="grid gap-2">
             <p><span className="font-medium">Name:</span> {profileLabel(profile)}</p>
             <p><span className="font-medium">Role:</span> {profile.role ?? '-'}</p>
-              <p><span className="font-medium">Email:</span> {profile.email ?? '-'}</p>
-              <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
-              <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
-              <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
-              <div>
-                <Button type="button" size="sm" variant="outline" onClick={() => setIsProfileEditOpen(open => !open)}>
-                  {isProfileEditOpen ? 'Close profile edit' : 'Open profile edit'}
-                </Button>
-              </div>
-              {isProfileEditOpen ? (
-                <div className="rounded border border-slate-200 bg-white/80 p-2">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Profile edit</p>
-                  {viewerRole === 'admin' ? <div className="mt-2 rounded border border-slate-200 bg-white p-2">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Admin email change</p>
-                    <emailChangeFetcher.Form
-                      method="post"
-                      action={`/manage/person${location.search}`}
-                      className="mt-2 grid gap-2"
-                    >
-                      <input type="hidden" name="intent" value="change-email-by-admin" />
-                      <input type="hidden" name="profile_id" value={profile.id} />
-                      <input type="hidden" name="trigger_zoom_sync" value="1" />
+            {viewerRole === 'admin' ? (
+              <emailChangeFetcher.Form method="post" action={`/manage/person${location.search}`} className="grid gap-1">
+                <input type="hidden" name="intent" value="change-email-by-admin" />
+                <input type="hidden" name="profile_id" value={profile.id} />
+                <input type="hidden" name="trigger_zoom_sync" value="1" />
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium">Email:</span>
+                  {isEditingEmail ? (
+                    <>
                       <input
                         type="email"
                         name="new_email"
                         value={nextEmail}
                         onChange={event => setNextEmail(event.target.value)}
-                        className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-                        placeholder="name@gmail.com"
+                        className="h-8 min-w-[220px] rounded-md border border-input bg-background px-2 text-sm"
                         required
                         disabled={isChangingEmail}
                       />
-                      <textarea
-                        name="reason"
-                        value={emailChangeReason}
-                        onChange={event => setEmailChangeReason(event.target.value)}
-                        rows={2}
-                        className="rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        placeholder="Reason for changing this email"
-                        required
-                        disabled={isChangingEmail}
-                      />
-                      <Button type="submit" size="sm" variant="outline" disabled={isChangingEmail}>
-                        {isChangingEmail ? 'Applying email change...' : 'Change email and re-sync Zoom'}
+                      <Button type="submit" size="icon-xs" variant="outline" disabled={isChangingEmail} aria-label="Save email">
+                        <Check />
                       </Button>
-                    </emailChangeFetcher.Form>
-                    {emailChangeFetcher.data?.error ? (
-                      <p className="mt-2 text-xs text-destructive">{emailChangeFetcher.data.error}</p>
-                    ) : null}
-                    {emailChangeFetcher.data?.success && emailChangeFetcher.data.result ? (
-                      <p className="mt-2 text-xs text-emerald-700">
-                        Updated {emailChangeFetcher.data.result.oldEmail} to {emailChangeFetcher.data.result.newEmail}. status=
-                        {emailChangeFetcher.data.result.status}; invites={emailChangeFetcher.data.result.inviteRowsUpdated}; classSync=
-                        {emailChangeFetcher.data.result.classSync.results.filter(entry => entry.ok).length}/
-                        {emailChangeFetcher.data.result.classSync.results.length}; log=
-                        {emailChangeFetcher.data.result.logId ?? 'n/a'}
-                      </p>
-                    ) : null}
-                  </div> : null}
-                  <selectedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="mt-2 flex flex-wrap items-center gap-2">
-                <input type="hidden" name="intent" value="update-riding" />
-                <input type="hidden" name="profile_id" value={profile.id} />
-                <input type="hidden" name="riding_name" value={selectedRiding} />
-                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Riding</span>
-                <Combobox
-                  value={selectedRiding}
-                  onChange={setSelectedRiding}
-                  options={[{ value: '', label: 'Unassigned' }, ...federalDistrictOptions]}
-                  placeholder="Select riding"
-                  disabled={selectedRidingFetcher.state !== 'idle'}
-                />
-                <Button type="submit" size="sm" variant="outline" disabled={selectedRidingFetcher.state !== 'idle'}>
-                  {selectedRidingFetcher.state !== 'idle' ? 'Saving...' : 'Save riding'}
-                </Button>
-                {selectedRidingFetcher.data?.error ? <p className="basis-full text-xs text-destructive">{selectedRidingFetcher.data.error}</p> : null}
-                {selectedRidingFetcher.data?.success ? <p className="basis-full text-xs text-emerald-600">Riding updated.</p> : null}
-              </selectedRidingFetcher.Form>
+                      <Button
+                        type="button"
+                        size="icon-xs"
+                        variant="outline"
+                        onClick={() => {
+                          setIsEditingEmail(false)
+                          setNextEmail(profile.email ?? '')
+                          setEmailChangeReason('')
+                        }}
+                        disabled={isChangingEmail}
+                        aria-label="Cancel email edit"
+                      >
+                        <X />
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <span>{profile.email ?? '-'}</span>
+                      <Button type="button" size="icon-xs" variant="ghost" onClick={() => setIsEditingEmail(true)} aria-label="Edit email">
+                        <Pencil />
+                      </Button>
+                    </>
+                  )}
                 </div>
-              ) : null}
+                {isEditingEmail ? (
+                  <input
+                    type="text"
+                    name="reason"
+                    value={emailChangeReason}
+                    onChange={event => setEmailChangeReason(event.target.value)}
+                    className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                    placeholder="Reason for changing this email"
+                    required
+                    disabled={isChangingEmail}
+                  />
+                ) : null}
+                {emailChangeFetcher.data?.error ? (
+                  <p className="text-xs text-destructive">{emailChangeFetcher.data.error}</p>
+                ) : null}
+                {emailChangeFetcher.data?.success && emailChangeFetcher.data.result ? (
+                  <p className="text-xs text-emerald-700">
+                    Updated {emailChangeFetcher.data.result.oldEmail} to {emailChangeFetcher.data.result.newEmail}. status=
+                    {emailChangeFetcher.data.result.status}; invites={emailChangeFetcher.data.result.inviteRowsUpdated}; classSync=
+                    {emailChangeFetcher.data.result.classSync.results.filter(entry => entry.ok).length}/
+                    {emailChangeFetcher.data.result.classSync.results.length}; log=
+                    {emailChangeFetcher.data.result.logId ?? 'n/a'}
+                  </p>
+                ) : null}
+              </emailChangeFetcher.Form>
+            ) : (
+              <p><span className="font-medium">Email:</span> {profile.email ?? '-'}</p>
+            )}
+            <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
+            <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
+            <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
+            <selectedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="grid gap-1">
+              <input type="hidden" name="intent" value="update-riding" />
+              <input type="hidden" name="profile_id" value={profile.id} />
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium">Riding:</span>
+                {isEditingRiding ? (
+                  <>
+                    <input
+                      type="text"
+                      name="riding_name"
+                      value={ridingDraft}
+                      onChange={event => setRidingDraft(event.target.value)}
+                      className="h-8 min-w-[220px] rounded-md border border-input bg-background px-2 text-sm"
+                      list="riding-options"
+                      placeholder="Unassigned"
+                      disabled={selectedRidingFetcher.state !== 'idle'}
+                    />
+                    <Button type="submit" size="icon-xs" variant="outline" disabled={selectedRidingFetcher.state !== 'idle'} aria-label="Save riding">
+                      <Check />
+                    </Button>
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="outline"
+                      onClick={() => {
+                        setIsEditingRiding(false)
+                        setRidingDraft(profile.federal_electoral_district_name ?? '')
+                      }}
+                      disabled={selectedRidingFetcher.state !== 'idle'}
+                      aria-label="Cancel riding edit"
+                    >
+                      <X />
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <span>{profile.federal_electoral_district_name || 'Unassigned'}</span>
+                    <input type="hidden" name="riding_name" value={profile.federal_electoral_district_name ?? ''} />
+                    <Button type="button" size="icon-xs" variant="ghost" onClick={() => setIsEditingRiding(true)} aria-label="Edit riding">
+                      <Pencil />
+                    </Button>
+                  </>
+                )}
+              </div>
+              <datalist id="riding-options">
+                {federalDistrictOptions.map(option => (
+                  <option key={option.value} value={option.value} />
+                ))}
+              </datalist>
+              {selectedRidingFetcher.data?.error ? <p className="text-xs text-destructive">{selectedRidingFetcher.data.error}</p> : null}
+              {selectedRidingFetcher.data?.success ? <p className="text-xs text-emerald-600">Riding updated.</p> : null}
+            </selectedRidingFetcher.Form>
           </div>
         </div>
 

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -43,6 +43,7 @@ export default function ManagePersonOverviewPage() {
   const [giftcardValue, setGiftcardValue] = useState(familyFormAnswers.giftcard_display === 'N/A' ? '' : familyFormAnswers.giftcard_display)
   const [nextEmail, setNextEmail] = useState(profile.email ?? '')
   const [emailChangeReason, setEmailChangeReason] = useState('')
+  const [isProfileEditOpen, setIsProfileEditOpen] = useState(false)
 
   useEffect(() => {
     setSelectedRiding(profile.federal_electoral_district_name ?? '')
@@ -86,6 +87,7 @@ export default function ManagePersonOverviewPage() {
 
   useEffect(() => {
     setNextEmail(profile.email ?? '')
+    setIsProfileEditOpen(false)
   }, [profile.email, profile.id])
 
   useEffect(() => {
@@ -109,55 +111,62 @@ export default function ManagePersonOverviewPage() {
               <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
               <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
               <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
-              {viewerRole === 'admin' ? <div className="rounded border border-slate-200 bg-white/80 p-2">
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Admin email change</p>
-                <emailChangeFetcher.Form
-                  method="post"
-                  action={`/manage/person${location.search}`}
-                  className="mt-2 grid gap-2"
-                >
-                  <input type="hidden" name="intent" value="change-email-by-admin" />
-                  <input type="hidden" name="profile_id" value={profile.id} />
-                  <input type="hidden" name="trigger_zoom_sync" value="1" />
-                  <input
-                    type="email"
-                    name="new_email"
-                    value={nextEmail}
-                    onChange={event => setNextEmail(event.target.value)}
-                    className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-                    placeholder="name@gmail.com"
-                    required
-                    disabled={isChangingEmail}
-                  />
-                  <textarea
-                    name="reason"
-                    value={emailChangeReason}
-                    onChange={event => setEmailChangeReason(event.target.value)}
-                    rows={2}
-                    className="rounded-md border border-input bg-background px-3 py-2 text-sm"
-                    placeholder="Reason for changing this email"
-                    required
-                    disabled={isChangingEmail}
-                  />
-                  <Button type="submit" size="sm" variant="outline" disabled={isChangingEmail}>
-                    {isChangingEmail ? 'Applying email change...' : 'Change email and re-sync Zoom'}
-                  </Button>
-                </emailChangeFetcher.Form>
-                {emailChangeFetcher.data?.error ? (
-                  <p className="mt-2 text-xs text-destructive">{emailChangeFetcher.data.error}</p>
-                ) : null}
-                {emailChangeFetcher.data?.success && emailChangeFetcher.data.result ? (
-                  <p className="mt-2 text-xs text-emerald-700">
-                    Updated {emailChangeFetcher.data.result.oldEmail} to {emailChangeFetcher.data.result.newEmail}. status=
-                    {emailChangeFetcher.data.result.status}; invites={emailChangeFetcher.data.result.inviteRowsUpdated}; classSync=
-                    {emailChangeFetcher.data.result.classSync.results.filter(entry => entry.ok).length}/
-                    {emailChangeFetcher.data.result.classSync.results.length}; log=
-                    {emailChangeFetcher.data.result.logId ?? 'n/a'}
-                  </p>
-                ) : null}
-              </div> : null}
               <div>
-                <selectedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="flex flex-wrap items-center gap-2">
+                <Button type="button" size="sm" variant="outline" onClick={() => setIsProfileEditOpen(open => !open)}>
+                  {isProfileEditOpen ? 'Close profile edit' : 'Open profile edit'}
+                </Button>
+              </div>
+              {isProfileEditOpen ? (
+                <div className="rounded border border-slate-200 bg-white/80 p-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Profile edit</p>
+                  {viewerRole === 'admin' ? <div className="mt-2 rounded border border-slate-200 bg-white p-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Admin email change</p>
+                    <emailChangeFetcher.Form
+                      method="post"
+                      action={`/manage/person${location.search}`}
+                      className="mt-2 grid gap-2"
+                    >
+                      <input type="hidden" name="intent" value="change-email-by-admin" />
+                      <input type="hidden" name="profile_id" value={profile.id} />
+                      <input type="hidden" name="trigger_zoom_sync" value="1" />
+                      <input
+                        type="email"
+                        name="new_email"
+                        value={nextEmail}
+                        onChange={event => setNextEmail(event.target.value)}
+                        className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                        placeholder="name@gmail.com"
+                        required
+                        disabled={isChangingEmail}
+                      />
+                      <textarea
+                        name="reason"
+                        value={emailChangeReason}
+                        onChange={event => setEmailChangeReason(event.target.value)}
+                        rows={2}
+                        className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        placeholder="Reason for changing this email"
+                        required
+                        disabled={isChangingEmail}
+                      />
+                      <Button type="submit" size="sm" variant="outline" disabled={isChangingEmail}>
+                        {isChangingEmail ? 'Applying email change...' : 'Change email and re-sync Zoom'}
+                      </Button>
+                    </emailChangeFetcher.Form>
+                    {emailChangeFetcher.data?.error ? (
+                      <p className="mt-2 text-xs text-destructive">{emailChangeFetcher.data.error}</p>
+                    ) : null}
+                    {emailChangeFetcher.data?.success && emailChangeFetcher.data.result ? (
+                      <p className="mt-2 text-xs text-emerald-700">
+                        Updated {emailChangeFetcher.data.result.oldEmail} to {emailChangeFetcher.data.result.newEmail}. status=
+                        {emailChangeFetcher.data.result.status}; invites={emailChangeFetcher.data.result.inviteRowsUpdated}; classSync=
+                        {emailChangeFetcher.data.result.classSync.results.filter(entry => entry.ok).length}/
+                        {emailChangeFetcher.data.result.classSync.results.length}; log=
+                        {emailChangeFetcher.data.result.logId ?? 'n/a'}
+                      </p>
+                    ) : null}
+                  </div> : null}
+                  <selectedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="mt-2 flex flex-wrap items-center gap-2">
                 <input type="hidden" name="intent" value="update-riding" />
                 <input type="hidden" name="profile_id" value={profile.id} />
                 <input type="hidden" name="riding_name" value={selectedRiding} />
@@ -175,7 +184,8 @@ export default function ManagePersonOverviewPage() {
                 {selectedRidingFetcher.data?.error ? <p className="basis-full text-xs text-destructive">{selectedRidingFetcher.data.error}</p> : null}
                 {selectedRidingFetcher.data?.success ? <p className="basis-full text-xs text-emerald-600">Riding updated.</p> : null}
               </selectedRidingFetcher.Form>
-            </div>
+                </div>
+              ) : null}
           </div>
         </div>
 

--- a/web/app/routes/manage/person.overview.tsx
+++ b/web/app/routes/manage/person.overview.tsx
@@ -18,13 +18,31 @@ const geoStatusLabel: Record<PersonLoaderData['ipEvidence'][number]['geo_status'
 }
 
 export default function ManagePersonOverviewPage() {
-  const { profile, ipEvidence, familyProfiles, primaryChildByGuardian, federalDistrictOptions, familyFormAnswers } = useOutletContext<PersonLoaderData>()
+  const { viewerRole, profile, ipEvidence, familyProfiles, primaryChildByGuardian, federalDistrictOptions, familyFormAnswers } = useOutletContext<PersonLoaderData>()
   const location = useLocation()
   const selectedRidingFetcher = useFetcher<{ error?: string; success?: boolean }>()
   const relatedRidingFetcher = useFetcher<{ error?: string; success?: boolean }>()
   const familyAnswerFetcher = useFetcher<{ error?: string; success?: boolean }>()
+  const emailChangeFetcher = useFetcher<{
+    error?: string
+    success?: boolean
+    result?: {
+      logId: string | null
+      oldEmail: string
+      newEmail: string
+      status: 'applied' | 'partial' | 'failed'
+      inviteRowsUpdated: number
+      classSync: {
+        attempted: boolean
+        impactedClassIds: string[]
+        results: Array<{ classId: string; ok: boolean }>
+      }
+    }
+  }>()
   const [selectedRiding, setSelectedRiding] = useState(profile.federal_electoral_district_name ?? '')
   const [giftcardValue, setGiftcardValue] = useState(familyFormAnswers.giftcard_display === 'N/A' ? '' : familyFormAnswers.giftcard_display)
+  const [nextEmail, setNextEmail] = useState(profile.email ?? '')
+  const [emailChangeReason, setEmailChangeReason] = useState('')
 
   useEffect(() => {
     setSelectedRiding(profile.federal_electoral_district_name ?? '')
@@ -66,6 +84,18 @@ export default function ManagePersonOverviewPage() {
     setGiftcardValue(familyFormAnswers.giftcard_display === 'N/A' ? '' : familyFormAnswers.giftcard_display)
   }, [familyFormAnswers.giftcard_display, profile.id])
 
+  useEffect(() => {
+    setNextEmail(profile.email ?? '')
+  }, [profile.email, profile.id])
+
+  useEffect(() => {
+    if (emailChangeFetcher.state !== 'idle') return
+    if (!emailChangeFetcher.data?.success) return
+    setEmailChangeReason('')
+  }, [emailChangeFetcher.data, emailChangeFetcher.state])
+
+  const isChangingEmail = emailChangeFetcher.state !== 'idle'
+
   return (
     <section className="rounded-lg border bg-card p-4">
       <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Personal information</h2>
@@ -75,12 +105,59 @@ export default function ManagePersonOverviewPage() {
           <div className="grid gap-2">
             <p><span className="font-medium">Name:</span> {profileLabel(profile)}</p>
             <p><span className="font-medium">Role:</span> {profile.role ?? '-'}</p>
-            <p><span className="font-medium">Email:</span> {profile.email ?? '-'}</p>
-            <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
-            <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
-            <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
-            <div>
-              <selectedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="flex flex-wrap items-center gap-2">
+              <p><span className="font-medium">Email:</span> {profile.email ?? '-'}</p>
+              <p><span className="font-medium">Phone:</span> {profile.phone ?? '-'}</p>
+              <p><span className="font-medium">DOB:</span> {formatDate(profile.date_of_birth)}</p>
+              <p><span className="font-medium">Address:</span> {profileAddress || '-'}</p>
+              {viewerRole === 'admin' ? <div className="rounded border border-slate-200 bg-white/80 p-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Admin email change</p>
+                <emailChangeFetcher.Form
+                  method="post"
+                  action={`/manage/person${location.search}`}
+                  className="mt-2 grid gap-2"
+                >
+                  <input type="hidden" name="intent" value="change-email-by-admin" />
+                  <input type="hidden" name="profile_id" value={profile.id} />
+                  <input type="hidden" name="trigger_zoom_sync" value="1" />
+                  <input
+                    type="email"
+                    name="new_email"
+                    value={nextEmail}
+                    onChange={event => setNextEmail(event.target.value)}
+                    className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                    placeholder="name@gmail.com"
+                    required
+                    disabled={isChangingEmail}
+                  />
+                  <textarea
+                    name="reason"
+                    value={emailChangeReason}
+                    onChange={event => setEmailChangeReason(event.target.value)}
+                    rows={2}
+                    className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    placeholder="Reason for changing this email"
+                    required
+                    disabled={isChangingEmail}
+                  />
+                  <Button type="submit" size="sm" variant="outline" disabled={isChangingEmail}>
+                    {isChangingEmail ? 'Applying email change...' : 'Change email and re-sync Zoom'}
+                  </Button>
+                </emailChangeFetcher.Form>
+                {emailChangeFetcher.data?.error ? (
+                  <p className="mt-2 text-xs text-destructive">{emailChangeFetcher.data.error}</p>
+                ) : null}
+                {emailChangeFetcher.data?.success && emailChangeFetcher.data.result ? (
+                  <p className="mt-2 text-xs text-emerald-700">
+                    Updated {emailChangeFetcher.data.result.oldEmail} to {emailChangeFetcher.data.result.newEmail}. status=
+                    {emailChangeFetcher.data.result.status}; invites={emailChangeFetcher.data.result.inviteRowsUpdated}; classSync=
+                    {emailChangeFetcher.data.result.classSync.results.filter(entry => entry.ok).length}/
+                    {emailChangeFetcher.data.result.classSync.results.length}; log=
+                    {emailChangeFetcher.data.result.logId ?? 'n/a'}
+                  </p>
+                ) : null}
+              </div> : null}
+              <div>
+                <selectedRidingFetcher.Form method="post" action={`/manage/person${location.search}`} className="flex flex-wrap items-center gap-2">
                 <input type="hidden" name="intent" value="update-riding" />
                 <input type="hidden" name="profile_id" value={profile.id} />
                 <input type="hidden" name="riding_name" value={selectedRiding} />

--- a/web/app/routes/manage/person.shared.ts
+++ b/web/app/routes/manage/person.shared.ts
@@ -36,6 +36,7 @@ export type SuspiciousSignalRow = {
 }
 
 export type PersonLoaderData = {
+  viewerRole: string | null
   profile: ProfileRow
   activityEvents: Array<{
     source: 'form_submission' | 'login_event'

--- a/web/app/routes/manage/person.tsx
+++ b/web/app/routes/manage/person.tsx
@@ -8,6 +8,7 @@ import { runIpEvidenceRecompute } from '@/lib/ip-evidence-recompute.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { refreshSuspiciousSignalsForProfile } from '@/lib/suspicious-signals.server'
 import { adminClient } from '@/lib/supabase/adminClient'
+import { changeEmailForProfileByAdmin } from '@/lib/admin/email-change.server'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
@@ -522,6 +523,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
 
   return {
+    viewerRole: auth.claims.role,
     profile: profileRow as ProfileRow,
     activityEvents,
     ipEvidence,
@@ -548,8 +550,57 @@ export async function action({ request }: LoaderFunctionArgs) {
 
   const formData = await request.formData()
   const intent = String(formData.get('intent') ?? '')
-  if (intent !== 'update-riding' && intent !== 'rescan-family' && intent !== 'update-family-form-answer') {
+  if (
+    intent !== 'update-riding' &&
+    intent !== 'rescan-family' &&
+    intent !== 'update-family-form-answer' &&
+    intent !== 'change-email-by-admin'
+  ) {
     return new Response('Unsupported action', { status: 400, headers: auth.headers })
+  }
+
+  if (intent === 'change-email-by-admin') {
+    if (auth.claims.role !== 'admin') {
+      return new Response('Unauthorized', { status: 403, headers: auth.headers })
+    }
+
+    const profileId = String(formData.get('profile_id') ?? '').trim()
+    const newEmail = String(formData.get('new_email') ?? '').trim()
+    const reason = String(formData.get('reason') ?? '').trim()
+    const triggerZoomSync = String(formData.get('trigger_zoom_sync') ?? '1') !== '0'
+
+    if (!profileId) {
+      return { error: 'Missing profile id.' }
+    }
+    if (!newEmail) {
+      return { error: 'New email is required.' }
+    }
+    if (!reason) {
+      return { error: 'Reason is required.' }
+    }
+
+    const appOrigin = new URL(request.url).origin
+    const result = await changeEmailForProfileByAdmin({
+      profileId,
+      newEmailRaw: newEmail,
+      actorUserId: auth.user.id,
+      reason,
+      appOrigin,
+      triggerZoomSync,
+    })
+
+    if (!result.ok) {
+      return {
+        success: false,
+        error: result.error ?? 'Email change failed.',
+        result,
+      }
+    }
+
+    return {
+      success: true,
+      result,
+    }
   }
 
   if (intent === 'update-family-form-answer') {

--- a/web/tests/e2e/admin-email-change.spec.ts
+++ b/web/tests/e2e/admin-email-change.spec.ts
@@ -1,0 +1,260 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  ensureReusableAdminAccount,
+  getAdminSupabaseClient,
+  hasAdminServiceEnv,
+  loginAsAdmin,
+} from './helpers/admin-account'
+import { uniqueSuffix } from './helpers/ids'
+
+const findAuthUserByEmail = async (email: string) => {
+  const adminSupabase = getAdminSupabaseClient()
+  let page = 1
+
+  while (true) {
+    const { data, error } = await adminSupabase.auth.admin.listUsers({ page, perPage: 200 })
+    if (error) throw new Error(error.message)
+
+    const users = data?.users ?? []
+    const found = users.find(user => (user.email ?? '').toLowerCase() === email.toLowerCase())
+    if (found) return found
+
+    if (users.length < 200) break
+    page += 1
+  }
+
+  return null
+}
+
+const ensureRoleAccount = async ({
+  email,
+  password,
+  role,
+  firstname,
+  surname,
+}: {
+  email: string
+  password: string
+  role: 'staff' | 'admin'
+  firstname: string
+  surname: string
+}) => {
+  const adminSupabase = getAdminSupabaseClient()
+  let user = await findAuthUserByEmail(email)
+
+  if (!user) {
+    const { data, error } = await adminSupabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { role },
+    })
+
+    if (error) {
+      const existing = await findAuthUserByEmail(email)
+      if (!existing) throw new Error(error.message)
+      user = existing
+    } else {
+      user = data.user
+    }
+  }
+
+  if (!user?.id) {
+    throw new Error('Failed to create or resolve role account user.')
+  }
+
+  const { error: normalizeUserError } = await adminSupabase.auth.admin.updateUserById(user.id, {
+    password,
+    email_confirm: true,
+    user_metadata: {
+      ...(user.user_metadata ?? {}),
+      role,
+    },
+  })
+
+  if (normalizeUserError) {
+    throw new Error(normalizeUserError.message)
+  }
+
+  const { data: profileRow, error: profileError } = await adminSupabase
+    .from('profile')
+    .upsert(
+      {
+        user_id: user.id,
+        role,
+        email,
+        firstname,
+        surname,
+        password_set: true,
+      },
+      { onConflict: 'email' }
+    )
+    .select('id')
+    .single()
+
+  if (profileError || !profileRow?.id) {
+    throw new Error(profileError?.message ?? 'Failed to upsert role profile')
+  }
+
+  const { error: roleError } = await adminSupabase
+    .from('user_roles')
+    .upsert({ user_id: user.id, role, assigned_by: user.id }, { onConflict: 'user_id' })
+
+  if (roleError) {
+    throw new Error(roleError.message)
+  }
+
+  return {
+    userId: user.id,
+    profileId: profileRow.id,
+  }
+}
+
+const loginAsRole = async (page: import('@playwright/test').Page, email: string, password: string) => {
+  await page.context().clearCookies()
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password').fill(password)
+  await page.getByRole('button', { name: 'Login' }).click()
+  await expect(page).toHaveURL(/\/(manage|home)/)
+}
+
+test.describe.serial('admin email change controls', () => {
+  test.skip(!hasAdminServiceEnv(), 'Requires SUPABASE_URL and SUPABASE_SECRET_KEY for admin setup')
+
+  let adminProfileId = ''
+  let staffProfileId = ''
+  const staffEmail = `sai+staff-${uniqueSuffix()}@chsolutions.ca`
+  const staffPassword = 'Password123456!'
+
+  test.beforeAll(async () => {
+    await ensureReusableAdminAccount()
+    const adminAccount = await ensureRoleAccount({
+      email: ADMIN_EMAIL,
+      password: ADMIN_PASSWORD,
+      role: 'admin',
+      firstname: 'Sai',
+      surname: 'Tests Admin',
+    })
+    adminProfileId = adminAccount.profileId
+
+    const staffAccount = await ensureRoleAccount({
+      email: staffEmail,
+      password: staffPassword,
+      role: 'staff',
+      firstname: 'Staff',
+      surname: 'Email Guard',
+    })
+    staffProfileId = staffAccount.profileId
+  })
+
+  test('logs a no-op admin email change attempt as applied', async ({ page }) => {
+    const adminSupabase = getAdminSupabaseClient()
+
+    const { data: beforeRow, error: beforeError } = await adminSupabase
+      .from('email_change_log')
+      .select('id, created_at')
+      .eq('profile_id', adminProfileId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (beforeError) {
+      throw new Error(beforeError.message)
+    }
+
+    await loginAsAdmin(page)
+    const response = await page.request.post(`/manage/person?profileId=${adminProfileId}`, {
+      form: {
+        intent: 'change-email-by-admin',
+        profile_id: adminProfileId,
+        new_email: ADMIN_EMAIL,
+        reason: 'No-op audit verification for unchanged email',
+        trigger_zoom_sync: '1',
+      },
+    })
+
+    expect(response.ok()).toBeTruthy()
+
+    await expect
+      .poll(async () => {
+        const { data } = await adminSupabase
+          .from('email_change_log')
+          .select('id, created_at')
+          .eq('profile_id', adminProfileId)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle()
+
+        if (!data?.id) return false
+        if (!beforeRow?.id) return true
+        return data.id !== beforeRow.id
+      })
+      .toBeTruthy()
+
+    const { data: row, error } = await adminSupabase
+      .from('email_change_log')
+      .select('status, old_email, new_email, auth_updated, profile_updated, invites_updated, details')
+      .eq('profile_id', adminProfileId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (error || !row) {
+      throw new Error(error?.message ?? 'Expected a recent email_change_log row for no-op attempt')
+    }
+
+    expect(row.status).toBe('applied')
+    expect(row.old_email).toBe(ADMIN_EMAIL.toLowerCase())
+    expect(row.new_email).toBe(ADMIN_EMAIL.toLowerCase())
+    expect(row.auth_updated).toBeFalsy()
+    expect(row.profile_updated).toBeFalsy()
+    expect(row.invites_updated).toBeFalsy()
+
+    const stages = Array.isArray((row.details as { stages?: unknown[] })?.stages)
+      ? ((row.details as { stages: Array<{ stage?: string; message?: string }> }).stages ?? [])
+      : []
+
+    const finalize = stages.find(stage => stage.stage === 'finalize')
+    expect(finalize?.message ?? '').toContain('No-op')
+  })
+
+  test('hides admin email form for non-admin and rejects direct post', async ({ page }) => {
+    const adminSupabase = getAdminSupabaseClient()
+    const rejectionReason = `Non-admin rejection verification ${uniqueSuffix()}`
+
+    await loginAsRole(page, staffEmail, staffPassword)
+    await page.goto(`/manage/person?profileId=${staffProfileId}`)
+
+    await expect(page.getByText('Admin email change')).toHaveCount(0)
+
+    const response = await page.request.post(`/manage/person?profileId=${staffProfileId}`, {
+      maxRedirects: 0,
+      form: {
+        intent: 'change-email-by-admin',
+        profile_id: staffProfileId,
+        new_email: `sai+staff-updated-${uniqueSuffix()}@chsolutions.ca`,
+        reason: rejectionReason,
+        trigger_zoom_sync: '1',
+      },
+    })
+
+    expect([302, 303, 403]).toContain(response.status())
+
+    const { data: logRow, error: logError } = await adminSupabase
+      .from('email_change_log')
+      .select('id')
+      .eq('profile_id', staffProfileId)
+      .eq('reason', rejectionReason)
+      .maybeSingle()
+
+    if (logError) {
+      throw new Error(logError.message)
+    }
+
+    expect(logRow).toBeNull()
+  })
+})


### PR DESCRIPTION
## What
- add admin email change service with staged logging and zoom re-sync hooks
- add `email_change_log` schema + migrations
- wire manage person action for `change-email-by-admin` with admin-only guard
- add manage person overview inline edit controls (pen -> check/x) for email and riding
- add focused e2e coverage for no-op logging and non-admin rejection behavior

## Verification
- npm run typecheck
- npm run test:e2e -- tests/e2e/admin-email-change.spec.ts --grep "admin email change controls"