### PR TITLE
Include attempted email in Zoom registrant failures

### DIFF
--- a/web/app/lib/zoom-jobs/provision.server.ts
+++ b/web/app/lib/zoom-jobs/provision.server.ts
@@ -557,11 +557,19 @@ const ensureRegistrantsForClass = async ({
       }
     }
 
-    const registrant = await zoomApiClient.registerParticipant(meetingId, {
-      first_name: identity.firstName,
-      last_name: identity.lastName,
-      email: identity.email,
-    })
+    let registrant: Awaited<ReturnType<typeof zoomApiClient.registerParticipant>>
+    try {
+      registrant = await zoomApiClient.registerParticipant(meetingId, {
+        first_name: identity.firstName,
+        last_name: identity.lastName,
+        email: identity.email,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown registrant creation error'
+      throw new Error(
+        `${message} | attempted_profile_id=${identity.profileId} | attempted_email=${identity.email}`
+      )
+    }
 
     const tokenHash = hashZlrToken(newZlrToken())
     const { error: upsertError } = await adminClient.from('class_zoom_registrant').upsert(


### PR DESCRIPTION
## What\n- include attempted profile id and attempted email in registrant provisioning errors\n- surfaces exact payload context when Zoom returns 400 on registrant creation\n\n## Validation\n- npm run typecheck (web)