### PR TITLE
Reintroduce gift card eligibility timing with legacy-safe resolution

### DIFF
--- a/supabase/schemas/06_gift_cards.sql
+++ b/supabase/schemas/06_gift_cards.sql
@@ -113,6 +113,9 @@ create index gift_card_upload_status_idx on public.gift_card_upload(status);
 create index gift_card_allocation_status_idx on public.gift_card_allocation(status);
 create index gift_card_allocation_class_profile_idx on public.gift_card_allocation(class_id, profile_id);
 create index gift_card_allocation_sent_idx on public.gift_card_allocation(reminder_sent_at);
+create index gift_card_allocation_allocated_unsent_idx
+  on public.gift_card_allocation(status, reminder_sent_at, id)
+  where status = 'allocated' and reminder_sent_at is null;
 create index gift_card_click_event_allocation_idx on public.gift_card_click_event(gift_card_allocation_id, created_at desc);
 create index gift_card_click_event_profile_idx on public.gift_card_click_event(profile_id, created_at desc);
 

--- a/web/app/lib/gift-cards/release.server.ts
+++ b/web/app/lib/gift-cards/release.server.ts
@@ -1,4 +1,6 @@
 const TORONTO_TIME_ZONE = 'America/Toronto'
+const ELIGIBILITY_TIMING_ENABLED =
+  (process.env.GIFT_CARD_ELIGIBILITY_TIMING_ENABLED ?? 'true').trim().toLowerCase() !== 'false'
 
 const torontoDateTimeFormatter = new Intl.DateTimeFormat('en-CA', {
   timeZone: TORONTO_TIME_ZONE,
@@ -26,6 +28,7 @@ const torontoPartsForDate = (date: Date) => {
   const parts = torontoDateTimeFormatter.formatToParts(date)
   const get = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? ''
   return {
+    weekday: get('weekday'),
     year: Number.parseInt(get('year'), 10),
     month: Number.parseInt(get('month'), 10),
     day: Number.parseInt(get('day'), 10),
@@ -90,6 +93,74 @@ export const nextReleaseAtIso = (classEndsAt: string | null) => {
 
   return null
 }
+
+const weekdayIndexByLabel: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+}
+
+export const classWeekFridayNoonTorontoIso = (classAtIso: string | null) => {
+  if (!classAtIso) return null
+  const classAt = new Date(classAtIso)
+  if (!Number.isFinite(classAt.getTime())) return null
+
+  const local = torontoPartsForDate(classAt)
+  const weekday = weekdayIndexByLabel[local.weekday]
+
+  if (!Number.isFinite(weekday)) return null
+
+  const daysSinceMonday = (weekday + 6) % 7
+  const monday = addDaysToDateParts(local.year, local.month, local.day, -daysSinceMonday)
+  const friday = addDaysToDateParts(monday.year, monday.month, monday.day, 4)
+  const fridayNoon = torontoTimeUtcForDate(friday.year, friday.month, friday.day, 12, 0)
+  return fridayNoon ? fridayNoon.toISOString() : null
+}
+
+export const eligibleAfterIso = (qualificationSinceAtIso: string | null) => {
+  if (!qualificationSinceAtIso) return null
+  const qualificationSinceAt = new Date(qualificationSinceAtIso)
+  if (!Number.isFinite(qualificationSinceAt.getTime())) return null
+  return new Date(qualificationSinceAt.getTime() + 6 * 60 * 60 * 1000).toISOString()
+}
+
+const maxIso = (leftIso: string | null, rightIso: string | null) => {
+  const leftMs = Date.parse((leftIso ?? '').trim())
+  const rightMs = Date.parse((rightIso ?? '').trim())
+  if (!Number.isFinite(leftMs) && !Number.isFinite(rightMs)) return null
+  if (!Number.isFinite(leftMs)) return rightIso
+  if (!Number.isFinite(rightMs)) return leftIso
+  return leftMs >= rightMs ? leftIso : rightIso
+}
+
+export const releaseReadyAtIso = ({
+  classAtIso,
+  qualificationSinceAtIso,
+}: {
+  classAtIso: string | null
+  qualificationSinceAtIso: string | null
+}) => {
+  const fridayNoon = classWeekFridayNoonTorontoIso(classAtIso)
+  const eligibleAfter = eligibleAfterIso(qualificationSinceAtIso)
+  return maxIso(fridayNoon, eligibleAfter)
+}
+
+export const isReleaseReadyNow = ({
+  releaseReadyAt,
+  now = Date.now(),
+}: {
+  releaseReadyAt: string | null | undefined
+  now?: number
+}) => {
+  const releaseReadyAtMs = Date.parse((releaseReadyAt ?? '').trim())
+  return Number.isFinite(releaseReadyAtMs) && releaseReadyAtMs <= now
+}
+
+export const isEligibilityTimingEnabled = () => ELIGIBILITY_TIMING_ENABLED
 
 export const isGiftCardReleasedNow = ({
   releaseAt,

--- a/web/app/lib/gift-cards/release.server.ts
+++ b/web/app/lib/gift-cards/release.server.ts
@@ -162,6 +162,93 @@ export const isReleaseReadyNow = ({
 
 export const isEligibilityTimingEnabled = () => ELIGIBILITY_TIMING_ENABLED
 
+type ReleaseResolutionSource =
+  | 'release_ready_at'
+  | 'computed_with_qualification'
+  | 'legacy_release'
+  | 'unresolved'
+
+type GiftCardReleaseMetadata = {
+  release_at?: string | null
+  release_ready_at?: string | null
+  qualification_since_at?: string | null
+} | null
+
+const validIsoOrNull = (value: string | null | undefined) => {
+  const trimmed = (value ?? '').trim()
+  return Number.isFinite(Date.parse(trimmed)) ? trimmed : null
+}
+
+const legacyEffectiveReleaseAtIso = ({
+  releaseAt,
+  classEndsAt,
+}: {
+  releaseAt: string | null | undefined
+  classEndsAt: string | null
+}) => validIsoOrNull(releaseAt) ?? validIsoOrNull(nextReleaseAtIso(classEndsAt))
+
+export const resolveGiftCardRelease = ({
+  metadata,
+  classAt,
+  classEndsAt,
+  now = Date.now(),
+  eligibilityTimingEnabled = isEligibilityTimingEnabled(),
+}: {
+  metadata: GiftCardReleaseMetadata
+  classAt: string | null
+  classEndsAt: string | null
+  now?: number
+  eligibilityTimingEnabled?: boolean
+}) => {
+  const releasedAtOrNull = (value: string | null) => {
+    if (!value) return false
+    return Date.parse(value) <= now
+  }
+
+  if (!eligibilityTimingEnabled) {
+    const effectiveReleaseAt = legacyEffectiveReleaseAtIso({ releaseAt: metadata?.release_at, classEndsAt })
+    return {
+      source: (effectiveReleaseAt ? 'legacy_release' : 'unresolved') as ReleaseResolutionSource,
+      effectiveReleaseAt,
+      isReleased: releasedAtOrNull(effectiveReleaseAt),
+    }
+  }
+
+  const explicitReadyAt = validIsoOrNull(metadata?.release_ready_at)
+  if (explicitReadyAt) {
+    return {
+      source: 'release_ready_at' as ReleaseResolutionSource,
+      effectiveReleaseAt: explicitReadyAt,
+      isReleased: releasedAtOrNull(explicitReadyAt),
+    }
+  }
+
+  const qualificationSinceAt = validIsoOrNull(metadata?.qualification_since_at)
+  if (qualificationSinceAt) {
+    const computedReadyAt = validIsoOrNull(
+      releaseReadyAtIso({
+        classAtIso: classAt,
+        qualificationSinceAtIso: qualificationSinceAt,
+      })
+    )
+
+    if (computedReadyAt) {
+      return {
+        source: 'computed_with_qualification' as ReleaseResolutionSource,
+        effectiveReleaseAt: computedReadyAt,
+        isReleased: releasedAtOrNull(computedReadyAt),
+      }
+    }
+  }
+
+  const legacyReleaseAt = legacyEffectiveReleaseAtIso({ releaseAt: metadata?.release_at, classEndsAt })
+  return {
+    source: (legacyReleaseAt ? 'legacy_release' : 'unresolved') as ReleaseResolutionSource,
+    effectiveReleaseAt: legacyReleaseAt,
+    isReleased: releasedAtOrNull(legacyReleaseAt),
+  }
+}
+
 export const isGiftCardReleasedNow = ({
   releaseAt,
   classEndsAt,

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -1,5 +1,11 @@
 import { sendTemplateEmail } from '@/lib/email/send-email.server'
-import { nextReleaseAtIso } from '@/lib/gift-cards/release.server'
+import {
+  eligibleAfterIso,
+  isEligibilityTimingEnabled,
+  isReleaseReadyNow,
+  nextReleaseAtIso,
+  releaseReadyAtIso,
+} from '@/lib/gift-cards/release.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
 
@@ -15,6 +21,7 @@ type GiftCardJobResult = {
 }
 
 const allocationKey = (classId: string, profileId: string) => `${classId}::${profileId}`
+const PAGE_SIZE = 500
 
 const TORONTO_TIME_ZONE = 'America/Toronto'
 
@@ -209,60 +216,8 @@ const requestedProviderFromDisplay = (value: string | null | undefined) => {
 
 const allocateGiftCards = async () => {
   const nowIso = new Date().toISOString()
-  const { data: attendanceRows, error: attendanceError } = await adminClient
-    .from('class_attendance')
-    .select('id, class_id, profile_id, camera_on, photo_status, gift_card_blocked, class:class_id(ends_at), profile:profile_id(email)')
-    .or('camera_on.eq.true,photo_status.eq.accepted,photo_status.eq.uploaded')
-
-  if (attendanceError) {
-    throw new Error(`Failed to load attendance rows: ${attendanceError.message}`)
-  }
-
-  const typedRows = (attendanceRows ?? []) as Array<{
-    id: string
-    class_id: string
-    profile_id: string
-    camera_on: boolean | null
-    photo_status: 'uploaded' | 'accepted' | 'rejected' | null
-    gift_card_blocked: boolean | null
-    class: { ends_at: string | null } | Array<{ ends_at: string | null }> | null
-    profile: { email: string | null } | Array<{ email: string | null }> | null
-  }>
-
-  const classIds = Array.from(new Set(typedRows.map(row => row.class_id)))
-  const profileIds = Array.from(new Set(typedRows.map(row => row.profile_id)))
-
-  let requestedProviderByProfileId = new Map<string, 'PC' | 'Sobeys' | 'meal_kit' | null>()
-  if (profileIds.length) {
-    try {
-      const enrichment = await loadWorkshopEnrollmentEnrichment(profileIds)
-      for (const profileId of profileIds) {
-        const display = enrichment[profileId]?.giftcard_display
-        requestedProviderByProfileId.set(profileId, requestedProviderFromDisplay(display))
-      }
-    } catch (error) {
-      console.warn('[gift-cards] provider preference enrichment failed', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
-  }
-
-  const { data: allocationRows, error: allocationError } = classIds.length
-    ? await adminClient
-        .from('gift_card_allocation')
-        .select('id, class_id, profile_id')
-        .in('class_id', classIds)
-        .in('profile_id', profileIds)
-    : { data: [], error: null }
-
-  if (allocationError) {
-    throw new Error(`Failed to load allocations: ${allocationError.message}`)
-  }
-
-  const allocationByPair = new Map<string, string>()
-  for (const row of allocationRows ?? []) {
-    allocationByPair.set(allocationKey(row.class_id, row.profile_id), row.id)
-  }
+  const eligibilityTimingEnabled = isEligibilityTimingEnabled()
+  const requestedProviderByProfileId = new Map<string, 'PC' | 'Sobeys' | 'meal_kit' | null>()
 
   const { data: assets, error: assetsError } = await adminClient
     .from('gift_card_asset')
@@ -287,70 +242,168 @@ const allocateGiftCards = async () => {
   }
   let allocated = 0
 
-  for (const row of typedRows) {
-    const hasAttendanceEvidence = row.camera_on === true || row.photo_status === 'accepted' || row.photo_status === 'uploaded'
-    if (!hasAttendanceEvidence) continue
-    if (row.gift_card_blocked) continue
-    if (allocationByPair.has(allocationKey(row.class_id, row.profile_id))) continue
+  let lastAttendanceId = ''
+  let pagesRead = 0
+  let rowsScanned = 0
 
-    const requestedProvider = requestedProviderByProfileId.get(row.profile_id) ?? null
-    if (requestedProvider === 'meal_kit') continue
-    const providerForAllocation = requestedProvider === 'Sobeys' ? 'Sobeys' : 'PC'
+  while (true) {
+    const attendanceQuery = adminClient
+      .from('class_attendance')
+      .select('id, class_id, profile_id, camera_on, photo_status, gift_card_blocked, class:class_id(starts_at, ends_at), profile:profile_id(email)')
+      .or('camera_on.eq.true,photo_status.eq.accepted,photo_status.eq.uploaded')
+      .order('id', { ascending: true })
+      .limit(PAGE_SIZE)
 
-    const providerBucket = availableByProvider[providerForAllocation]
-    if (!providerBucket.length) continue
+    const { data: attendanceRows, error: attendanceError } = lastAttendanceId
+      ? await attendanceQuery.gt('id', lastAttendanceId)
+      : await attendanceQuery
 
-    const classRelation = Array.isArray(row.class) ? row.class[0] : row.class
-    const releaseAt = nextReleaseAtIso(classRelation?.ends_at ?? null)
-    if (!releaseAt) continue
-
-    const assetId = providerBucket.shift() as string
-    const { data: updatedAsset, error: claimError } = await adminClient
-      .from('gift_card_asset')
-      .update({
-        status: 'allocated',
-        assigned_profile_id: row.profile_id,
-        allocated_at: nowIso,
-      })
-      .eq('id', assetId)
-      .eq('status', 'available')
-      .select('id')
-      .maybeSingle()
-
-    if (claimError || !updatedAsset?.id) {
-      continue
+    if (attendanceError) {
+      throw new Error(`Failed to load attendance rows: ${attendanceError.message}`)
     }
 
-    const { data: inserted, error: insertError } = await adminClient
-      .from('gift_card_allocation')
-      .insert({
-        class_id: row.class_id,
-        profile_id: row.profile_id,
-        class_attendance_id: row.id,
-        gift_card_asset_id: assetId,
-        status: 'allocated',
-        metadata: {
-          release_at: releaseAt,
-        },
-      })
-      .select('id')
-      .maybeSingle()
+    const typedRows = (attendanceRows ?? []) as Array<{
+      id: string
+      class_id: string
+      profile_id: string
+      camera_on: boolean | null
+      photo_status: 'uploaded' | 'accepted' | 'rejected' | null
+      gift_card_blocked: boolean | null
+      class: { starts_at: string | null; ends_at: string | null } | Array<{ starts_at: string | null; ends_at: string | null }> | null
+      profile: { email: string | null } | Array<{ email: string | null }> | null
+    }>
 
-    if (insertError || !inserted?.id) {
-      await adminClient
+    if (!typedRows.length) break
+
+    pagesRead += 1
+    rowsScanned += typedRows.length
+
+    const classIds = Array.from(new Set(typedRows.map(row => row.class_id)))
+    const profileIds = Array.from(new Set(typedRows.map(row => row.profile_id)))
+
+    const uncachedProfileIds = profileIds.filter(profileId => !requestedProviderByProfileId.has(profileId))
+    if (uncachedProfileIds.length) {
+      try {
+        const enrichment = await loadWorkshopEnrollmentEnrichment(uncachedProfileIds)
+        for (const profileId of uncachedProfileIds) {
+          const display = enrichment[profileId]?.giftcard_display
+          requestedProviderByProfileId.set(profileId, requestedProviderFromDisplay(display))
+        }
+      } catch (error) {
+        console.warn('[gift-cards] provider preference enrichment failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    const { data: allocationRows, error: allocationError } = classIds.length
+      ? await adminClient
+          .from('gift_card_allocation')
+          .select('id, class_id, profile_id')
+          .in('class_id', classIds)
+          .in('profile_id', profileIds)
+      : { data: [], error: null }
+
+    if (allocationError) {
+      throw new Error(`Failed to load allocations: ${allocationError.message}`)
+    }
+
+    const allocationByPair = new Map<string, string>()
+    for (const row of allocationRows ?? []) {
+      allocationByPair.set(allocationKey(row.class_id, row.profile_id), row.id)
+    }
+
+    for (const row of typedRows) {
+      const hasAttendanceEvidence = row.camera_on === true || row.photo_status === 'accepted' || row.photo_status === 'uploaded'
+      if (!hasAttendanceEvidence) continue
+      if (row.gift_card_blocked) continue
+      if (allocationByPair.has(allocationKey(row.class_id, row.profile_id))) continue
+
+      const requestedProvider = requestedProviderByProfileId.get(row.profile_id) ?? null
+      if (requestedProvider === 'meal_kit') continue
+      const providerForAllocation = requestedProvider === 'Sobeys' ? 'Sobeys' : 'PC'
+
+      const providerBucket = availableByProvider[providerForAllocation]
+      if (!providerBucket.length) continue
+
+      const classRelation = Array.isArray(row.class) ? row.class[0] : row.class
+      const classAt = classRelation?.starts_at ?? classRelation?.ends_at ?? null
+      const releaseAt = nextReleaseAtIso(classRelation?.ends_at ?? null)
+      if (!releaseAt) continue
+
+      const qualificationSinceAt = eligibilityTimingEnabled ? nowIso : null
+      const releaseReadyAt = eligibilityTimingEnabled
+        ? releaseReadyAtIso({ classAtIso: classAt, qualificationSinceAtIso: qualificationSinceAt })
+        : null
+      if (eligibilityTimingEnabled && !releaseReadyAt) continue
+
+      const assetId = providerBucket.shift() as string
+      const { data: updatedAsset, error: claimError } = await adminClient
         .from('gift_card_asset')
         .update({
-          status: 'available',
-          assigned_profile_id: null,
-          allocated_at: null,
+          status: 'allocated',
+          assigned_profile_id: row.profile_id,
+          allocated_at: nowIso,
         })
         .eq('id', assetId)
-      continue
+        .eq('status', 'available')
+        .select('id')
+        .maybeSingle()
+
+      if (claimError || !updatedAsset?.id) {
+        continue
+      }
+
+      const metadata = eligibilityTimingEnabled
+        ? {
+            release_at: releaseAt,
+            qualification_since_at: qualificationSinceAt,
+            eligible_after_at: eligibleAfterIso(qualificationSinceAt),
+            release_ready_at: releaseReadyAt,
+          }
+        : {
+            release_at: releaseAt,
+          }
+
+      const { data: inserted, error: insertError } = await adminClient
+        .from('gift_card_allocation')
+        .insert({
+          class_id: row.class_id,
+          profile_id: row.profile_id,
+          class_attendance_id: row.id,
+          gift_card_asset_id: assetId,
+          status: 'allocated',
+          metadata,
+        })
+        .select('id')
+        .maybeSingle()
+
+      if (insertError || !inserted?.id) {
+        await adminClient
+          .from('gift_card_asset')
+          .update({
+            status: 'available',
+            assigned_profile_id: null,
+            allocated_at: null,
+          })
+          .eq('id', assetId)
+        continue
+      }
+
+      allocationByPair.set(allocationKey(row.class_id, row.profile_id), inserted.id)
+      allocated += 1
     }
 
-    allocationByPair.set(allocationKey(row.class_id, row.profile_id), inserted.id)
-    allocated += 1
+    lastAttendanceId = typedRows[typedRows.length - 1]?.id ?? lastAttendanceId
+    if (typedRows.length < PAGE_SIZE) break
   }
+
+  console.info('[gift-cards][allocate]', {
+    eligibilityTimingEnabled,
+    pagesRead,
+    rowsScanned,
+    allocated,
+  })
 
   return allocated
 }
@@ -358,10 +411,11 @@ const allocateGiftCards = async () => {
 const sendDueReminders = async (appOrigin: string) => {
   const now = new Date()
   const nowIso = now.toISOString()
+  const eligibilityTimingEnabled = isEligibilityTimingEnabled()
   const publicHubOrigin = resolvePublicHubOrigin(appOrigin)
   const hubUrl = `${publicHubOrigin}/home`
   const reminderSlotIso = currentTorontoReminderSlotIso(now)
-  if (!reminderSlotIso) {
+  if (!eligibilityTimingEnabled && !reminderSlotIso) {
     return {
       remindersSent: 0,
       remindersSkipped: 0,
@@ -370,41 +424,60 @@ const sendDueReminders = async (appOrigin: string) => {
     }
   }
 
-  const { data: allocations, error: allocationError } = await adminClient
-    .from('gift_card_allocation')
-    .select(
-      'id, class_id, profile_id, gift_card_asset_id, status, blocked, reminder_sent_at, metadata, class:class_id(ends_at), profile:profile_id(email), asset:gift_card_asset_id(provider, value, status, assigned_profile_id)'
-    )
-    .eq('status', 'allocated')
-    .is('reminder_sent_at', null)
-
-  if (allocationError) {
-    throw new Error(`Failed to load due reminders: ${allocationError.message}`)
-  }
-
   let remindersSent = 0
   let remindersSkipped = 0
   let reminderFailures = 0
   const errors: string[] = []
 
-  const rows = (allocations ?? []) as Array<{
-    id: string
-    class_id: string
-    profile_id: string
-    gift_card_asset_id: string
-    status: 'allocated' | 'sent' | 'opened'
-    blocked: boolean
-    reminder_sent_at: string | null
-    metadata: { release_at?: string | null } | null
-    class: { ends_at: string | null } | Array<{ ends_at: string | null }> | null
-    profile: { email: string | null } | Array<{ email: string | null }> | null
-    asset:
-      | { provider: 'PC' | 'Sobeys'; value: number; status: string; assigned_profile_id: string | null }
-      | Array<{ provider: 'PC' | 'Sobeys'; value: number; status: string; assigned_profile_id: string | null }>
-      | null
-  }>
+  let lastAllocationId = ''
+  let pagesRead = 0
+  let rowsScanned = 0
 
-  for (const row of rows) {
+  while (true) {
+    const allocationQuery = adminClient
+      .from('gift_card_allocation')
+      .select(
+        'id, class_id, profile_id, gift_card_asset_id, status, blocked, reminder_sent_at, metadata, class:class_id(starts_at, ends_at), profile:profile_id(email), asset:gift_card_asset_id(provider, value, status, assigned_profile_id)'
+      )
+      .eq('status', 'allocated')
+      .is('reminder_sent_at', null)
+      .order('id', { ascending: true })
+      .limit(PAGE_SIZE)
+
+    const { data: allocations, error: allocationError } = lastAllocationId
+      ? await allocationQuery.gt('id', lastAllocationId)
+      : await allocationQuery
+
+    if (allocationError) {
+      throw new Error(`Failed to load due reminders: ${allocationError.message}`)
+    }
+
+    const rows = (allocations ?? []) as Array<{
+      id: string
+      class_id: string
+      profile_id: string
+      gift_card_asset_id: string
+      status: 'allocated' | 'sent' | 'opened'
+      blocked: boolean
+      reminder_sent_at: string | null
+      metadata: {
+        release_at?: string | null
+        release_ready_at?: string | null
+        qualification_since_at?: string | null
+      } | null
+      class: { starts_at: string | null; ends_at: string | null } | Array<{ starts_at: string | null; ends_at: string | null }> | null
+      profile: { email: string | null } | Array<{ email: string | null }> | null
+      asset:
+        | { provider: 'PC' | 'Sobeys'; value: number; status: string; assigned_profile_id: string | null }
+        | Array<{ provider: 'PC' | 'Sobeys'; value: number; status: string; assigned_profile_id: string | null }>
+        | null
+    }>
+
+    if (!rows.length) break
+    pagesRead += 1
+    rowsScanned += rows.length
+
+    for (const row of rows) {
     const allocationLockAcquired = await tryAcquireGiftCardAllocationLock(row.id)
     if (!allocationLockAcquired) {
       remindersSkipped += 1
@@ -418,25 +491,38 @@ const sendDueReminders = async (appOrigin: string) => {
     }
 
     const classRelation = Array.isArray(row.class) ? row.class[0] : row.class
-    const expectedReleaseAt = nextReleaseAtIso(classRelation?.ends_at ?? null)
-    const releaseAt = (row.metadata?.release_at ?? '').trim() || expectedReleaseAt || ''
-    if (!releaseAt) {
-      continue
-    }
+    const classAt = classRelation?.starts_at ?? classRelation?.ends_at ?? null
+    if (eligibilityTimingEnabled) {
+      const releaseReadyAt =
+        row.metadata?.release_ready_at ??
+        releaseReadyAtIso({
+          classAtIso: classAt,
+          qualificationSinceAtIso: row.metadata?.qualification_since_at ?? null,
+        })
+      if (!isReleaseReadyNow({ releaseReadyAt, now: now.getTime() })) {
+        continue
+      }
+    } else {
+      const expectedReleaseAt = nextReleaseAtIso(classRelation?.ends_at ?? null)
+      const releaseAt = (row.metadata?.release_at ?? '').trim() || expectedReleaseAt || ''
+      if (!releaseAt) {
+        continue
+      }
 
-    const releaseDate = new Date(releaseAt)
-    if (!Number.isFinite(releaseDate.getTime()) || releaseDate.getTime() > now.getTime()) {
-      continue
-    }
+      const releaseDate = new Date(releaseAt)
+      if (!Number.isFinite(releaseDate.getTime()) || releaseDate.getTime() > now.getTime()) {
+        continue
+      }
 
-    const releaseToronto = torontoPartsForDate(releaseDate)
-    const reminderSlotForReleaseDate = reminderSlotIsoForTorontoDate(
-      releaseToronto.year,
-      releaseToronto.month,
-      releaseToronto.day
-    )
-    if (!reminderSlotForReleaseDate || reminderSlotForReleaseDate !== reminderSlotIso) {
-      continue
+      const releaseToronto = torontoPartsForDate(releaseDate)
+      const reminderSlotForReleaseDate = reminderSlotIsoForTorontoDate(
+        releaseToronto.year,
+        releaseToronto.month,
+        releaseToronto.day
+      )
+      if (!reminderSlotForReleaseDate || reminderSlotForReleaseDate !== reminderSlotIso) {
+        continue
+      }
     }
 
     const profileRelation = Array.isArray(row.profile) ? row.profile[0] : row.profile
@@ -520,6 +606,19 @@ const sendDueReminders = async (appOrigin: string) => {
       await releaseGiftCardAllocationLock(row.id)
     }
   }
+
+    lastAllocationId = rows[rows.length - 1]?.id ?? lastAllocationId
+    if (rows.length < PAGE_SIZE) break
+  }
+
+  console.info('[gift-cards][reminders]', {
+    eligibilityTimingEnabled,
+    pagesRead,
+    rowsScanned,
+    remindersSent,
+    remindersSkipped,
+    reminderFailures,
+  })
 
   return {
     remindersSent,

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -2,9 +2,9 @@ import { sendTemplateEmail } from '@/lib/email/send-email.server'
 import {
   eligibleAfterIso,
   isEligibilityTimingEnabled,
-  isReleaseReadyNow,
   nextReleaseAtIso,
   releaseReadyAtIso,
+  resolveGiftCardRelease,
 } from '@/lib/gift-cards/release.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
@@ -411,23 +411,20 @@ const allocateGiftCards = async () => {
 const sendDueReminders = async (appOrigin: string) => {
   const now = new Date()
   const nowIso = now.toISOString()
-  const eligibilityTimingEnabled = isEligibilityTimingEnabled()
   const publicHubOrigin = resolvePublicHubOrigin(appOrigin)
   const hubUrl = `${publicHubOrigin}/home`
   const reminderSlotIso = currentTorontoReminderSlotIso(now)
-  if (!eligibilityTimingEnabled && !reminderSlotIso) {
-    return {
-      remindersSent: 0,
-      remindersSkipped: 0,
-      reminderFailures: 0,
-      errors: [],
-    }
-  }
 
   let remindersSent = 0
   let remindersSkipped = 0
   let reminderFailures = 0
   const errors: string[] = []
+  const releaseSourceCount = {
+    release_ready_at: 0,
+    computed_with_qualification: 0,
+    legacy_release: 0,
+    unresolved: 0,
+  }
 
   let lastAllocationId = ''
   let pagesRead = 0
@@ -492,25 +489,25 @@ const sendDueReminders = async (appOrigin: string) => {
 
     const classRelation = Array.isArray(row.class) ? row.class[0] : row.class
     const classAt = classRelation?.starts_at ?? classRelation?.ends_at ?? null
-    if (eligibilityTimingEnabled) {
-      const releaseReadyAt =
-        row.metadata?.release_ready_at ??
-        releaseReadyAtIso({
-          classAtIso: classAt,
-          qualificationSinceAtIso: row.metadata?.qualification_since_at ?? null,
-        })
-      if (!isReleaseReadyNow({ releaseReadyAt, now: now.getTime() })) {
-        continue
-      }
-    } else {
-      const expectedReleaseAt = nextReleaseAtIso(classRelation?.ends_at ?? null)
-      const releaseAt = (row.metadata?.release_at ?? '').trim() || expectedReleaseAt || ''
-      if (!releaseAt) {
+    const release = resolveGiftCardRelease({
+      metadata: row.metadata,
+      classAt,
+      classEndsAt: classRelation?.ends_at ?? null,
+      now: now.getTime(),
+    })
+    releaseSourceCount[release.source] += 1
+
+    if (!release.isReleased) {
+      continue
+    }
+
+    if (release.source === 'legacy_release') {
+      if (!reminderSlotIso || !release.effectiveReleaseAt) {
         continue
       }
 
-      const releaseDate = new Date(releaseAt)
-      if (!Number.isFinite(releaseDate.getTime()) || releaseDate.getTime() > now.getTime()) {
+      const releaseDate = new Date(release.effectiveReleaseAt)
+      if (!Number.isFinite(releaseDate.getTime())) {
         continue
       }
 
@@ -612,12 +609,13 @@ const sendDueReminders = async (appOrigin: string) => {
   }
 
   console.info('[gift-cards][reminders]', {
-    eligibilityTimingEnabled,
+    eligibilityTimingEnabled: isEligibilityTimingEnabled(),
     pagesRead,
     rowsScanned,
     remindersSent,
     remindersSkipped,
     reminderFailures,
+    releaseSourceCount,
   })
 
   return {

--- a/web/app/routes/glr.$token.ts
+++ b/web/app/routes/glr.$token.ts
@@ -3,7 +3,7 @@ import { redirect, type LoaderFunctionArgs } from 'react-router'
 import { extractRequestMetadata } from '@/lib/request-metadata.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 
-import { isEligibilityTimingEnabled, isGiftCardReleasedNow, isReleaseReadyNow, releaseReadyAtIso } from '@/lib/gift-cards/release.server'
+import { resolveGiftCardRelease } from '@/lib/gift-cards/release.server'
 import { hashGlrToken } from '@/lib/gift-cards/token.server'
 
 const homeMessageRedirect = ({ request, message }: { request: Request; message: string }) => {
@@ -53,19 +53,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const classAt = (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.starts_at ??
     (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ??
     null
-  const released = isEligibilityTimingEnabled()
-    ? isReleaseReadyNow({
-        releaseReadyAt:
-          allocation?.metadata?.release_ready_at ??
-          releaseReadyAtIso({
-            classAtIso: classAt,
-            qualificationSinceAtIso: allocation?.metadata?.qualification_since_at ?? null,
-          }),
-      })
-    : isGiftCardReleasedNow({
-        releaseAt: allocation?.metadata?.release_at,
-        classEndsAt: (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ?? null,
-      })
+  const released = resolveGiftCardRelease({
+    metadata: allocation?.metadata ?? null,
+    classAt,
+    classEndsAt: (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ?? null,
+  }).isReleased
 
   if (!allocation || allocation.blocked || (allocation.status === 'allocated' && !released)) {
     return invalidLink({ request })

--- a/web/app/routes/glr.$token.ts
+++ b/web/app/routes/glr.$token.ts
@@ -3,7 +3,7 @@ import { redirect, type LoaderFunctionArgs } from 'react-router'
 import { extractRequestMetadata } from '@/lib/request-metadata.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 
-import { isGiftCardReleasedNow } from '@/lib/gift-cards/release.server'
+import { isEligibilityTimingEnabled, isGiftCardReleasedNow, isReleaseReadyNow, releaseReadyAtIso } from '@/lib/gift-cards/release.server'
 import { hashGlrToken } from '@/lib/gift-cards/token.server'
 
 const homeMessageRedirect = ({ request, message }: { request: Request; message: string }) => {
@@ -26,7 +26,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const tokenHash = hashGlrToken(token)
   const { data: allocationByHash, error: allocationError } = await adminClient
     .from('gift_card_allocation')
-    .select('id, profile_id, blocked, status, metadata, class_id, gift_card_asset_id, asset:gift_card_asset_id(asset_url), class:class_id(ends_at)')
+    .select('id, profile_id, blocked, status, metadata, class_id, gift_card_asset_id, asset:gift_card_asset_id(asset_url), class:class_id(starts_at, ends_at)')
     .eq('glr_token_hash', tokenHash)
     .maybeSingle()
 
@@ -43,17 +43,29 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (!allocation && isUuidToken) {
     const { data: allocationById } = await adminClient
       .from('gift_card_allocation')
-      .select('id, profile_id, blocked, status, metadata, class_id, gift_card_asset_id, asset:gift_card_asset_id(asset_url), class:class_id(ends_at)')
+      .select('id, profile_id, blocked, status, metadata, class_id, gift_card_asset_id, asset:gift_card_asset_id(asset_url), class:class_id(starts_at, ends_at)')
       .eq('id', token)
       .maybeSingle()
     allocation = allocationById
   }
 
   const classRelation = allocation?.class
-  const released = isGiftCardReleasedNow({
-    releaseAt: allocation?.metadata?.release_at,
-    classEndsAt: (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ?? null,
-  })
+  const classAt = (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.starts_at ??
+    (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ??
+    null
+  const released = isEligibilityTimingEnabled()
+    ? isReleaseReadyNow({
+        releaseReadyAt:
+          allocation?.metadata?.release_ready_at ??
+          releaseReadyAtIso({
+            classAtIso: classAt,
+            qualificationSinceAtIso: allocation?.metadata?.qualification_since_at ?? null,
+          }),
+      })
+    : isGiftCardReleasedNow({
+        releaseAt: allocation?.metadata?.release_at,
+        classEndsAt: (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ?? null,
+      })
 
   if (!allocation || allocation.blocked || (allocation.status === 'allocated' && !released)) {
     return invalidLink({ request })

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/input'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { enforceOnboardingGuard } from '@/lib/auth.server'
 import { getMaskedEmailHint, normalizeEmail } from '@/lib/email-domain'
-import { isEligibilityTimingEnabled, isGiftCardReleasedNow, isReleaseReadyNow, releaseReadyAtIso } from '@/lib/gift-cards/release.server'
+import { resolveGiftCardRelease } from '@/lib/gift-cards/release.server'
 import { resolveFamilyGraph } from '@/lib/family.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
@@ -410,21 +410,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     } | null
   }>).reduce<Record<string, string>>((acc, row) => {
     if (row.blocked) return acc
-    const released = isEligibilityTimingEnabled()
-      ? isReleaseReadyNow({
-          releaseReadyAt:
-            row.metadata?.release_ready_at ??
-            releaseReadyAtIso({
-              classAtIso: classAtById[row.class_id] ?? null,
-              qualificationSinceAtIso: row.metadata?.qualification_since_at ?? null,
-            }),
-          now,
-        })
-      : isGiftCardReleasedNow({
-          releaseAt: row.metadata?.release_at,
-          classEndsAt: classEndsAtById[row.class_id] ?? null,
-          now,
-        })
+    const released = resolveGiftCardRelease({
+      metadata: row.metadata,
+      classAt: classAtById[row.class_id] ?? null,
+      classEndsAt: classEndsAtById[row.class_id] ?? null,
+      now,
+    }).isReleased
     const availableByReminder = Boolean(row.reminder_sent_at && (row.status === 'sent' || row.status === 'opened'))
     if (!released && !availableByReminder) return acc
     const selectedProfileId = selectedProfileIdByClass[row.class_id]

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/input'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { enforceOnboardingGuard } from '@/lib/auth.server'
 import { getMaskedEmailHint, normalizeEmail } from '@/lib/email-domain'
-import { isGiftCardReleasedNow } from '@/lib/gift-cards/release.server'
+import { isEligibilityTimingEnabled, isGiftCardReleasedNow, isReleaseReadyNow, releaseReadyAtIso } from '@/lib/gift-cards/release.server'
 import { resolveFamilyGraph } from '@/lib/family.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
@@ -288,6 +288,9 @@ export async function loader({ request }: Route.LoaderArgs) {
     acc[classRow.workshop_id].push(classRow)
     return acc
   }, {})
+  const classAtById = Object.fromEntries(
+    classes.map(classRow => [classRow.id, classRow.starts_at || classRow.ends_at])
+  ) as Record<string, string>
   const classEndsAtById = Object.fromEntries(classes.map(classRow => [classRow.id, classRow.ends_at])) as Record<string, string>
 
   const classIds = classes.map(classRow => classRow.id)
@@ -400,14 +403,28 @@ export async function loader({ request }: Route.LoaderArgs) {
     status: 'allocated' | 'sent' | 'opened'
     blocked: boolean
     reminder_sent_at: string | null
-    metadata: { release_at?: string | null } | null
+    metadata: {
+      release_at?: string | null
+      release_ready_at?: string | null
+      qualification_since_at?: string | null
+    } | null
   }>).reduce<Record<string, string>>((acc, row) => {
     if (row.blocked) return acc
-    const released = isGiftCardReleasedNow({
-      releaseAt: row.metadata?.release_at,
-      classEndsAt: classEndsAtById[row.class_id] ?? null,
-      now,
-    })
+    const released = isEligibilityTimingEnabled()
+      ? isReleaseReadyNow({
+          releaseReadyAt:
+            row.metadata?.release_ready_at ??
+            releaseReadyAtIso({
+              classAtIso: classAtById[row.class_id] ?? null,
+              qualificationSinceAtIso: row.metadata?.qualification_since_at ?? null,
+            }),
+          now,
+        })
+      : isGiftCardReleasedNow({
+          releaseAt: row.metadata?.release_at,
+          classEndsAt: classEndsAtById[row.class_id] ?? null,
+          now,
+        })
     const availableByReminder = Boolean(row.reminder_sent_at && (row.status === 'sent' || row.status === 'opened'))
     if (!released && !availableByReminder) return acc
     const selectedProfileId = selectedProfileIdByClass[row.class_id]

--- a/web/app/routes/manage/gift-cards.tsx
+++ b/web/app/routes/manage/gift-cards.tsx
@@ -2,6 +2,7 @@ import { Link, useLoaderData } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
+import { isEligibilityTimingEnabled } from '@/lib/gift-cards/release.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { createClient } from '@/lib/supabase/server'
 import TableDisplay from './table-display'
@@ -146,6 +147,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       release: `Mon/Fri ${formatTorontoClock(RELEASE_HOUR_TORONTO, RELEASE_MINUTE_TORONTO)}`,
       reminder: `Mon/Fri ${formatTorontoClock(REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)}`,
     },
+    eligibilityTimingEnabled: isEligibilityTimingEnabled(),
     statusTotals,
     totalAssetCount,
     columns: ['provider', 'account_number', 'pin', 'value', 'status', 'asset_url', 'profile_display', 'upload_id', 'created_at'],
@@ -181,8 +183,17 @@ export default function GiftCardsPage() {
             ))}
           </div>
           <div className="rounded border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">System timing</span>{' '}
-            (timezone: {data.systemTiming.timezone}) - Available: {data.systemTiming.release} - Reminder: {data.systemTiming.reminder}
+            {data.eligibilityTimingEnabled ? (
+              <>
+                <span className="font-medium text-foreground">Availability rule</span> Available and reminder eligible after 6
+                hours qualified and past class-week Friday noon (Toronto).
+              </>
+            ) : (
+              <>
+                <span className="font-medium text-foreground">System timing</span>{' '}
+                (timezone: {data.systemTiming.timezone}) - Available: {data.systemTiming.release} - Reminder: {data.systemTiming.reminder}
+              </>
+            )}
           </div>
           <Button asChild>
             <Link to="/manage/gift-cards/upload">Upload gift cards</Link>

--- a/web/tests/unit/gift-card-release.spec.ts
+++ b/web/tests/unit/gift-card-release.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  classWeekFridayNoonTorontoIso,
+  isReleaseReadyNow,
+  releaseReadyAtIso,
+} from '../../app/lib/gift-cards/release.server'
+
+test('class week Friday noon uses same week for Friday evening classes', async () => {
+  const mondayClass = classWeekFridayNoonTorontoIso('2026-07-06T14:00:00.000Z')
+  const fridayEveningClass = classWeekFridayNoonTorontoIso('2026-07-10T23:00:00.000Z')
+
+  expect(mondayClass).toBe('2026-07-10T16:00:00.000Z')
+  expect(fridayEveningClass).toBe('2026-07-10T16:00:00.000Z')
+})
+
+test('release ready time is max of Friday noon and qualified plus six hours', async () => {
+  const beforeFridayNoon = releaseReadyAtIso({
+    classAtIso: '2026-07-08T12:00:00.000Z',
+    qualificationSinceAtIso: '2026-07-08T12:00:00.000Z',
+  })
+  const afterFridayNoon = releaseReadyAtIso({
+    classAtIso: '2026-07-10T23:00:00.000Z',
+    qualificationSinceAtIso: '2026-07-10T22:00:00.000Z',
+  })
+
+  expect(beforeFridayNoon).toBe('2026-07-10T16:00:00.000Z')
+  expect(afterFridayNoon).toBe('2026-07-11T04:00:00.000Z')
+})
+
+test('Toronto noon conversion is stable across DST boundaries', async () => {
+  const spring = classWeekFridayNoonTorontoIso('2026-03-09T14:00:00.000Z')
+  const fall = classWeekFridayNoonTorontoIso('2026-11-02T15:00:00.000Z')
+
+  expect(spring).toBe('2026-03-13T16:00:00.000Z')
+  expect(fall).toBe('2026-11-06T17:00:00.000Z')
+})
+
+test('readiness check compares release_ready_at with now', async () => {
+  expect(
+    isReleaseReadyNow({
+      releaseReadyAt: '2026-07-10T16:00:00.000Z',
+      now: Date.parse('2026-07-10T15:59:59.000Z'),
+    })
+  ).toBeFalsy()
+  expect(
+    isReleaseReadyNow({
+      releaseReadyAt: '2026-07-10T16:00:00.000Z',
+      now: Date.parse('2026-07-10T16:00:00.000Z'),
+    })
+  ).toBeTruthy()
+})

--- a/web/tests/unit/gift-card-release.spec.ts
+++ b/web/tests/unit/gift-card-release.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test'
 import {
   classWeekFridayNoonTorontoIso,
   isReleaseReadyNow,
+  resolveGiftCardRelease,
   releaseReadyAtIso,
 } from '../../app/lib/gift-cards/release.server'
 
@@ -49,4 +50,34 @@ test('readiness check compares release_ready_at with now', async () => {
       now: Date.parse('2026-07-10T16:00:00.000Z'),
     })
   ).toBeTruthy()
+})
+
+test('release resolver uses explicit release_ready_at when present', async () => {
+  const release = resolveGiftCardRelease({
+    metadata: {
+      release_ready_at: '2026-07-10T16:00:00.000Z',
+      qualification_since_at: null,
+      release_at: '2026-07-14T16:00:00.000Z',
+    },
+    classAt: '2026-07-08T12:00:00.000Z',
+    classEndsAt: '2026-07-08T13:00:00.000Z',
+    now: Date.parse('2026-07-10T16:00:00.000Z'),
+  })
+
+  expect(release.source).toBe('release_ready_at')
+  expect(release.isReleased).toBeTruthy()
+})
+
+test('release resolver falls back to legacy release when qualification metadata is missing', async () => {
+  const release = resolveGiftCardRelease({
+    metadata: {
+      release_at: '2026-07-14T16:00:00.000Z',
+    },
+    classAt: '2026-07-08T12:00:00.000Z',
+    classEndsAt: '2026-07-08T13:00:00.000Z',
+    now: Date.parse('2026-07-11T16:00:00.000Z'),
+  })
+
+  expect(release.source).toBe('legacy_release')
+  expect(release.isReleased).toBeFalsy()
 })


### PR DESCRIPTION
## What changed
- reintroduced eligibility-based gift card release timing and metadata writes
- added shared release resolver to keep home, GLR links, and reminders consistent
- kept legacy-safe fallback for rows without qualification metadata
- added pagination and release-source metrics in gift card reminder processing
- restored and expanded gift card release unit coverage
- aligned gift card allocation partial index in declarative schema

## Verification
- npm run typecheck (web)
- npm run test:unit -- tests/unit/gift-card-release.spec.ts
- npm run build (web)

## Notes
- no backfill migration is included; runtime business logic handles existing rows safely.