### PR TITLE
Instrument onboarding path and optimize home loader

### DIFF
--- a/supabase/migrations/20260707211000_onboarding_guardian_lookup_index.sql
+++ b/supabase/migrations/20260707211000_onboarding_guardian_lookup_index.sql
@@ -1,0 +1,2 @@
+create index if not exists person_guardian_child_child_guardian_idx
+  on public.person_guardian_child (child_profile_id, guardian_profile_id);

--- a/supabase/schemas/02_create_guardian_child.sql
+++ b/supabase/schemas/02_create_guardian_child.sql
@@ -11,6 +11,9 @@ create unique index person_guardian_child_primary_one
   on public.person_guardian_child (guardian_profile_id)
   where primary_child = true;
 
+create index person_guardian_child_child_guardian_idx
+  on public.person_guardian_child (child_profile_id, guardian_profile_id);
+
 alter table public.person_guardian_child enable row level security;
 
 create policy person_guardian_child_read_guardian

--- a/web/app/lib/auth.server.ts
+++ b/web/app/lib/auth.server.ts
@@ -7,6 +7,11 @@ import { createClient } from "@/lib/supabase/server";
 
 const ONBOARDING_GUARD_TIMEOUT_MS = Number.parseInt(process.env.ONBOARDING_GUARD_TIMEOUT_MS ?? '15000', 10)
 const onboardingGuardTimeoutMs = Number.isFinite(ONBOARDING_GUARD_TIMEOUT_MS) ? ONBOARDING_GUARD_TIMEOUT_MS : 15000
+const AUTH_PERMISSION_DRIFT_ALERT_TIMEOUT_MS = 2000
+const authPermissionDriftWebhookUrl = (process.env.AUTH_PERMISSION_DRIFT_WEBHOOK_URL ?? '').trim()
+
+const shouldLogAuthInstrumentation =
+  process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
 
 const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -29,7 +34,55 @@ function getOnboardingMode() {
   return mode === "permission" ? "permission" : "role";
 }
 
