### PR TITLE
Mask email hints and cache onboarding guard lookups

### DIFF
--- a/web/app/lib/auth.server.ts
+++ b/web/app/lib/auth.server.ts
@@ -1,7 +1,7 @@
 import { redirect } from "react-router";
 
 import { adminClient } from "@/lib/supabase/adminClient";
-import { getEmailDomainHint } from "@/lib/email-domain";
+import { getMaskedEmailHint } from "@/lib/email-domain";
 import { getSignUpDetailsStatus } from "@/lib/onboarding.server";
 import { isRoleAtLeast, rolesUpTo } from "@/lib/roles";
 import { createClient } from "@/lib/supabase/server";
@@ -38,19 +38,19 @@ function getOnboardingMode() {
 const sortedPermissions = (permissions: string[]) => [...permissions].sort()
 
 const emitPermissionDriftAlert = async ({
-  emailDomainHint,
+  emailHint,
   role,
   jwtPermissions,
   rolePermissions,
 }: {
-  emailDomainHint: string | null
+  emailHint: string | null
   role: string
   jwtPermissions: string[]
   rolePermissions: string[]
 }) => {
   const payload = {
     event: 'auth_permission_drift',
-    emailDomainHint,
+    emailHint,
     role,
     jwtPermissions,
     rolePermissions,
@@ -75,7 +75,7 @@ const emitPermissionDriftAlert = async ({
     )
   } catch (error) {
     console.error('[auth] permission drift alert webhook failed', {
-      emailDomainHint,
+      emailHint,
       role,
       error: error instanceof Error ? error.message : String(error),
     })
@@ -87,7 +87,7 @@ export async function requireAuth(request: Request) {
   const { supabase, headers } = createClient(request);
   const { data: userData, error: userError } = await supabase.auth.getUser();
   const user = userData?.user;
-  const emailDomainHint = getEmailDomainHint(user?.email)
+  const emailHint = getMaskedEmailHint(user?.email)
 
   if (userError || !user) {
     throw redirect("/login", { headers });
@@ -126,7 +126,7 @@ export async function requireAuth(request: Request) {
 
     if (driftDetected) {
       void emitPermissionDriftAlert({
-        emailDomainHint,
+        emailHint,
         role,
         jwtPermissions: sortedJwtPermissions,
         rolePermissions: sortedRolePermissions,
@@ -139,7 +139,7 @@ export async function requireAuth(request: Request) {
   if (shouldLogAuthInstrumentation) {
     console.info('[auth-instrumentation]', {
       event: 'require_auth',
-      emailDomainHint,
+      emailHint,
       role,
       durationMs: Date.now() - startedAt,
       claimsPermissionCount: claimPermissions.length,
@@ -161,7 +161,7 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
     if (shouldLogAuthInstrumentation) {
       console.info('[auth-instrumentation]', {
         event: 'onboarding_guard_bypass_staff',
-        emailDomainHint: getEmailDomainHint(auth.user.email),
+        emailHint: getMaskedEmailHint(auth.user.email),
         role: auth.claims.role,
         durationMs: Date.now() - startedAt,
       })
@@ -179,7 +179,7 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
     )
   } catch (error) {
     console.error('[auth] onboarding guard lookup failed', {
-      emailDomainHint: getEmailDomainHint(auth.user.email),
+      emailHint: getMaskedEmailHint(auth.user.email),
       role: auth.claims.role,
       error: error instanceof Error ? error.message : String(error),
     })
@@ -230,7 +230,7 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
   if (shouldLogAuthInstrumentation) {
     console.info('[auth-instrumentation]', {
       event: 'onboarding_guard_complete',
-      emailDomainHint: getEmailDomainHint(auth.user.email),
+      emailHint: getMaskedEmailHint(auth.user.email),
       role: auth.claims.role,
       durationMs: Date.now() - startedAt,
       shouldRedirectToForms,

--- a/web/app/lib/auth.server.ts
+++ b/web/app/lib/auth.server.ts
@@ -8,11 +8,20 @@ import { createClient } from "@/lib/supabase/server";
 
 const ONBOARDING_GUARD_TIMEOUT_MS = Number.parseInt(process.env.ONBOARDING_GUARD_TIMEOUT_MS ?? '15000', 10)
 const onboardingGuardTimeoutMs = Number.isFinite(ONBOARDING_GUARD_TIMEOUT_MS) ? ONBOARDING_GUARD_TIMEOUT_MS : 15000
+const ONBOARDING_STATUS_CACHE_TTL_MS = process.env.NODE_ENV === 'test' ? 0 : 5000
 const AUTH_PERMISSION_DRIFT_ALERT_TIMEOUT_MS = 2000
 const authPermissionDriftWebhookUrl = (process.env.AUTH_PERMISSION_DRIFT_WEBHOOK_URL ?? '').trim()
 
 const shouldLogAuthInstrumentation =
   process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
+
+const onboardingStatusCache = new Map<
+  string,
+  {
+    expiresAt: number
+    promise: ReturnType<typeof getSignUpDetailsStatus>
+  }
+>()
 
 const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -80,6 +89,43 @@ const emitPermissionDriftAlert = async ({
       error: error instanceof Error ? error.message : String(error),
     })
   }
+}
+
+const getCachedSignUpDetailsStatus = (
+  supabase: ReturnType<typeof createClient>['supabase'],
+  userId: string,
+  role: string
+) => {
+  if (ONBOARDING_STATUS_CACHE_TTL_MS <= 0) {
+    return withTimeout(
+      getSignUpDetailsStatus(supabase, userId, role),
+      onboardingGuardTimeoutMs,
+      'onboarding_guard'
+    )
+  }
+
+  const key = `${userId}:${role}`
+  const now = Date.now()
+  const cached = onboardingStatusCache.get(key)
+  if (cached && cached.expiresAt > now) {
+    return cached.promise
+  }
+
+  const promise = withTimeout(
+    getSignUpDetailsStatus(supabase, userId, role),
+    onboardingGuardTimeoutMs,
+    'onboarding_guard'
+  ).catch(error => {
+    onboardingStatusCache.delete(key)
+    throw error
+  })
+
+  onboardingStatusCache.set(key, {
+    expiresAt: now + ONBOARDING_STATUS_CACHE_TTL_MS,
+    promise,
+  })
+
+  return promise
 }
 
 export async function requireAuth(request: Request) {
@@ -172,11 +218,7 @@ export async function enforceOnboardingGuard(request: Request, opts?: { allowMyF
   const { supabase } = createClient(request);
   let signUpStatus
   try {
-    signUpStatus = await withTimeout(
-      getSignUpDetailsStatus(supabase, auth.user.id, auth.claims.role),
-      onboardingGuardTimeoutMs,
-      'onboarding_guard'
-    )
+    signUpStatus = await getCachedSignUpDetailsStatus(supabase, auth.user.id, auth.claims.role)
   } catch (error) {
     console.error('[auth] onboarding guard lookup failed', {
       emailHint: getMaskedEmailHint(auth.user.email),

--- a/web/app/lib/email-domain.ts
+++ b/web/app/lib/email-domain.ts
@@ -8,16 +8,22 @@ export const ALLOWED_EMAIL_PATTERN = `^[^\\s@]+@(${ALLOWED_EMAIL_DOMAINS
 
 export const normalizeEmail = (value: string) => value.trim().toLowerCase()
 
-export const getEmailDomainHint = (email: string | null | undefined) => {
+export const getMaskedEmailHint = (email: string | null | undefined) => {
   if (!email) return null
   const normalized = normalizeEmail(email)
   const parts = normalized.split('@')
-  if (parts.length !== 2 || !parts[1]) return null
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null
 
+  const username = parts[0]
   const domain = parts[1]
-  if (domain.length <= 5) return domain
-  return `${domain.slice(0, 3)}${domain.slice(-2)}`
+  const usernamePrefix = username.slice(0, 3)
+  const usernameSuffix = username.length > 3 ? username.slice(-2) : ''
+  const maskedUsername = usernameSuffix ? `${usernamePrefix}***${usernameSuffix}` : `${usernamePrefix}***`
+
+  return `${maskedUsername}@${domain}`
 }
+
+export const getEmailDomainHint = getMaskedEmailHint
 
 export const isAllowedEmailDomain = (value: string) => {
   const normalized = normalizeEmail(value)

--- a/web/app/lib/onboarding.server.ts
+++ b/web/app/lib/onboarding.server.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 import type { Database, Json } from '@/lib/database.types'
-import { getEmailDomainHint } from '@/lib/email-domain'
+import { getMaskedEmailHint } from '@/lib/email-domain'
 import { loadSubmissionAnswerState } from '@/lib/form-submission-answers.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { getSignUpFlowContext } from '@/lib/sign-up-flow-context.server'
@@ -201,7 +201,7 @@ export async function getSignUpDetailsStatus(
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_missing_profile',
-        emailDomainHint: null,
+        emailHint: null,
         roleOverride: roleOverride ?? null,
         durationMs: Date.now() - startedAt,
       })
@@ -215,12 +215,12 @@ export async function getSignUpDetailsStatus(
   }
 
   const role = roleOverride && roleOverride !== 'unassigned' ? roleOverride : profile.role ?? roleOverride ?? null
-  const emailDomainHint = getEmailDomainHint(profile.email)
+  const emailHint = getMaskedEmailHint(profile.email)
   if (!role || role === 'unassigned') {
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_unassigned',
-        emailDomainHint,
+        emailHint,
         profileId: profile.id,
         durationMs: Date.now() - startedAt,
       })
@@ -232,7 +232,7 @@ export async function getSignUpDetailsStatus(
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_non_signup_role_complete',
-        emailDomainHint,
+        emailHint,
         profileId: profile.id,
         role,
         durationMs: Date.now() - startedAt,
@@ -290,7 +290,7 @@ export async function getSignUpDetailsStatus(
     if (shouldLogOnboardingInstrumentation) {
       console.info('[onboarding-instrumentation]', {
         event: 'signup_status_student',
-        emailDomainHint,
+        emailHint,
         profileId: profile.id,
         formsComplete,
         guardianCount: guardianIds.length,
@@ -310,7 +310,7 @@ export async function getSignUpDetailsStatus(
   if (shouldLogOnboardingInstrumentation) {
     console.info('[onboarding-instrumentation]', {
       event: 'signup_status_guardian',
-      emailDomainHint,
+      emailHint,
       profileId: profile.id,
       formsComplete,
       durationMs: Date.now() - startedAt,

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -6,11 +6,11 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { enforceOnboardingGuard } from '@/lib/auth.server'
+import { getMaskedEmailHint, normalizeEmail } from '@/lib/email-domain'
 import { isGiftCardReleasedNow } from '@/lib/gift-cards/release.server'
 import { resolveFamilyGraph } from '@/lib/family.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
-import { getEmailDomainHint, normalizeEmail } from '@/lib/email-domain'
 import {
   Table,
   TableBody,
@@ -228,7 +228,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (shouldLogHomeInstrumentation) {
     console.info('[home-instrumentation]', {
       event: 'home_loader_base',
-      emailDomainHint: getEmailDomainHint(auth.user.email),
+      emailHint: getMaskedEmailHint(auth.user.email),
       role: auth.claims.role,
       familyProfiles: family.familyProfileIds.length,
       enrollmentCount: enrollments.length,


### PR DESCRIPTION
## What changed
- changed instrumentation identity field to masked email hint format from username + domain (example: sai+test@chsolutions.ca -> sai***st@chsolutions.ca)
- updated auth, onboarding, and home instrumentation payloads to use emailHint
- added short-lived in-process cache for onboarding status lookups in enforceOnboardingGuard
  - deduplicates parallel root/home loader guard checks for the same user/role
  - keeps timeout/error behavior unchanged

## Why
- reduce PII exposure in logs while keeping traceability
- reduce duplicate onboarding DB work that was inflating home route latency

## Verification
- npm run typecheck (web/)