### PR TITLE
Add Tuesday meal-kit pickup reminder flow

### DIFF
--- a/supabase/migrations/20260708195500_meal_kit_pickup_reminder_email_draft.sql
+++ b/supabase/migrations/20260708195500_meal_kit_pickup_reminder_email_draft.sql
@@ -1,0 +1,111 @@
+create or replace function public.ensure_meal_kit_pickup_reminder_email_draft()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_draft_id uuid;
+  v_version_id uuid;
+begin
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    'meal_kit_pickup_reminder_v1',
+    'Meal kit pickup reminder',
+    'Reminder for meal kit families on Tuesday morning pickup window.',
+    'Sent Tuesday mornings Toronto time to families with meal kit preference.',
+    'meal_kit_pickup.reminder',
+    'web/app/lib/gift-cards/runner.server.ts',
+    'transactional',
+    'draft',
+    true,
+    '{}'::jsonb,
+    'SummerLunch+ meal kit pickup reminder for today',
+    E'Hi,\nThis is a friendly reminder that summerlunch+ meal kit pickup is today, Tuesday, at the East York Town Centre.\nPickup Location: Thorncliffe Community Hub - Entrance 6\nPickup Time: Between 1:00 PM and 6:00 PM\nPlease remember to bring reusable bags or a shopping trolley/cart, as the meal kits can be heavy.\nIf you are unable to attend pickup, please let us know as soon as possible by replying to this email.\nWe look forward to seeing you today!\n- The summerlunch+ Team'
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      is_system = true,
+      variables_schema = case
+        when public.email_draft.variables_schema = '{}'::jsonb then excluded.variables_schema
+        else public.email_draft.variables_schema
+      end,
+      current_subject_markdown = case
+        when char_length(btrim(public.email_draft.current_subject_markdown)) = 0 then excluded.current_subject_markdown
+        else public.email_draft.current_subject_markdown
+      end,
+      current_body_markdown = case
+        when char_length(btrim(public.email_draft.current_body_markdown)) = 0 then excluded.current_body_markdown
+        else public.email_draft.current_body_markdown
+      end
+  returning id into v_draft_id;
+
+  insert into public.email_draft_version (
+    email_draft_id,
+    version_number,
+    subject_markdown,
+    body_markdown,
+    subject_rendered,
+    html_rendered,
+    text_rendered,
+    variables_schema,
+    change_note,
+    published_at
+  )
+  values (
+    v_draft_id,
+    1,
+    'SummerLunch+ meal kit pickup reminder for today',
+    E'Hi,\nThis is a friendly reminder that summerlunch+ meal kit pickup is today, Tuesday, at the East York Town Centre.\nPickup Location: Thorncliffe Community Hub - Entrance 6\nPickup Time: Between 1:00 PM and 6:00 PM\nPlease remember to bring reusable bags or a shopping trolley/cart, as the meal kits can be heavy.\nIf you are unable to attend pickup, please let us know as soon as possible by replying to this email.\nWe look forward to seeing you today!\n- The summerlunch+ Team',
+    'SummerLunch+ meal kit pickup reminder for today',
+    '<p>Hi,<br />This is a friendly reminder that summerlunch+ meal kit pickup is today, Tuesday, at the East York Town Centre.<br />Pickup Location: Thorncliffe Community Hub - Entrance 6<br />Pickup Time: Between 1:00 PM and 6:00 PM<br />Please remember to bring reusable bags or a shopping trolley/cart, as the meal kits can be heavy.<br />If you are unable to attend pickup, please let us know as soon as possible by replying to this email.<br />We look forward to seeing you today!<br />- The summerlunch+ Team</p>',
+    E'Hi,\nThis is a friendly reminder that summerlunch+ meal kit pickup is today, Tuesday, at the East York Town Centre.\nPickup Location: Thorncliffe Community Hub - Entrance 6\nPickup Time: Between 1:00 PM and 6:00 PM\nPlease remember to bring reusable bags or a shopping trolley/cart, as the meal kits can be heavy.\nIf you are unable to attend pickup, please let us know as soon as possible by replying to this email.\nWe look forward to seeing you today!\n- The summerlunch+ Team',
+    '{}'::jsonb,
+    'Seeded meal kit pickup reminder draft content.',
+    now()
+  )
+  on conflict (email_draft_id, version_number) do nothing;
+
+  if exists (
+    select 1
+    from public.email_draft
+    where id = v_draft_id
+      and published_version_id is null
+  ) then
+    select version.id
+      into v_version_id
+    from public.email_draft_version as version
+    where version.email_draft_id = v_draft_id
+    order by version.version_number desc
+    limit 1;
+
+    update public.email_draft
+    set
+      published_version_id = v_version_id,
+      status = 'published'
+    where id = v_draft_id;
+  end if;
+end;
+$$;
+
+select public.ensure_meal_kit_pickup_reminder_email_draft();

