### PR TITLE
Fix family gift-card visibility on home dashboard

### DIFF
--- a/web/app/lib/router-instrumentation.ts
+++ b/web/app/lib/router-instrumentation.ts
@@ -26,6 +26,8 @@ export const useRouterInstrumentation = () => {
   const navStartRef = useRef<number | null>(null)
   const navFromRef = useRef<string>('')
   const fetcherRunsRef = useRef<Map<string, FetcherRun>>(new Map())
+  const lastNavPendingLogRef = useRef<number>(0)
+  const lastFetcherPendingLogByKeyRef = useRef<Map<string, number>>(new Map())
 
   useEffect(() => {
     const state = navigation.state
@@ -56,6 +58,32 @@ export const useRouterInstrumentation = () => {
   }, [location.pathname, location.search, navigation.formAction, navigation.formMethod, navigation.location, navigation.state])
 
   useEffect(() => {
+    if (navigation.state === 'idle') {
+      lastNavPendingLogRef.current = 0
+      return
+    }
+
+    const tick = window.setInterval(() => {
+      if (navStartRef.current === null) return
+      const elapsedMs = Math.round(performance.now() - navStartRef.current)
+      const now = Date.now()
+      if (now - lastNavPendingLogRef.current < 2000) return
+      lastNavPendingLogRef.current = now
+      logEvent('navigation_still_blocked', {
+        from: navFromRef.current,
+        to: navigation.location ? `${navigation.location.pathname}${navigation.location.search}` : null,
+        elapsedMs,
+        state: navigation.state,
+        activeFetcherCount: fetchers.filter(fetcher => fetcher.state !== 'idle').length,
+      })
+    }, 1000)
+
+    return () => {
+      window.clearInterval(tick)
+    }
+  }, [fetchers, navigation.location, navigation.state])
+
+  useEffect(() => {
     const activeKeys = new Set<string>()
 
     for (const fetcher of fetchers) {
@@ -76,6 +104,25 @@ export const useRouterInstrumentation = () => {
         })
       }
 
+      if (fetcher.state !== 'idle') {
+        const run = fetcherRunsRef.current.get(key)
+        if (run) {
+          const elapsedMs = Math.round(performance.now() - run.startedAt)
+          const lastLogAt = lastFetcherPendingLogByKeyRef.current.get(key) ?? 0
+          const now = Date.now()
+          if (elapsedMs >= 2000 && now - lastLogAt >= 2000) {
+            lastFetcherPendingLogByKeyRef.current.set(key, now)
+            logEvent('fetcher_still_blocked', {
+              key,
+              href: run.href,
+              elapsedMs,
+              state: fetcher.state,
+              currentUrl: `${location.pathname}${location.search}`,
+            })
+          }
+        }
+      }
+
       if (fetcher.state === 'idle' && fetcherRunsRef.current.has(key)) {
         const run = fetcherRunsRef.current.get(key)
         if (!run) continue
@@ -87,12 +134,14 @@ export const useRouterInstrumentation = () => {
           currentUrl: `${location.pathname}${location.search}`,
         })
         fetcherRunsRef.current.delete(key)
+        lastFetcherPendingLogByKeyRef.current.delete(key)
       }
     }
 
     for (const [key] of fetcherRunsRef.current.entries()) {
       if (activeKeys.has(key)) continue
       fetcherRunsRef.current.delete(key)
+      lastFetcherPendingLogByKeyRef.current.delete(key)
     }
   }, [fetchers, location.pathname, location.search])
 }

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -324,12 +324,19 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const profilePriority: string[] = []
   const primaryChildId = family.profileRole === 'guardian' ? (family.primaryChildByGuardian.get(family.profileId) ?? null) : null
-  if (primaryChildId) profilePriority.push(primaryChildId)
+
+  if (family.profileRole === 'student') {
+    profilePriority.push(family.profileId)
+  } else if (primaryChildId) {
+    profilePriority.push(primaryChildId)
+  }
+
   for (const child of family.children) profilePriority.push(child.id)
   for (const guardian of family.guardians) profilePriority.push(guardian.id)
   if (family.profileId) profilePriority.push(family.profileId)
 
   const orderedFamilyProfileIds = Array.from(new Set(profilePriority))
