### PR TITLE
Improve login pending and onboarding timeout UX

### DIFF
--- a/web/app/lib/auth.server.ts
+++ b/web/app/lib/auth.server.ts
@@ -5,6 +5,25 @@ import { getSignUpDetailsStatus } from "@/lib/onboarding.server";
 import { isRoleAtLeast, rolesUpTo } from "@/lib/roles";
 import { createClient } from "@/lib/supabase/server";
 
+const ONBOARDING_GUARD_TIMEOUT_MS = Number.parseInt(process.env.ONBOARDING_GUARD_TIMEOUT_MS ?? '15000', 10)
+const onboardingGuardTimeoutMs = Number.isFinite(ONBOARDING_GUARD_TIMEOUT_MS) ? ONBOARDING_GUARD_TIMEOUT_MS : 15000
+
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${label}: timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
 function getOnboardingMode() {
   const mode = process.env.ONBOARDING_MODE;
   return mode === "permission" ? "permission" : "role";
@@ -56,7 +75,24 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
   }
 
   const { supabase } = createClient(request);
-  const signUpStatus = await getSignUpDetailsStatus(supabase, auth.user.id, auth.claims.role);
+  let signUpStatus
+  try {
+    signUpStatus = await withTimeout(
+      getSignUpDetailsStatus(supabase, auth.user.id, auth.claims.role),
+      onboardingGuardTimeoutMs,
+      'onboarding_guard'
+    )
+  } catch (error) {
+    console.error('[auth] onboarding guard lookup failed', {
+      userId: auth.user.id,
+      role: auth.claims.role,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw new Response('Account loading is taking longer than expected. Please try again in a minute.', {
+      status: 503,
+      headers: auth.headers,
+    })
+  }
   if (!signUpStatus.isComplete) {
     if (!signUpStatus.profileId) {
       throw redirect("/sign-up", { headers: auth.headers });

--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -193,6 +193,8 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
     details =
       error.status === 404
         ? "The requested page could not be found."
+        : error.status === 503
+          ? "We are having trouble loading your account right now. Please wait a minute and try again."
         : error.statusText || details;
   } else if (import.meta.env.DEV && error && error instanceof Error) {
     details = error.message;

--- a/web/app/routes/auth/login.tsx
+++ b/web/app/routes/auth/login.tsx
@@ -17,6 +17,7 @@ import {
   Link,
   redirect,
   useFetcher,
+  useNavigation,
 } from 'react-router'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -67,9 +68,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
 export default function Login() {
   const fetcher = useFetcher<typeof action>()
+  const navigation = useNavigation()
 
   const error = fetcher.data?.error
-  const loading = fetcher.state === 'submitting'
+  const loading = fetcher.state === 'submitting' || navigation.state !== 'idle'
 
   return (
     <AuthStickerBackground dense>
@@ -107,7 +109,7 @@ export default function Login() {
                   </div>
                   {error && <p className="text-sm text-red-500">{error}</p>}
                   <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? 'Logging in...' : 'Login'}
+                    {loading ? 'Please wait...' : 'Login'}
                   </Button>
                 </div>
                 <div className="mt-4 text-center text-sm">


### PR DESCRIPTION
## What
- keep login button disabled while navigation is pending (not just form submit)
- add onboarding guard timeout handling with a user-facing 503 response on stalls
- surface a clearer account-loading error message in the root error boundary for 503s

## Why
- regular users were seeing `/home` pending behavior with no clear feedback
- this prevents repeat login clicks and gives explicit timeout messaging when onboarding lookups stall

## Testing
- `npm run typecheck`