+const sortedPermissions = (permissions: string[]) => [...permissions].sort()
+
+const emitPermissionDriftAlert = async ({
+  userId,
+  role,
+  jwtPermissions,
+  rolePermissions,
+}: {
+  userId: string
+  role: string
+  jwtPermissions: string[]
+  rolePermissions: string[]
+}) => {
+  const payload = {
+    event: 'auth_permission_drift',
+    userId,
+    role,
+    jwtPermissions,
+    rolePermissions,
+    occurredAt: new Date().toISOString(),
+  }
+
+  console.error('[auth] permission drift detected', payload)
+
+  if (!authPermissionDriftWebhookUrl) return
+
+  try {
+    await withTimeout(
+      fetch(authPermissionDriftWebhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      }).then(() => undefined),
+      AUTH_PERMISSION_DRIFT_ALERT_TIMEOUT_MS,
+      'auth_permission_drift_alert'
+    )
+  } catch (error) {
+    console.error('[auth] permission drift alert webhook failed', {
+      userId,
+      role,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
 export async function requireAuth(request: Request) {
+  const startedAt = Date.now()
   const { supabase, headers } = createClient(request);
   const { data: userData, error: userError } = await supabase.auth.getUser();
   const user = userData?.user;
@@ -49,6 +102,7 @@ export async function requireAuth(request: Request) {
     : [];
 
   let permissions = claimPermissions;
+  let rolePermissions: string[] = []
   const roleScope = rolesUpTo(role);
   if (roleScope.length) {
     const { data: permissionRows, error: permissionsError } = await adminClient
@@ -56,10 +110,40 @@ export async function requireAuth(request: Request) {
       .select("permission")
       .in("role", roleScope);
     if (!permissionsError && permissionRows) {
-      permissions = Array.from(new Set(permissionRows.map((row) => row.permission)));
+      rolePermissions = Array.from(new Set(permissionRows.map((row) => row.permission)));
+      permissions = rolePermissions;
     }
   }
+
+  if (rolePermissions.length) {
+    const sortedJwtPermissions = sortedPermissions(claimPermissions)
+    const sortedRolePermissions = sortedPermissions(rolePermissions)
+    const driftDetected =
+      sortedJwtPermissions.length !== sortedRolePermissions.length ||
+      sortedJwtPermissions.some((permission, index) => permission !== sortedRolePermissions[index])
+
+    if (driftDetected) {
+      void emitPermissionDriftAlert({
+        userId: user.id,
+        role,
+        jwtPermissions: sortedJwtPermissions,
+        rolePermissions: sortedRolePermissions,
+      })
+    }
+  }
+
   const onboardingComplete = Boolean(claims?.onboarding_complete);
+
+  if (shouldLogAuthInstrumentation) {
+    console.info('[auth-instrumentation]', {
+      event: 'require_auth',
+      userId: user.id,
+      role,
+      durationMs: Date.now() - startedAt,
+      claimsPermissionCount: claimPermissions.length,
+      rolePermissionCount: rolePermissions.length,
+    })
+  }
 
   return {
     user,
@@ -69,8 +153,17 @@ export async function requireAuth(request: Request) {
 }
 
 export async function enforceOnboardingGuard(request: Request, opts?: { allowMyForms?: boolean }) {
+  const startedAt = Date.now()
   const auth = await requireAuth(request);
   if (isRoleAtLeast(auth.claims.role, "staff")) {
+    if (shouldLogAuthInstrumentation) {
+      console.info('[auth-instrumentation]', {
+        event: 'onboarding_guard_bypass_staff',
+        userId: auth.user.id,
+        role: auth.claims.role,
+        durationMs: Date.now() - startedAt,
+      })
+    }
     return { ...auth, shouldRedirectToForms: false };
   }
 
@@ -130,6 +223,16 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
       needsOnboarding,
     });
     throw redirect("/my-forms", { headers: auth.headers });
+  }
+
+  if (shouldLogAuthInstrumentation) {
+    console.info('[auth-instrumentation]', {
+      event: 'onboarding_guard_complete',
+      userId: auth.user.id,
+      role: auth.claims.role,
+      durationMs: Date.now() - startedAt,
+      shouldRedirectToForms,
+    })
   }
 
   return { ...auth, shouldRedirectToForms };

--- a/web/app/lib/onboarding.server.ts
+++ b/web/app/lib/onboarding.server.ts
@@ -1,8 +1,37 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 import type { Database, Json } from '@/lib/database.types'
+import { loadSubmissionAnswerState } from '@/lib/form-submission-answers.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { getSignUpFlowContext } from '@/lib/sign-up-flow-context.server'
+
+const SIGN_UP_FLOW_CACHE_TTL_MS = process.env.NODE_ENV === 'test' ? 0 : 30_000
+let signUpFlowCache: {
+  fetchedAt: number
+  rows: Array<{ form_id: string | null; roles: string[] | null; condition: Json | null; slug: string | null }>
+} | null = null
+
+const shouldLogOnboardingInstrumentation =
+  process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
+
+const getCachedSignUpFlowEntries = async (supabase: SupabaseClient<Database>) => {
+  const now = Date.now()
+  if (signUpFlowCache && now - signUpFlowCache.fetchedAt < SIGN_UP_FLOW_CACHE_TTL_MS) {
+    return signUpFlowCache.rows
+  }
+
+  const { data: flowEntries } = await supabase
+    .from('sign_up_flow')
+    .select('form_id, roles, condition, slug')
+    .order('step_order')
+
+  const rows = (flowEntries ?? []) as Array<{ form_id: string | null; roles: string[] | null; condition: Json | null; slug: string | null }>
+  signUpFlowCache = {
+    fetchedAt: now,
+    rows,
+  }
+  return rows
+}
 
 export type SignUpDetailsStatus = {
   isComplete: boolean
@@ -53,51 +82,24 @@ const isConditionMet = (condition: Json | null | undefined, answers: Record<stri
   return true
 }
 
-const buildAnswerMapFromSubmissions = (
-  submissions: Array<{
-    form_id: string | null
-    submitted_at: string | null
-    form_answer: Array<{ question_code: string | null; value: Json }> | null
-  }>
-) => {
-  const answers: Record<string, Json> = {}
-
-  for (const submission of submissions) {
-    for (const answer of submission.form_answer ?? []) {
-      if (!answer.question_code) continue
-      answers[answer.question_code] = answer.value
-    }
-  }
-
-  return answers
-}
-
 export const getProfileSignUpCompletion = async (
   supabase: SupabaseClient<Database>,
   profileId: string,
   role: Database['public']['Enums']['app_role'],
   options: { skipSlugs?: string[] } = {}
 ): Promise<boolean> => {
-  const { data: submissions } = await supabase
-    .from('form_submission')
-    .select('form_id, submitted_at, form_answer ( question_code, value )')
-    .eq('profile_id', profileId)
-    .order('submitted_at', { ascending: true })
+  const startedAt = Date.now()
+  const { answers, submissions } = await loadSubmissionAnswerState(supabase, profileId)
+  const submittedFormIds = new Set(submissions.map(submission => submission.form_id).filter(Boolean))
 
-  const answers = buildAnswerMapFromSubmissions(submissions ?? [])
-  const submittedFormIds = new Set((submissions ?? []).map(submission => submission.form_id).filter(Boolean))
-
-  const { data: flowEntries } = await supabase
-    .from('sign_up_flow')
-    .select('form_id, roles, condition, slug')
-    .order('step_order')
+  const flowEntries = await getCachedSignUpFlowEntries(supabase)
 
   const relevantForms = (flowEntries ?? [])
     .filter(entry => entry.roles?.includes(role))
     .filter(entry => isConditionMet(entry.condition as Json, answers))
     .filter(entry => !(options.skipSlugs ?? []).includes(entry.slug ?? ''))
     .map(entry => entry.form_id)
-    .filter(Boolean)
+    .filter((formId): formId is string => Boolean(formId))
 
   if (!relevantForms.length) {
     return true
@@ -105,6 +107,16 @@ export const getProfileSignUpCompletion = async (
 
   const formsComplete = relevantForms.every(formId => submittedFormIds.has(formId))
   if (!formsComplete) {
+    if (shouldLogOnboardingInstrumentation) {
+      console.info('[onboarding-instrumentation]', {
+        event: 'profile_sign_up_completion_incomplete',
+        profileId,
+        role,
+        relevantFormCount: relevantForms.length,
+        submittedFormCount: submittedFormIds.size,
+        durationMs: Date.now() - startedAt,
+      })
+    }
     return false
   }
 
@@ -115,7 +127,25 @@ export const getProfileSignUpCompletion = async (
       .eq('guardian_profile_id', profileId)
       .limit(1)
       .maybeSingle()
-    return Boolean(relationship?.id)
+    const complete = Boolean(relationship?.id)
+    if (shouldLogOnboardingInstrumentation) {
+      console.info('[onboarding-instrumentation]', {
+        event: 'profile_sign_up_completion_guardian',
+        profileId,
+        complete,
+        durationMs: Date.now() - startedAt,
+      })
+    }
+    return complete
+  }
+
+  if (shouldLogOnboardingInstrumentation) {
+    console.info('[onboarding-instrumentation]', {
+      event: 'profile_sign_up_completion_complete',
+      profileId,
+      role,
+      durationMs: Date.now() - startedAt,
+    })
   }
 
   return true
@@ -124,20 +154,25 @@ export const getProfileSignUpCompletion = async (
 export const getProfileSignUpCompletionWithContext = async (
   supabase: SupabaseClient<Database>,
   profileId: string,
-  role: Database['public']['Enums']['app_role']
+  role: Database['public']['Enums']['app_role'],
+  options: { email?: string | null } = {}
 ): Promise<boolean> => {
   if (role !== 'guardian' && role !== 'student') {
     return getProfileSignUpCompletion(supabase, profileId, role)
   }
 
-  const { data: profile } = await supabase
-    .from('profile')
-    .select('email')
-    .eq('id', profileId)
-    .maybeSingle()
+  let email = options.email ?? null
+  if (!email) {
+    const { data: profile } = await supabase
+      .from('profile')
+      .select('email')
+      .eq('id', profileId)
+      .maybeSingle()
+    email = profile?.email ?? null
+  }
 
   const signUpFlowContext = await getSignUpFlowContext(supabase, {
-    email: profile?.email ?? null,
+    email,
     role,
   })
 
@@ -154,6 +189,7 @@ export async function getSignUpDetailsStatus(
   userId: string,
   roleOverride?: string | null
 ): Promise<SignUpDetailsStatus> {
+  const startedAt = Date.now()
   const { data: profile, error } = await supabase
     .from('profile')
     .select('id, role, email')
@@ -161,6 +197,14 @@ export async function getSignUpDetailsStatus(
     .single()
 
   if (error || !profile?.id) {
+    if (shouldLogOnboardingInstrumentation) {
+      console.info('[onboarding-instrumentation]', {
+        event: 'signup_status_missing_profile',
+        userId,
+        roleOverride: roleOverride ?? null,
+        durationMs: Date.now() - startedAt,
+      })
+    }
     return {
       isComplete: false,
       profileId: null,
@@ -171,17 +215,35 @@ export async function getSignUpDetailsStatus(
 
   const role = roleOverride && roleOverride !== 'unassigned' ? roleOverride : profile.role ?? roleOverride ?? null
   if (!role || role === 'unassigned') {
+    if (shouldLogOnboardingInstrumentation) {
+      console.info('[onboarding-instrumentation]', {
+        event: 'signup_status_unassigned',
+        userId,
+        profileId: profile.id,
+        durationMs: Date.now() - startedAt,
+      })
+    }
     return { isComplete: false, profileId: profile.id, role, waitingOnGuardians: false }
   }
 
   if (!isSignUpDetailsRole(role)) {
+    if (shouldLogOnboardingInstrumentation) {
+      console.info('[onboarding-instrumentation]', {
+        event: 'signup_status_non_signup_role_complete',
+        userId,
+        profileId: profile.id,
+        role,
+        durationMs: Date.now() - startedAt,
+      })
+    }
     return { isComplete: true, profileId: profile.id, role, waitingOnGuardians: false }
   }
 
   const formsComplete = await getProfileSignUpCompletionWithContext(
     supabase,
     profile.id,
-    role
+    role,
+    { email: profile.email ?? null }
   )
 
   if (role === 'student') {
@@ -200,24 +262,57 @@ export async function getSignUpDetailsStatus(
       }
     }
 
+    const { data: guardianProfiles } = await adminClient
+      .from('profile')
+      .select('id, email')
+      .in('id', guardianIds)
+
+    const guardianEmailById = new Map(
+      (guardianProfiles ?? []).map(row => [row.id, row.email ?? null])
+    )
+
     const guardianCompletions = await Promise.all(
       guardianIds.map(guardianId =>
-        getProfileSignUpCompletionWithContext(adminClient, guardianId, 'guardian')
+        getProfileSignUpCompletionWithContext(adminClient, guardianId, 'guardian', {
+          email: guardianEmailById.get(guardianId) ?? null,
+        })
       )
     )
     const hasCompleteGuardian = guardianCompletions.some(Boolean)
-    return {
+    const result = {
       isComplete: formsComplete && hasCompleteGuardian,
       profileId: profile.id,
       role,
       waitingOnGuardians: formsComplete && !hasCompleteGuardian,
     }
+    if (shouldLogOnboardingInstrumentation) {
+      console.info('[onboarding-instrumentation]', {
+        event: 'signup_status_student',
+        userId,
+        profileId: profile.id,
+        formsComplete,
+        guardianCount: guardianIds.length,
+        hasCompleteGuardian,
+        durationMs: Date.now() - startedAt,
+      })
+    }
+    return result
   }
 
-  return {
+  const result = {
     isComplete: formsComplete,
     profileId: profile.id,
     role,
     waitingOnGuardians: false,
   }
+  if (shouldLogOnboardingInstrumentation) {
+    console.info('[onboarding-instrumentation]', {
+      event: 'signup_status_guardian',
+      userId,
+      profileId: profile.id,
+      formsComplete,
+      durationMs: Date.now() - startedAt,
+    })
+  }
+  return result
 }

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -110,6 +110,9 @@ const personName = (profile: { firstname: string | null; surname: string | null;
   return full || profile.email || 'Unnamed'
 }
 
+const shouldLogHomeInstrumentation =
+  process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
+
 const sendInvite = async ({
   email,
   role,
@@ -181,6 +184,7 @@ const sendInvite = async ({
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
+  const startedAt = Date.now()
   const auth = await enforceOnboardingGuard(request)
   if (isRoleAtLeast(auth.claims.role, 'instructor')) {
     throw redirect('/manage', { headers: auth.headers })
@@ -191,10 +195,20 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const family = await resolveFamilyGraph(supabase, auth.user.id)
 
-  const { data: familyProfilesRaw } = await adminClient
-    .from('profile')
-    .select('id, role, firstname, surname, email, user_id')
-    .in('id', family.familyProfileIds)
+  const [familyProfilesResponse, enrollmentsResponse] = await Promise.all([
+    adminClient
+      .from('profile')
+      .select('id, role, firstname, surname, email, user_id')
+      .in('id', family.familyProfileIds),
+    supabase
+      .from('workshop_enrollment')
+      .select('id, workshop_id, semester_id, status, requested_at, profile_id')
+      .in('profile_id', family.familyProfileIds)
+      .order('requested_at', { ascending: false }),
+  ])
+
+  const familyProfilesRaw = familyProfilesResponse.data
+  const enrollmentsRaw = enrollmentsResponse.data
 
   const familyProfiles = (familyProfilesRaw ?? []) as FamilyProfile[]
 
@@ -210,13 +224,35 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const invites = (invitesRaw ?? []) as InviteRow[]
 
-  const { data: enrollmentsRaw } = await supabase
-    .from('workshop_enrollment')
-    .select('id, workshop_id, semester_id, status, requested_at, profile_id')
-    .in('profile_id', family.familyProfileIds)
-    .order('requested_at', { ascending: false })
-
   const enrollments = (enrollmentsRaw ?? []) as EnrollmentRow[]
+  if (shouldLogHomeInstrumentation) {
+    console.info('[home-instrumentation]', {
+      event: 'home_loader_base',
+      userId: auth.user.id,
+      role: auth.claims.role,
+      familyProfiles: family.familyProfileIds.length,
+      enrollmentCount: enrollments.length,
+      durationMs: Date.now() - startedAt,
+    })
+  }
+
+  if (!enrollments.length) {
+    return {
+      family,
+      familyProfiles,
+      invites,
+      workshopsById: {},
+      semesterById: {},
+      enrollments,
+      classesByWorkshop: {},
+      joinUrlByClass: {},
+      giftCardLinkByClass: {},
+      selectedProfileIdByClass: {},
+      selectedPhotoStatusByClass: {},
+      nextClass: null,
+    } satisfies LoaderData
+  }
+
   const workshopIds = Array.from(new Set(enrollments.map(row => row.workshop_id).filter((id): id is string => Boolean(id))))
 
   const { data: workshopsRaw } = workshopIds.length


### PR DESCRIPTION
## What changed
- added auth/onboarding instrumentation logs for guard and completion phases
- added JWT-vs-role_permission drift detection with optional webhook alerts
- optimized onboarding completion checks (sign_up_flow cache + guardian email batching)
- optimized /home loader by parallelizing base queries and short-circuiting when no enrollments
- added person_guardian_child(child_profile_id, guardian_profile_id) index via schema + migration

## Verification
- npm run typecheck (pass)
- npm run test (Playwright): 9 passed, 4 failed, 1 skipped
  - failing specs:
    - tests/e2e/admin-enrollment-approval.spec.ts
    - tests/e2e/guardian-signup-enroll.spec.ts
    - tests/e2e/manage-workshop-filter-loading.spec.ts
    - tests/e2e/student-resend-guardian-invite.spec.ts

## Notes
- applied migration locally with: supabase migration up --include-all