### PR TITLE
Grant staff profiles.read permission

### DIFF
--- a/supabase/migrations/20260709120000_staff_profiles_read_permission.sql
+++ b/supabase/migrations/20260709120000_staff_profiles_read_permission.sql
@@ -1,0 +1,3 @@
+insert into public.role_permission (role, permission)
+values ('staff'::app_role, 'profiles.read'::app_permissions)
+on conflict do nothing;

--- a/supabase/schemas/00_roles.sql
+++ b/supabase/schemas/00_roles.sql
@@ -171,6 +171,11 @@ select r.role, p.permission
 from (values ('admin'::app_role), ('manager'::app_role)) as r(role)
 cross join (select unnest(enum_range(null::app_permissions)) as permission) p
 on conflict do nothing;
+
+insert into public.role_permission (role, permission)
+values ('staff'::app_role, 'profiles.read'::app_permissions)
+on conflict do nothing;
+
 grant execute on function public.current_user_role() to authenticated, supabase_auth_admin;
 
 -- Auto-provision a user role on signup.


### PR DESCRIPTION
## What
- add staff profiles.read permission to declarative role permission seed in supabase/schemas/00_roles.sql
- add migration to grant profiles.read to staff in existing environments

## Why
- staff can access /manage/families in UI, but RLS checks authorize('profiles.read') on person_guardian_child
- without this permission, staff see an effectively blank families view

## Notes
- migration is idempotent (on conflict do nothing)