+  const profileRankById = new Map(orderedFamilyProfileIds.map((profileId, index) => [profileId, index]))
 
   const joinUrlByClass = classes.reduce<Record<string, string>>((acc, classRow) => {
     if (!classRow.workshop_id) return acc
@@ -408,7 +415,15 @@ export async function loader({ request }: Route.LoaderArgs) {
       release_ready_at?: string | null
       qualification_since_at?: string | null
     } | null
-  }>).reduce<Record<string, string>>((acc, row) => {
+  }>).reduce<
+    Record<
+      string,
+      {
+        href: string
+        rank: number
+      }
+    >
+  >((acc, row) => {
     if (row.blocked) return acc
     const released = resolveGiftCardRelease({
       metadata: row.metadata,
@@ -418,11 +433,21 @@ export async function loader({ request }: Route.LoaderArgs) {
     }).isReleased
     const availableByReminder = Boolean(row.reminder_sent_at && (row.status === 'sent' || row.status === 'opened'))
     if (!released && !availableByReminder) return acc
-    const selectedProfileId = selectedProfileIdByClass[row.class_id]
-    if (!selectedProfileId || selectedProfileId !== row.profile_id) return acc
-    acc[row.class_id] = `/glr/${row.id}`
+
+    const rank = profileRankById.get(row.profile_id) ?? Number.MAX_SAFE_INTEGER
+    const existing = acc[row.class_id]
+    if (existing && existing.rank <= rank) return acc
+
+    acc[row.class_id] = {
+      href: `/glr/${row.id}`,
+      rank,
+    }
     return acc
   }, {})
+
+  const giftCardLinkByClassFinal = Object.fromEntries(
+    Object.entries(giftCardLinkByClass).map(([classId, value]) => [classId, value.href])
+  ) as Record<string, string>
 
   const nextClassCandidate = classes
     .filter(classRow => Boolean(classRow.workshop_id) && approvedWorkshopIds.has(classRow.workshop_id) && new Date(classRow.starts_at).getTime() > now)
@@ -447,7 +472,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     enrollments,
     classesByWorkshop,
     joinUrlByClass,
-    giftCardLinkByClass,
+    giftCardLinkByClass: giftCardLinkByClassFinal,
     selectedProfileIdByClass,
     selectedPhotoStatusByClass,
     nextClass,

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -153,6 +153,7 @@ type FormAnswerPreferenceRow = {
 
 const IN_CLAUSE_BATCH_SIZE = 150
 const CLASS_ATTENDANCE_FETCH_BATCH_SIZE = 1000
+const RELATED_FETCH_BATCH_SIZE = 1000
 
 const isSchemaMismatchError = (error: { code?: string | null; message?: string | null } | null) => {
   if (!error) return false
@@ -331,12 +332,19 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   for (const chunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
-    const { data, error } = await adminClient
-      .from('class_zoom_registrant')
-      .select('class_id, profile_id, zoom_registrant_id, zoom_join_url, last_sent_at')
-      .in('class_id', chunk)
-    if (error) throw new Response(error.message, { status: 500 })
-    registrantRows.push(...((data ?? []) as RegistrantRow[]))
+    for (let offset = 0; ; offset += RELATED_FETCH_BATCH_SIZE) {
+      const { data, error } = await adminClient
+        .from('class_zoom_registrant')
+        .select('class_id, profile_id, zoom_registrant_id, zoom_join_url, last_sent_at')
+        .in('class_id', chunk)
+        .order('class_id', { ascending: true })
+        .order('profile_id', { ascending: true })
+        .range(offset, offset + RELATED_FETCH_BATCH_SIZE - 1)
+      if (error) throw new Response(error.message, { status: 500 })
+      const rows = (data ?? []) as RegistrantRow[]
+      registrantRows.push(...rows)
+      if (rows.length < RELATED_FETCH_BATCH_SIZE) break
+    }
   }
 
   for (const chunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {


### PR DESCRIPTION
## What changed
- updated home gift-card link selection so any eligible family allocation for a class can surface, instead of requiring exact selected-profile match
- ranks available allocations by family priority and picks the best released entry
- includes router instrumentation enhancements currently on branch for pending navigation/fetcher diagnostics

## Verification
- npm run typecheck (web)