### PR TITLE
Expose Zoom registrant 400 error details

### DIFF
--- a/web/app/lib/zoom-jobs/zoom-api.client.server.ts
+++ b/web/app/lib/zoom-jobs/zoom-api.client.server.ts
@@ -32,7 +32,27 @@ export class ZoomApiError extends Error {
   payload: unknown
 
   constructor({ status, path, payload }: { status: number; path: string; payload: unknown }) {
-    super(`zoom-api ${path} failed (${status})`)
+    const payloadSummary = (() => {
+      if (!payload) return ''
+      if (typeof payload === 'string') {
+        const trimmed = payload.trim()
+        return trimmed ? `: ${trimmed}` : ''
+      }
+      if (typeof payload === 'object') {
+        const detail =
+          'detail' in (payload as Record<string, unknown>)
+            ? (payload as Record<string, unknown>).detail
+            : null
+        if (typeof detail === 'string' && detail.trim()) {
+          return `: ${detail.trim()}`
+        }
+        const serialized = JSON.stringify(payload)
+        return serialized && serialized !== '{}' ? `: ${serialized}` : ''
+      }
+      return ''
+    })()
+
+    super(`zoom-api ${path} failed (${status})${payloadSummary}`)
     this.name = 'ZoomApiError'
     this.status = status
     this.path = path

--- a/zoom-api/app/main.py
+++ b/zoom-api/app/main.py
@@ -176,6 +176,23 @@ def healthz() -> dict[str, str]:
 
 def _as_http_exception(exc: httpx.HTTPStatusError) -> HTTPException:
     status = exc.response.status_code
+    payload = None
+    try:
+        payload = exc.response.json()
+    except ValueError:
+        payload = exc.response.text
+
+    upstream_detail = None
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        code = payload.get("code")
+        if isinstance(message, str) and message.strip():
+            upstream_detail = f"{message.strip()}"
+            if code is not None:
+                upstream_detail = f"{upstream_detail} (zoom_code={code})"
+    elif isinstance(payload, str) and payload.strip():
+        upstream_detail = payload.strip()
+
     if status == 404:
         detail = "Zoom resource not found. Check meeting/user identifiers."
     elif status == 403:
@@ -184,6 +201,19 @@ def _as_http_exception(exc: httpx.HTTPStatusError) -> HTTPException:
         detail = "Zoom rate limit exceeded. Retry shortly."
     else:
         detail = f"Zoom API request failed with status {status}."
+
+    if upstream_detail:
+        detail = f"{detail} {upstream_detail}"
+
+    print(
+        "[zoom-api] upstream request failed",
+        {
+            "status": status,
+            "method": exc.request.method if exc.request else None,
+            "url": str(exc.request.url) if exc.request else None,
+            "payload": payload,
+        },
+    )
     return HTTPException(status_code=status, detail=detail)
 
 @app.post("/zoom/connect", dependencies=[Depends(get_api_key)])


### PR DESCRIPTION
## What\n- include upstream Zoom error payload/details in web `ZoomApiError` messages\n- include upstream Zoom message/code in zoom-api HTTP error detail\n- log upstream zoom-api failures with method/url/status/payload for operator debugging\n\n## Validation\n- npm run typecheck (web)\n- .venv/bin/pytest tests/test_main.py -k "register_participants or remove_registrant" -v (zoom-api)