--- a/web/app/lib/email/templates/index.ts
+++ b/web/app/lib/email/templates/index.ts
@@ -18,6 +18,10 @@ import {
   renderGiftCardReminderEmail,
   type GiftCardReminderTemplateData,
 } from '@/lib/email/templates/gift-card-reminder'
+import {
+  renderMealKitPickupReminderEmail,
+  type MealKitPickupReminderTemplateData,
+} from '@/lib/email/templates/meal-kit-pickup-reminder'
 
 export type EmailTemplateMap = {
   family_enrollment_requested_v1: FamilyEnrollmentRequestedTemplateData
@@ -25,6 +29,7 @@ export type EmailTemplateMap = {
   class_reminder_login_v1: ClassReminderLoginTemplateData
   class_camera_or_photo_followup_v1: ClassCameraOrPhotoFollowupTemplateData
   gift_card_reminder_v1: GiftCardReminderTemplateData
+  meal_kit_pickup_reminder_v1: MealKitPickupReminderTemplateData
 }
 
 export type EmailTemplateKey = keyof EmailTemplateMap
@@ -48,6 +53,9 @@ export const emailTemplates: {
   },
   gift_card_reminder_v1: {
     render: renderGiftCardReminderEmail,
+  },
+  meal_kit_pickup_reminder_v1: {
+    render: renderMealKitPickupReminderEmail,
   },
 }
 

--- a/web/app/lib/email/templates/meal-kit-pickup-reminder.ts
+++ b/web/app/lib/email/templates/meal-kit-pickup-reminder.ts
@@ -1,0 +1,49 @@
+export type MealKitPickupReminderTemplateData = Record<string, never>
+
+export const renderMealKitPickupReminderEmail = (_data: MealKitPickupReminderTemplateData) => {
+  const subject = 'SummerLunch+ meal kit pickup reminder for today'
+  const text = `Hi,
+This is a friendly reminder that summerlunch+ meal kit pickup is today, Tuesday, at the East York Town Centre.
+Pickup Location: Thorncliffe Community Hub - Entrance 6
+Pickup Time: Between 1:00 PM and 6:00 PM
+Please remember to bring reusable bags or a shopping trolley/cart, as the meal kits can be heavy.
+If you are unable to attend pickup, please let us know as soon as possible by replying to this email.
+We look forward to seeing you today!
+- The summerlunch+ Team`
+
+  const html = `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background-color:#f6f8fb;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0;padding:24px;background-color:#f6f8fb;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background-color:#ffffff;border-radius:12px;overflow:hidden;">
+            <tr>
+              <td style="padding:24px 24px 8px 24px;text-align:center;">
+                <img src="https://cdn.summerlunchplus.com/summerlunch%2B.png" alt="SummerLunch Plus" width="180" style="display:block;margin:0 auto;border:0;outline:none;text-decoration:none;height:auto;" />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
+                <p style="margin:0 0 12px 0;">Hi,</p>
+                <p style="margin:0 0 12px 0;">This is a friendly reminder that summerlunch+ meal kit pickup is <strong>today, Tuesday</strong>, at the East York Town Centre.</p>
+                <p style="margin:0 0 8px 0;">Pickup Location: Thorncliffe Community Hub - Entrance 6</p>
+                <p style="margin:0 0 12px 0;">Pickup Time: Between 1:00 PM and 6:00 PM</p>
+                <p style="margin:0 0 12px 0;">Please remember to bring reusable bags or a shopping trolley/cart, as the meal kits can be heavy.</p>
+                <p style="margin:0 0 12px 0;">If you are unable to attend pickup, please let us know as soon as possible by replying to this email.</p>
+                <p style="margin:0;">We look forward to seeing you today!<br />- The summerlunch+ Team</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`
+
+  return {
+    subject,
+    text,
+    html,
+  }
+}

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -17,6 +17,9 @@ type GiftCardJobResult = {
   remindersSent: number
   remindersSkipped: number
   reminderFailures: number
+  mealKitRemindersSent: number
+  mealKitRemindersSkipped: number
+  mealKitReminderFailures: number
   errors: string[]
 }
 
