### PR TITLE
Reduce scheduler duplicate email contention

### DIFF
--- a/supabase/migrations/20260708193000_gift_card_runner_scale_indexes.sql
+++ b/supabase/migrations/20260708193000_gift_card_runner_scale_indexes.sql
@@ -1,0 +1,7 @@
+begin;
+
+create index if not exists gift_card_allocation_allocated_unsent_idx
+  on public.gift_card_allocation (status, reminder_sent_at, id)
+  where status = 'allocated' and reminder_sent_at is null;
+
+commit;

--- a/web/app/lib/email/send-email.server.ts
+++ b/web/app/lib/email/send-email.server.ts
@@ -111,6 +111,19 @@ export const sendTransactionalEmail = async ({
 }: SendTransactionalEmailArgs): Promise<SendTransactionalEmailResult> => {
   const normalizedEmail = toEmail.trim().toLowerCase()
 
+  if (eventKey) {
+    const { data: existing, error: existingError } = await adminClient
+      .from('email_message')
+      .select('id')
+      .eq('event_key', eventKey)
+      .eq('to_email', normalizedEmail)
+      .maybeSingle()
+
+    if (!existingError && existing?.id) {
+      return { status: 'skipped', id: existing.id, error: null }
+    }
+  }
+
   const { data: queuedRow, error: queueError } = await adminClient
     .from('email_message')
     .insert({

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -57,6 +57,44 @@ const resolvePublicHubOrigin = (fallbackOrigin: string) => {
   return ensureOrigin(fallbackOrigin)
 }
 
+const tryAcquireGiftCardRunnerLock = async () => {
+  const { data, error } = await adminClient.rpc('zoom_try_advisory_lock', {
+    p_lock_name: 'gift-card:runner',
+  })
+  if (error) throw new Error(`Failed to acquire gift-card runner lock: ${error.message}`)
+  return data === true
+}
+
+const releaseGiftCardRunnerLock = async () => {
+  const { data, error } = await adminClient.rpc('zoom_advisory_unlock', {
+    p_lock_name: 'gift-card:runner',
+  })
+  if (error) {
+    console.error('[gift-cards][lock] unlock failed', { error: error.message })
+    return false
+  }
+  return data === true
+}
+
+const tryAcquireGiftCardAllocationLock = async (allocationId: string) => {
+  const { data, error } = await adminClient.rpc('zoom_try_advisory_lock', {
+    p_lock_name: `gift-card:allocation:${allocationId}`,
+  })
+  if (error) throw new Error(`Failed to acquire gift-card allocation lock: ${error.message}`)
+  return data === true
+}
+
+const releaseGiftCardAllocationLock = async (allocationId: string) => {
+  const { data, error } = await adminClient.rpc('zoom_advisory_unlock', {
+    p_lock_name: `gift-card:allocation:${allocationId}`,
+  })
+  if (error) {
+    console.error('[gift-cards][lock] allocation unlock failed', { allocationId, error: error.message })
+    return false
+  }
+  return data === true
+}
+
 const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
 const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
 
@@ -367,6 +405,13 @@ const sendDueReminders = async (appOrigin: string) => {
   }>
 
   for (const row of rows) {
+    const allocationLockAcquired = await tryAcquireGiftCardAllocationLock(row.id)
+    if (!allocationLockAcquired) {
+      remindersSkipped += 1
+      continue
+    }
+
+    try {
     if (row.blocked) {
       remindersSkipped += 1
       continue
@@ -471,6 +516,9 @@ const sendDueReminders = async (appOrigin: string) => {
     } else {
       remindersSkipped += 1
     }
+    } finally {
+      await releaseGiftCardAllocationLock(row.id)
+    }
   }
 
   return {
@@ -482,6 +530,19 @@ const sendDueReminders = async (appOrigin: string) => {
 }
 
 export const runGiftCardJobs = async ({ appOrigin, runId }: { appOrigin: string; runId: string }): Promise<GiftCardJobResult> => {
+  const lockAcquired = await tryAcquireGiftCardRunnerLock()
+  if (!lockAcquired) {
+    return {
+      runId,
+      allocated: 0,
+      remindersSent: 0,
+      remindersSkipped: 0,
+      reminderFailures: 0,
+      errors: ['gift-card runner lock not acquired'],
+    }
+  }
+
+  try {
   const errors: string[] = []
 
   let allocated = 0
@@ -511,5 +572,8 @@ export const runGiftCardJobs = async ({ appOrigin, runId }: { appOrigin: string;
     remindersSkipped,
     reminderFailures,
     errors,
+  }
+  } finally {
+    await releaseGiftCardRunnerLock()
   }
 }

--- a/web/app/lib/zoom-jobs/runner.server.ts
+++ b/web/app/lib/zoom-jobs/runner.server.ts
@@ -28,6 +28,44 @@ const resolvePublicAppOrigin = (fallbackOrigin: string) => {
   return ensureOrigin(explicitOrigin || fallbackOrigin)
 }
 
+const tryAcquireZoomRunnerLock = async () => {
+  const { data, error } = await adminClient.rpc('zoom_try_advisory_lock', {
+    p_lock_name: 'zoom:runner',
+  })
+  if (error) throw new Error(`Failed to acquire Zoom runner lock: ${error.message}`)
+  return data === true
+}
+
+const releaseZoomRunnerLock = async () => {
+  const { data, error } = await adminClient.rpc('zoom_advisory_unlock', {
+    p_lock_name: 'zoom:runner',
+  })
+  if (error) {
+    console.error('[zoom-jobs][lock] runner unlock failed', { error: error.message })
+    return false
+  }
+  return data === true
+}
+
+const tryAcquireZoomRegistrantReminderLock = async (registrantId: string) => {
+  const { data, error } = await adminClient.rpc('zoom_try_advisory_lock', {
+    p_lock_name: `zoom:registrant-reminder:${registrantId}`,
+  })
+  if (error) throw new Error(`Failed to acquire Zoom registrant reminder lock: ${error.message}`)
+  return data === true
+}
+
+const releaseZoomRegistrantReminderLock = async (registrantId: string) => {
+  const { data, error } = await adminClient.rpc('zoom_advisory_unlock', {
+    p_lock_name: `zoom:registrant-reminder:${registrantId}`,
+  })
+  if (error) {
+    console.error('[zoom-jobs][lock] registrant reminder unlock failed', { registrantId, error: error.message })
+    return false
+  }
+  return data === true
+}
+
 const REPROVISION_HORIZON_MINUTES = 36 * 60
 const REMINDER_WINDOW_MINUTES = 2 * 60
 const POST_CLASS_FOLLOWUP_DELAY_HOURS = 24
@@ -439,6 +477,13 @@ const sendReminderCoverage = async ({ now, appOrigin, onlyClassId }: { now: Date
     }
 
     for (const registrant of registrants ?? []) {
+      const reminderLockAcquired = await tryAcquireZoomRegistrantReminderLock(registrant.id)
+      if (!reminderLockAcquired) {
+        skipped += 1
+        continue
+      }
+
+      try {
       if (registrant.last_sent_at) {
         skipped += 1
         continue
@@ -492,6 +537,9 @@ const sendReminderCoverage = async ({ now, appOrigin, onlyClassId }: { now: Date
         }
       } else {
         failed += 1
+      }
+      } finally {
+        await releaseZoomRegistrantReminderLock(registrant.id)
       }
     }
   }
@@ -940,6 +988,18 @@ const syncPostClassAttendance = async ({ now, onlyClassId }: { now: Date; onlyCl
 }
 
 export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?: Date; appOrigin: string; runId?: string }) => {
+  const lockAcquired = await tryAcquireZoomRunnerLock()
+  if (!lockAcquired) {
+    return {
+      ok: true,
+      runId: runId ?? null,
+      ranAt: now.toISOString(),
+      skipped: true,
+      reason: 'zoom runner lock not acquired',
+    }
+  }
+
+  try {
   console.info('[zoom-jobs] run started', {
     runId: runId ?? null,
     now: now.toISOString(),
@@ -977,6 +1037,9 @@ export const runZoomJobs = async ({ now = new Date(), appOrigin, runId }: { now?
     postClassCameraOrPhotoFollowup,
     attendanceRowBackfill,
     attendanceSync,
+  }
+  } finally {
+    await releaseZoomRunnerLock()
   }
 }
 


### PR DESCRIPTION
## What
- restore manual migration `20260708193000_gift_card_runner_scale_indexes.sql`
- add server-side pre-check for `(event_key, to_email)` before queuing `email_message`
- add per-runner advisory locks for gift-card and zoom runners
- add per-recipient reminder locks (gift-card allocation / zoom registrant) to reduce overlap races

## Why
- reduce repeated duplicate-key contention on `email_message_event_key_to_email_unique` caused by scheduler overlap/retries

## Testing
- `npm run typecheck`