### PR TITLE
Mask instrumentation domains and update onboarding helper usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,46 @@
 # AGENTS.md
 
 ## Repo boundaries
-- Product app is `web/` (React Router v7 SSR). Run Node commands in `web/`; root `package.json` has no scripts.
-- `scheduler/` (cron worker) and `zoom-api/` (FastAPI) are separate deployables with their own run/test flows.
-- When touching `zoom-api/`, follow `zoom-api/CLAUDE.md`.
+- Main product is `web/` (React Router v7 SSR). Run Node commands in `web/`; root `package.json` has no scripts.
+- `scheduler/` and `zoom-api/` are separate deployables with separate run/test flows.
+- When touching `zoom-api/`, read and follow `zoom-api/CLAUDE.md` first.
 
 ## Web app wiring that causes regressions
-- Routes are manually declared in `web/app/routes.ts`; new route files 404 until registered.
-- `npm run typecheck` runs `react-router typegen` + `tsc`; run it after route edits to refresh generated route types.
-- `web/app/root.tsx` enforces onboarding redirects on almost every path; add new public/auth paths to its allowlist or they will be gated.
-- Keep onboarding logic aligned across `web/app/root.tsx`, `web/app/lib/auth.server.ts`, and `web/app/routes/auth/sign-up-details.tsx`.
-- Signup details route is `/auth/sign-up-details` (with hyphen).
-- `createClient` in `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; propagate `headers` on redirects/responses or auth cookies are lost.
-- Path aliases `~/` and `@/` both resolve to `web/app/*` (`web/tsconfig.json`).
-- For heavy manage tables that should not block nav (`email-message`, class attendance flows), use a lightweight route loader + client `fetcher.load()` loading state, then fetch full table payload with a query flag (for example `_deferTable=1`).
-- Do not export ad-hoc server helper functions from route modules that also render client components; React Router only strips server code from `loader`/`action`/`headers`/`middleware`, and extra exports can trigger "Server-only module referenced by client" Vite errors.
-- If a manage table must support "all-values" filtering and complete row coverage (for example `email-message`), force a full-scan table loader request (clear `page`/`pageSize`, use unsupported sort sentinel) so filtering runs against the full dataset, not just one page.
+- Routes are manually declared in `web/app/routes.ts`; adding only a route file still 404s.
+- After route edits, run `npm run typecheck` in `web/` (`react-router typegen && tsc`) so generated route types refresh.
+- `web/app/root.tsx` enforces onboarding redirects for most paths. New public/auth routes must be added to its allowlist.
+- Keep onboarding behavior aligned across `web/app/root.tsx`, `web/app/lib/auth.server.ts`, and `web/app/routes/auth/sign-up-details.tsx`.
+- Signup details URL is `/auth/sign-up-details` (hyphenated).
+- `createClient` in `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; pass `headers` through redirects/responses or auth cookies are dropped.
+- `~/` and `@/` both map to `web/app/*` (`web/tsconfig.json`).
+- For heavy manage tables, use the existing deferred pattern: lightweight page loader + client `fetcher.load()` request (see `web/app/routes/manage/deferred-table-display.tsx`).
+- For full-dataset filtering tables (for example `email-message`), use the full-scan loader pattern: set `_deferTable=1`, clear `page`/`pageSize`, and force `sort=__full_scan__`.
 
 ## Local setup and verification
-- First-time local app setup (repo root): `cp web/.env.template web/.env.local` -> `supabase start --debug` -> copy values from `supabase status -o json` into `web/.env.local`.
-- `ONBOARDING_MODE` falls back to `role`; only `permission` enables permission-gated onboarding.
-- Key commands in `web/`: `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, `npm run test`.
-- There is no lint/format script in `web/package.json`; do not invent `npm run lint`.
-- Focused tests: `npm run test:e2e -- tests/e2e/<spec>.spec.ts --grep "..."` and `npm run test:unit -- tests/unit/<spec>.spec.ts`.
-- CI (`.github/workflows/tests.yml`) boots Supabase and runs only `npm run test`; typecheck is not part of CI.
+- Initial local setup (repo root): `cp web/.env.template web/.env.local` -> `supabase start --debug` -> copy values from `supabase status -o json` into `web/.env.local`.
+- `ONBOARDING_MODE` defaults to `role`; only `permission` enables permission-gated onboarding.
+- Key `web/` commands: `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, `npm run test`.
+- There is no lint script in `web/package.json`; do not invent `npm run lint`.
+- Focused runs: `npm run test:e2e -- tests/e2e/<spec>.spec.ts --grep "..."` and `npm run test:unit -- tests/unit/<spec>.spec.ts`.
 
-## Test behavior gotchas
-- `npm run test` is Playwright over both `web/tests/e2e` and `web/tests/unit`; there is no Jest/Vitest suite.
-- If `PLAYWRIGHT_BASE_URL` is unset, Playwright auto-starts `npm run dev -- --port 5173`.
-- Admin e2e helpers skip/fail without `SUPABASE_URL` and `SUPABASE_SECRET_KEY` (env or `web/.env.local`).
+## Test/CI behavior
+- `npm run test` is Playwright for both `web/tests/e2e` and `web/tests/unit`.
+- If `PLAYWRIGHT_BASE_URL` is unset, Playwright auto-starts `npm run dev -- --port 5173` (`web/playwright.config.ts`).
+- Admin e2e setup helpers require `SUPABASE_URL` and `SUPABASE_SECRET_KEY` (env or `web/.env.local`).
+- CI in `.github/workflows/tests.yml` installs deps in `web/`, boots Supabase, writes `web/.env.local`, and runs only `npm run test` (no typecheck step).
 
-## Database and auth guardrails
-- Treat declarative SQL in `supabase/schemas/` as source of truth; do not hand-edit existing `supabase/migrations/*`.
-- Schema flow (repo root): edit `supabase/schemas/*` -> `supabase db diff -f <name>` -> `supabase migration up`.
-- After schema changes, regenerate `web/app/lib/database.types.ts` with:
+## Database and Supabase workflow
+- Source of truth is declarative SQL in `supabase/schemas/`; do not hand-edit existing `supabase/migrations/*`.
+- Schema change flow (repo root): edit `supabase/schemas/*` -> `supabase db diff -f <name>` -> `supabase migration up`.
+- After schema changes, regenerate `web/app/lib/database.types.ts`:
   `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`.
-- DB-backed features must ship permissions + RLS together (`app_permissions`, `role_permission`, policies) per `CODE_STANDARDS.md`.
-- Auth truth is `public.user_roles` + JWT claims; `auth.users.raw_user_meta_data.role` can drift.
-
-## Scheduler/Supabase integration gotchas
-- Internal cron auth requires matching `INTERNAL_RUNNER_SECRET` in `scheduler` and `web`.
-- Job timing source of truth is `scheduler/crontab` (not README text).
-- Default seed mode in `supabase/config.toml` uses bootstrap + sanitized prod snapshot (`./seeds/prod-data/*-sanitized.sql`).
+- Ship DB features with permissions + RLS updates together (`app_permissions`, `role_permission`, policies), as enforced by `CODE_STANDARDS.md`.
+- Auth source of truth for authorization is `public.user_roles` + JWT claims; metadata role can drift.
+- `supabase/config.toml` seeds with app bootstrap + sanitized prod snapshot by default (`./seeds/prod-data/*-sanitized.sql`).
 - Supabase auth email templates are configured in `supabase/config.toml` and loaded from `supabase/templates/*.html`.
+
+## Scheduler and zoom-api gotchas
+- Internal cron auth requires matching `INTERNAL_RUNNER_SECRET` in both `scheduler` and `web`.
+- Job schedule source of truth is `scheduler/crontab` (currently includes zoom, gift-card, export run, and export cleanup jobs).
+- Scheduler local commands are in `scheduler/Makefile` (`make cron`, `make cron-bg`, `make logs`, `make down`, `make smoke-all`).
+- In `zoom-api`, auth changes must keep FastAPI `HTTPBearer` and keep `test_openapi_declares_security_scheme` passing (from `zoom-api/CLAUDE.md`).

--- a/web/app/lib/auth.server.ts
+++ b/web/app/lib/auth.server.ts
@@ -1,6 +1,7 @@
 import { redirect } from "react-router";
 
 import { adminClient } from "@/lib/supabase/adminClient";
+import { getEmailDomainHint } from "@/lib/email-domain";
 import { getSignUpDetailsStatus } from "@/lib/onboarding.server";
 import { isRoleAtLeast, rolesUpTo } from "@/lib/roles";
 import { createClient } from "@/lib/supabase/server";
@@ -37,19 +38,19 @@ function getOnboardingMode() {
 const sortedPermissions = (permissions: string[]) => [...permissions].sort()
 
 const emitPermissionDriftAlert = async ({
-  userId,
+  emailDomainHint,
   role,
   jwtPermissions,
   rolePermissions,
 }: {
-  userId: string
+  emailDomainHint: string | null
   role: string
   jwtPermissions: string[]
   rolePermissions: string[]
 }) => {
   const payload = {
     event: 'auth_permission_drift',
-    userId,
+    emailDomainHint,
     role,
     jwtPermissions,
     rolePermissions,
@@ -74,7 +75,7 @@ const emitPermissionDriftAlert = async ({
     )
   } catch (error) {
     console.error('[auth] permission drift alert webhook failed', {
-      userId,
+      emailDomainHint,
       role,
       error: error instanceof Error ? error.message : String(error),
     })
@@ -86,6 +87,7 @@ export async function requireAuth(request: Request) {
   const { supabase, headers } = createClient(request);
   const { data: userData, error: userError } = await supabase.auth.getUser();
   const user = userData?.user;
+  const emailDomainHint = getEmailDomainHint(user?.email)
 
   if (userError || !user) {
     throw redirect("/login", { headers });
@@ -124,7 +126,7 @@ export async function requireAuth(request: Request) {
 
     if (driftDetected) {
       void emitPermissionDriftAlert({
-        userId: user.id,
+        emailDomainHint,
         role,
         jwtPermissions: sortedJwtPermissions,
         rolePermissions: sortedRolePermissions,
@@ -137,7 +139,7 @@ export async function requireAuth(request: Request) {
   if (shouldLogAuthInstrumentation) {
     console.info('[auth-instrumentation]', {
       event: 'require_auth',
-      userId: user.id,
+      emailDomainHint,
       role,
       durationMs: Date.now() - startedAt,
       claimsPermissionCount: claimPermissions.length,
@@ -159,7 +161,7 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
     if (shouldLogAuthInstrumentation) {
       console.info('[auth-instrumentation]', {
         event: 'onboarding_guard_bypass_staff',
-        userId: auth.user.id,
+        emailDomainHint: getEmailDomainHint(auth.user.email),
         role: auth.claims.role,
         durationMs: Date.now() - startedAt,
       })
@@ -177,7 +179,7 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
     )
   } catch (error) {
     console.error('[auth] onboarding guard lookup failed', {
-      userId: auth.user.id,
+      emailDomainHint: getEmailDomainHint(auth.user.email),
       role: auth.claims.role,
       error: error instanceof Error ? error.message : String(error),
     })
@@ -228,7 +230,7 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
   if (shouldLogAuthInstrumentation) {
     console.info('[auth-instrumentation]', {
       event: 'onboarding_guard_complete',
-      userId: auth.user.id,
+      emailDomainHint: getEmailDomainHint(auth.user.email),
       role: auth.claims.role,
       durationMs: Date.now() - startedAt,
       shouldRedirectToForms,

--- a/web/app/lib/email-domain.ts
+++ b/web/app/lib/email-domain.ts
@@ -8,6 +8,17 @@ export const ALLOWED_EMAIL_PATTERN = `^[^\\s@]+@(${ALLOWED_EMAIL_DOMAINS
 
 export const normalizeEmail = (value: string) => value.trim().toLowerCase()
 
+export const getEmailDomainHint = (email: string | null | undefined) => {
+  if (!email) return null
+  const normalized = normalizeEmail(email)
+  const parts = normalized.split('@')
+  if (parts.length !== 2 || !parts[1]) return null
+
+  const domain = parts[1]
+  if (domain.length <= 5) return domain
+  return `${domain.slice(0, 3)}${domain.slice(-2)}`
+}
+
 export const isAllowedEmailDomain = (value: string) => {
   const normalized = normalizeEmail(value)
   const parts = normalized.split('@')

--- a/web/app/lib/onboarding.server.ts
+++ b/web/app/lib/onboarding.server.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 import type { Database, Json } from '@/lib/database.types'
+import { getEmailDomainHint } from '@/lib/email-domain'
 import { loadSubmissionAnswerState } from '@/lib/form-submission-answers.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { getSignUpFlowContext } from '@/lib/sign-up-flow-context.server'
@@ -200,7 +201,7 @@ export async function getSignUpDetailsStatus(
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_missing_profile',
-        userId,
+        emailDomainHint: null,
         roleOverride: roleOverride ?? null,
         durationMs: Date.now() - startedAt,
       })
@@ -214,11 +215,12 @@ export async function getSignUpDetailsStatus(
   }
 
   const role = roleOverride && roleOverride !== 'unassigned' ? roleOverride : profile.role ?? roleOverride ?? null
+  const emailDomainHint = getEmailDomainHint(profile.email)
   if (!role || role === 'unassigned') {
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_unassigned',
-        userId,
+        emailDomainHint,
         profileId: profile.id,
         durationMs: Date.now() - startedAt,
       })
@@ -230,7 +232,7 @@ export async function getSignUpDetailsStatus(
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_non_signup_role_complete',
-        userId,
+        emailDomainHint,
         profileId: profile.id,
         role,
         durationMs: Date.now() - startedAt,
@@ -288,7 +290,7 @@ export async function getSignUpDetailsStatus(
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_student',
-        userId,
+        emailDomainHint,
         profileId: profile.id,
         formsComplete,
         guardianCount: guardianIds.length,
@@ -308,7 +310,7 @@ export async function getSignUpDetailsStatus(
   if (shouldLogOnboardingInstrumentation) {
     console.info('[onboarding-instrumentation]', {
       event: 'signup_status_guardian',
-      userId,
+      emailDomainHint,
       profileId: profile.id,
       formsComplete,
       durationMs: Date.now() - startedAt,

--- a/web/app/routes/auth/sign-up-details.tsx
+++ b/web/app/routes/auth/sign-up-details.tsx
@@ -12,6 +12,7 @@ import {
 import FormQuestion, { type FormQuestionData } from '@/components/forms/form-question'
 import type { Database, Json } from '@/lib/database.types'
 import { normalizeEmail } from '@/lib/email-domain'
+import { loadSubmissionAnswerState } from '@/lib/form-submission-answers.server'
 import { getProfileSignUpCompletionWithContext } from '@/lib/onboarding.server'
 import { extractRequestMetadata } from '@/lib/request-metadata.server'
 import { ridingLookupProvider } from '@/lib/riding-lookup.server'
@@ -192,30 +193,6 @@ const parseFormValue = (question: FormQuestionData, formData: FormData) => {
   return rawValue
 }
 
-const buildAnswerMapFromSubmissions = (
-  submissions: Array<{
-    form_id: string | null
-    submitted_at: string | null
-    form_answer: Array<{ question_code: string | null; value: Json }> | null
-  }>
-) => {
-  const answers: Record<string, Json> = {}
-  const byForm: Record<string, Record<string, Json>> = {}
-
-  for (const submission of submissions) {
-    if (!submission.form_id) continue
-    const formAnswers: Record<string, Json> = {}
-    for (const answer of submission.form_answer ?? []) {
-      if (!answer.question_code) continue
-      formAnswers[answer.question_code] = answer.value
-      answers[answer.question_code] = answer.value
-    }
-    byForm[submission.form_id] = formAnswers
-  }
-
-  return { answers, byForm }
-}
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { supabase, headers } = createClient(request)
   const { data: userData } = await supabase.auth.getUser()
@@ -255,12 +232,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     role: resolvedRole,
   })
 
-  const { data: submissions } = await supabase
-    .from('form_submission')
-    .select('form_id, submitted_at, form_answer ( question_code, value )')
-    .eq('profile_id', pid)
-    .order('submitted_at', { ascending: true })
-  const submissionData = buildAnswerMapFromSubmissions(submissions ?? [])
+  const submissionData = await loadSubmissionAnswerState(supabase, pid)
   const mealKitFlag = await districtMealKitFlag(
     typeof profile.federal_electoral_district_name === 'string' ? profile.federal_electoral_district_name : null
   )
@@ -652,12 +624,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return { error: 'Form is not configured' }
   }
 
-  const { data: submissions } = await supabase
-    .from('form_submission')
-    .select('form_id, submitted_at, form_answer ( question_code, value )')
-    .eq('profile_id', pid)
-    .order('submitted_at', { ascending: true })
-  const submissionData = buildAnswerMapFromSubmissions(submissions ?? [])
+  const submissionData = await loadSubmissionAnswerState(supabase, pid)
 
   const submittedAnswers: Record<string, Json> = {}
   for (const question of questions) {

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -10,7 +10,7 @@ import { isGiftCardReleasedNow } from '@/lib/gift-cards/release.server'
 import { resolveFamilyGraph } from '@/lib/family.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
-import { normalizeEmail } from '@/lib/email-domain'
+import { getEmailDomainHint, normalizeEmail } from '@/lib/email-domain'
 import {
   Table,
   TableBody,
@@ -228,7 +228,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (shouldLogHomeInstrumentation) {
     console.info('[home-instrumentation]', {
       event: 'home_loader_base',
-      userId: auth.user.id,
+      emailDomainHint: getEmailDomainHint(auth.user.email),
       role: auth.claims.role,
       familyProfiles: family.familyProfileIds.length,
       enrollmentCount: enrollments.length,


### PR DESCRIPTION
## What changed
- masked auth/onboarding/home instrumentation context to use emailDomainHint (first 3 + last 2 chars of domain)
- added getEmailDomainHint helper in web/app/lib/email-domain.ts
- switched sign-up details flow to use shared submission answer helper in onboarding path
- includes repository guidance updates in AGENTS.md

## Verification
- npm run typecheck in web/ (pass)
- npm run build in web/ (pass)