@@ -104,6 +107,8 @@ const releaseGiftCardAllocationLock = async (allocationId: string) => {
 
 const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONTO', isProductionRuntime ? 12 : 11)
 const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
+const MEAL_KIT_REMINDER_HOUR_TORONTO = parseHourMinuteEnv('MEAL_KIT_REMINDER_HOUR_TORONTO', 9)
+const MEAL_KIT_REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('MEAL_KIT_REMINDER_MINUTE_TORONTO', 0)
 
 const torontoPartsForDate = (date: Date) => {
   const parts = torontoDateTimeFormatter.formatToParts(date)
@@ -160,6 +165,245 @@ const currentTorontoReminderSlotIso = (now: Date) => {
 const reminderSlotIsoForTorontoDate = (year: number, month: number, day: number) => {
   const slot = torontoTimeUtcForDate(year, month, day, REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)
   return slot ? slot.toISOString() : null
+}
+
+const currentTorontoMealKitReminderSlotIso = (now: Date) => {
+  const toronto = torontoPartsForDate(now)
+  if (
+    toronto.weekday !== 'Tue' ||
+    toronto.hour !== MEAL_KIT_REMINDER_HOUR_TORONTO ||
+    toronto.minute < MEAL_KIT_REMINDER_MINUTE_TORONTO ||
+    toronto.minute >= MEAL_KIT_REMINDER_MINUTE_TORONTO + 5
+  ) {
+    return null
+  }
+
+  const slot = torontoTimeUtcForDate(
+    toronto.year,
+    toronto.month,
+    toronto.day,
+    MEAL_KIT_REMINDER_HOUR_TORONTO,
+    MEAL_KIT_REMINDER_MINUTE_TORONTO
+  )
+  return slot ? slot.toISOString() : null
+}
+
+const CHUNK_SIZE = 250
+
+const chunkArray = <T,>(items: T[], size: number) => {
+  if (size <= 0 || !items.length) return [] as T[][]
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+const resolveRecipientEmailsByProfileIds = async (profileIds: string[]) => {
+  const uniqueProfileIds = Array.from(new Set(profileIds.filter(Boolean)))
+  const emailsByProfileId = new Map<string, string>()
+  if (!uniqueProfileIds.length) return emailsByProfileId
+
+  const directEmailByProfileId = new Map<string, string>()
+  for (const chunk of chunkArray(uniqueProfileIds, CHUNK_SIZE)) {
+    const { data, error } = await adminClient.from('profile').select('id, email').in('id', chunk)
+    if (error) {
+      throw new Error(`Failed to load profile emails: ${error.message}`)
+    }
+    for (const row of data ?? []) {
+      const email = (row.email ?? '').trim().toLowerCase()
+      if (email) {
+        directEmailByProfileId.set(row.id, email)
+      }
+    }
+  }
+
+  const guardianIdsByChild = new Map<string, string[]>()
+  const guardianIds = new Set<string>()
+  for (const chunk of chunkArray(uniqueProfileIds, CHUNK_SIZE)) {
+    const { data, error } = await adminClient
+      .from('person_guardian_child')
+      .select('child_profile_id, guardian_profile_id')
+      .in('child_profile_id', chunk)
+
+    if (error) {
+      throw new Error(`Failed to load guardian relationships: ${error.message}`)
+    }
+
+    for (const row of data ?? []) {
+      if (!row.child_profile_id || !row.guardian_profile_id) continue
+      const bucket = guardianIdsByChild.get(row.child_profile_id) ?? []
+      if (!bucket.includes(row.guardian_profile_id)) {
+        bucket.push(row.guardian_profile_id)
+      }
+      guardianIdsByChild.set(row.child_profile_id, bucket)
+      guardianIds.add(row.guardian_profile_id)
+    }
+  }
+
+  const guardianEmailByProfileId = new Map<string, string>()
+  const guardianIdList = Array.from(guardianIds)
+  for (const chunk of chunkArray(guardianIdList, CHUNK_SIZE)) {
+    const { data, error } = await adminClient.from('profile').select('id, email').in('id', chunk)
+    if (error) {
+      throw new Error(`Failed to load guardian emails: ${error.message}`)
+    }
+    for (const row of data ?? []) {
+      const email = (row.email ?? '').trim().toLowerCase()
+      if (email) {
+        guardianEmailByProfileId.set(row.id, email)
+      }
+    }
+  }
+
+  for (const profileId of uniqueProfileIds) {
+    const direct = directEmailByProfileId.get(profileId)
+    if (direct) {
+      emailsByProfileId.set(profileId, direct)
+      continue
+    }
+
+    const guardianCandidates = guardianIdsByChild.get(profileId) ?? []
+    for (const guardianId of guardianCandidates) {
+      const guardianEmail = guardianEmailByProfileId.get(guardianId)
+      if (guardianEmail) {
+        emailsByProfileId.set(profileId, guardianEmail)
+        break
+      }
+    }
+  }
+
+  return emailsByProfileId
+}
+
+const sendMealKitPickupReminders = async () => {
+  const now = new Date()
+  const nowIso = now.toISOString()
+  const reminderSlotIso = currentTorontoMealKitReminderSlotIso(now)
+  if (!reminderSlotIso) {
+    return {
+      remindersSent: 0,
+      remindersSkipped: 0,
+      reminderFailures: 0,
+      errors: [] as string[],
+    }
+  }
+
+  const { data: activeSemesters, error: activeSemestersError } = await adminClient
+    .from('semester')
+    .select('id')
+    .lte('starts_at', nowIso)
+    .gte('ends_at', nowIso)
+
+  if (activeSemestersError) {
+    throw new Error(`Failed to load active semesters: ${activeSemestersError.message}`)
+  }
+
+  const activeSemesterIds = (activeSemesters ?? []).map(row => row.id)
+  if (!activeSemesterIds.length) {
+    return {
+      remindersSent: 0,
+      remindersSkipped: 0,
+      reminderFailures: 0,
+      errors: [] as string[],
+    }
+  }
+
+  const approvedProfileIds = new Set<string>()
+  for (const semesterIdChunk of chunkArray(activeSemesterIds, CHUNK_SIZE)) {
+    const { data: enrollments, error: enrollmentError } = await adminClient
+      .from('workshop_enrollment')
+      .select('profile_id')
+      .in('semester_id', semesterIdChunk)
+      .eq('status', 'approved')
+      .not('profile_id', 'is', null)
+
+    if (enrollmentError) {
+      throw new Error(`Failed to load approved enrollments: ${enrollmentError.message}`)
+    }
+
+    for (const enrollment of enrollments ?? []) {
+      if (enrollment.profile_id) {
+        approvedProfileIds.add(enrollment.profile_id)
+      }
+    }
+  }
+
+  const profileIds = Array.from(approvedProfileIds)
+  if (!profileIds.length) {
+    return {
+      remindersSent: 0,
+      remindersSkipped: 0,
+      reminderFailures: 0,
+      errors: [] as string[],
+    }
+  }
+
+  const enrichment = await loadWorkshopEnrollmentEnrichment(profileIds)
+  const mealKitProfileIds = profileIds.filter(profileId => {
+    const value = (enrichment[profileId]?.giftcard_display ?? '').trim().toLowerCase()
+    return value === 'meal kit'
+  })
+
+  if (!mealKitProfileIds.length) {
+    return {
+      remindersSent: 0,
+      remindersSkipped: 0,
+      reminderFailures: 0,
+      errors: [] as string[],
+    }
+  }
+
+  const emailsByProfileId = await resolveRecipientEmailsByProfileIds(mealKitProfileIds)
+  const uniqueRecipients = new Map<string, string>()
+  for (const profileId of mealKitProfileIds) {
+    const email = (emailsByProfileId.get(profileId) ?? '').trim().toLowerCase()
+    if (email && !uniqueRecipients.has(email)) {
+      uniqueRecipients.set(email, profileId)
+    }
+  }
+
+  let remindersSent = 0
+  let remindersSkipped = 0
+  let reminderFailures = 0
+  const errors: string[] = []
+
+  for (const [toEmail, profileId] of uniqueRecipients.entries()) {
+    const eventKey = `meal-kit-pickup-reminder:${reminderSlotIso}:${toEmail}`
+    const emailResult = await sendTemplateEmail({
+      toEmail,
+      templateKey: 'meal_kit_pickup_reminder_v1',
+      templateData: {},
+      profileId,
+      eventKey,
+    })
+
+    if (emailResult.status === 'failed') {
+      reminderFailures += 1
+      errors.push(`meal-kit ${toEmail}: ${emailResult.error ?? 'send failed'}`)
+      continue
+    }
+
+    if (emailResult.status === 'sent') {
+      remindersSent += 1
+    } else {
+      remindersSkipped += 1
+    }
+  }
+
+  console.info('[gift-cards][meal-kit-reminders]', {
+    remindersSent,
+    remindersSkipped,
+    reminderFailures,
+    recipientsScanned: uniqueRecipients.size,
+  })
+
+  return {
+    remindersSent,
+    remindersSkipped,
+    reminderFailures,
+    errors,
+  }
 }
 
 const resolveRecipientEmail = async (profileId: string, fallbackEmail: string | null) => {
@@ -635,6 +879,9 @@ export const runGiftCardJobs = async ({ appOrigin, runId }: { appOrigin: string;
       remindersSent: 0,
       remindersSkipped: 0,
       reminderFailures: 0,
+      mealKitRemindersSent: 0,
+      mealKitRemindersSkipped: 0,
+      mealKitReminderFailures: 0,
       errors: ['gift-card runner lock not acquired'],
     }
   }
@@ -662,12 +909,28 @@ export const runGiftCardJobs = async ({ appOrigin, runId }: { appOrigin: string;
     errors.push(error instanceof Error ? error.message : 'reminder step failed')
   }
 
+  let mealKitRemindersSent = 0
+  let mealKitRemindersSkipped = 0
+  let mealKitReminderFailures = 0
+  try {
+    const mealKitReminderResult = await sendMealKitPickupReminders()
+    mealKitRemindersSent = mealKitReminderResult.remindersSent
+    mealKitRemindersSkipped = mealKitReminderResult.remindersSkipped
+    mealKitReminderFailures = mealKitReminderResult.reminderFailures
+    errors.push(...mealKitReminderResult.errors)
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'meal-kit reminder step failed')
+  }
+
   return {
     runId,
     allocated,
     remindersSent,
     remindersSkipped,
     reminderFailures,
+    mealKitRemindersSent,
+    mealKitRemindersSkipped,
+    mealKitReminderFailures,
     errors,
   }
   } finally {


### PR DESCRIPTION
## What\n- add meal-kit pickup reminder template (`meal_kit_pickup_reminder_v1`)\n- seed/publish template via manual migration\n- add Tuesday Toronto-time reminder pass to gift-card runner for approved meal-kit families\n- dedupe recipients by email and use idempotent event keys per slot\n\n## Validation\n- npm run typecheck (web)