### PR TITLE
Enforce availability-state release and add manual allocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - `~/` and `@/` both map to `web/app/*` (`web/tsconfig.json`).
 - For heavy manage tables, use the existing deferred pattern: lightweight page loader + client `fetcher.load()` request (see `web/app/routes/manage/deferred-table-display.tsx`).
 - For full-dataset filtering tables (for example `email-message`), use the full-scan loader pattern: set `_deferTable=1`, clear `page`/`pageSize`, and force `sort=__full_scan__`.
+- In deferred/manage loaders, always paginate large related-table fetches (`.range(...)` loops with stable `order(...)`) instead of single `.in(...)` reads. PostgREST row caps can silently truncate related rows (for example `class_zoom_registrant`) and produce false UI states.
 
 ## Local setup and verification
 - Initial local setup (repo root): `cp web/.env.template web/.env.local` -> `supabase start --debug` -> copy values from `supabase status -o json` into `web/.env.local`.

--- a/web/app/lib/gift-cards/release.server.ts
+++ b/web/app/lib/gift-cards/release.server.ts
@@ -163,6 +163,8 @@ export const isReleaseReadyNow = ({
 export const isEligibilityTimingEnabled = () => ELIGIBILITY_TIMING_ENABLED
 
 type ReleaseResolutionSource =
+  | 'availability_state'
+  | 'missing_availability_state'
   | 'release_ready_at'
   | 'computed_with_qualification'
   | 'legacy_release'
@@ -172,6 +174,7 @@ type GiftCardReleaseMetadata = {
   release_at?: string | null
   release_ready_at?: string | null
   qualification_since_at?: string | null
+  availability_state?: string | null
 } | null
 
 const validIsoOrNull = (value: string | null | undefined) => {
@@ -187,7 +190,14 @@ const legacyEffectiveReleaseAtIso = ({
   classEndsAt: string | null
 }) => validIsoOrNull(releaseAt) ?? validIsoOrNull(nextReleaseAtIso(classEndsAt))
 
-export const resolveGiftCardRelease = ({
+const normalizeAvailabilityState = (value: string | null | undefined) => {
+  const normalized = (value ?? '').trim().toLowerCase()
+  if (normalized === 'available' || normalized === 'true') return 'available'
+  if (normalized === 'unavailable' || normalized === 'false') return 'unavailable'
+  return null
+}
+
+export const resolveGiftCardReleaseFromTiming = ({
   metadata,
   classAt,
   classEndsAt,
@@ -246,6 +256,43 @@ export const resolveGiftCardRelease = ({
     source: (legacyReleaseAt ? 'legacy_release' : 'unresolved') as ReleaseResolutionSource,
     effectiveReleaseAt: legacyReleaseAt,
     isReleased: releasedAtOrNull(legacyReleaseAt),
+  }
+}
+
+export const resolveGiftCardRelease = ({
+  metadata,
+  classAt,
+  classEndsAt,
+  now = Date.now(),
+  eligibilityTimingEnabled = isEligibilityTimingEnabled(),
+}: {
+  metadata: GiftCardReleaseMetadata
+  classAt: string | null
+  classEndsAt: string | null
+  now?: number
+  eligibilityTimingEnabled?: boolean
+}) => {
+  const availabilityState = normalizeAvailabilityState(metadata?.availability_state)
+  if (availabilityState === 'available') {
+    return {
+      source: 'availability_state' as ReleaseResolutionSource,
+      effectiveReleaseAt: null,
+      isReleased: true,
+    }
+  }
+
+  if (availabilityState === 'unavailable') {
+    return {
+      source: 'availability_state' as ReleaseResolutionSource,
+      effectiveReleaseAt: null,
+      isReleased: false,
+    }
+  }
+
+  return {
+    source: 'missing_availability_state' as ReleaseResolutionSource,
+    effectiveReleaseAt: null,
+    isReleased: false,
   }
 }
 

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -5,6 +5,7 @@ import {
   nextReleaseAtIso,
   releaseReadyAtIso,
   resolveGiftCardRelease,
+  resolveGiftCardReleaseFromTiming,
 } from '@/lib/gift-cards/release.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
@@ -14,6 +15,7 @@ import { hashGlrToken, newGlrToken } from './token.server'
 type GiftCardJobResult = {
   runId: string
   allocated: number
+  availabilityBackfilled: number
   remindersSent: number
   remindersSkipped: number
   reminderFailures: number
@@ -604,9 +606,14 @@ const allocateGiftCards = async () => {
             qualification_since_at: qualificationSinceAt,
             eligible_after_at: eligibleAfterIso(qualificationSinceAt),
             release_ready_at: releaseReadyAt,
+            availability_state:
+              releaseReadyAt && Date.parse(releaseReadyAt) <= Date.parse(nowIso)
+                ? 'available'
+                : 'unavailable',
           }
         : {
             release_at: releaseAt,
+            availability_state: Date.parse(releaseAt) <= Date.parse(nowIso) ? 'available' : 'unavailable',
           }
 
       const { data: inserted, error: insertError } = await adminClient
@@ -664,6 +671,8 @@ const sendDueReminders = async (appOrigin: string) => {
   let reminderFailures = 0
   const errors: string[] = []
   const releaseSourceCount = {
+    availability_state: 0,
+    missing_availability_state: 0,
     release_ready_at: 0,
     computed_with_qualification: 0,
     legacy_release: 0,
@@ -705,6 +714,7 @@ const sendDueReminders = async (appOrigin: string) => {
         release_at?: string | null
         release_ready_at?: string | null
         qualification_since_at?: string | null
+        availability_state?: string | null
       } | null
       class: { starts_at: string | null; ends_at: string | null } | Array<{ starts_at: string | null; ends_at: string | null }> | null
       profile: { email: string | null } | Array<{ email: string | null }> | null
@@ -733,6 +743,34 @@ const sendDueReminders = async (appOrigin: string) => {
 
     const classRelation = Array.isArray(row.class) ? row.class[0] : row.class
     const classAt = classRelation?.starts_at ?? classRelation?.ends_at ?? null
+    const timingRelease = resolveGiftCardReleaseFromTiming({
+      metadata: row.metadata,
+      classAt,
+      classEndsAt: classRelation?.ends_at ?? null,
+      now: now.getTime(),
+    })
+
+    const currentAvailabilityState = (row.metadata?.availability_state ?? '').trim().toLowerCase()
+    const expectedAvailabilityState = timingRelease.isReleased ? 'available' : 'unavailable'
+    if (currentAvailabilityState !== expectedAvailabilityState) {
+      const nextMetadata = {
+        ...(row.metadata ?? {}),
+        availability_state: expectedAvailabilityState,
+      }
+      const { error: availabilityStateUpdateError } = await adminClient
+        .from('gift_card_allocation')
+        .update({ metadata: nextMetadata })
+        .eq('id', row.id)
+
+      if (availabilityStateUpdateError) {
+        reminderFailures += 1
+        errors.push(`allocation ${row.id}: failed to update availability state: ${availabilityStateUpdateError.message}`)
+        continue
+      }
+
+      row.metadata = nextMetadata
+    }
+
     const release = resolveGiftCardRelease({
       metadata: row.metadata,
       classAt,
@@ -745,12 +783,12 @@ const sendDueReminders = async (appOrigin: string) => {
       continue
     }
 
-    if (release.source === 'legacy_release') {
-      if (!reminderSlotIso || !release.effectiveReleaseAt) {
+    if (timingRelease.source === 'legacy_release') {
+      if (!reminderSlotIso || !timingRelease.effectiveReleaseAt) {
         continue
       }
 
-      const releaseDate = new Date(release.effectiveReleaseAt)
+      const releaseDate = new Date(timingRelease.effectiveReleaseAt)
       if (!Number.isFinite(releaseDate.getTime())) {
         continue
       }
@@ -870,12 +908,118 @@ const sendDueReminders = async (appOrigin: string) => {
   }
 }
 
+const backfillQualifiedAvailabilityStates = async () => {
+  const now = new Date()
+  const nowIso = now.toISOString()
+
+  let updated = 0
+  let skipped = 0
+  let failures = 0
+  let lastAllocationId = ''
+  let pagesRead = 0
+  let rowsScanned = 0
+
+  while (true) {
+    const allocationQuery = adminClient
+      .from('gift_card_allocation')
+      .select('id, metadata, class:class_id(starts_at, ends_at)')
+      .order('id', { ascending: true })
+      .limit(PAGE_SIZE)
+
+    const { data: allocations, error: allocationError } = lastAllocationId
+      ? await allocationQuery.gt('id', lastAllocationId)
+      : await allocationQuery
+
+    if (allocationError) {
+      throw new Error(`Failed to load allocations for availability backfill: ${allocationError.message}`)
+    }
+
+    const rows = (allocations ?? []) as Array<{
+      id: string
+      metadata: {
+        release_at?: string | null
+        release_ready_at?: string | null
+        qualification_since_at?: string | null
+        availability_state?: string | null
+      } | null
+      class: { starts_at: string | null; ends_at: string | null } | Array<{ starts_at: string | null; ends_at: string | null }> | null
+    }>
+
+    if (!rows.length) break
+    pagesRead += 1
+    rowsScanned += rows.length
+
+    for (const row of rows) {
+      const classRelation = Array.isArray(row.class) ? row.class[0] : row.class
+      const classAt = classRelation?.starts_at ?? classRelation?.ends_at ?? null
+      const timingRelease = resolveGiftCardReleaseFromTiming({
+        metadata: row.metadata,
+        classAt,
+        classEndsAt: classRelation?.ends_at ?? null,
+        now: now.getTime(),
+      })
+
+      if (!timingRelease.isReleased) {
+        skipped += 1
+        continue
+      }
+
+      const currentAvailabilityState = (row.metadata?.availability_state ?? '').trim().toLowerCase()
+      if (currentAvailabilityState === 'available' || currentAvailabilityState === 'true') {
+        skipped += 1
+        continue
+      }
+
+      const metadata =
+        row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata)
+          ? ({ ...row.metadata } as Record<string, unknown>)
+          : {}
+
+      metadata.availability_state = 'available'
+      metadata.availability_backfilled_at = nowIso
+
+      const { error: updateError } = await adminClient
+        .from('gift_card_allocation')
+        .update({ metadata })
+        .eq('id', row.id)
+
+      if (updateError) {
+        failures += 1
+        console.error('[gift-cards][availability-backfill] update failed', {
+          allocationId: row.id,
+          error: updateError.message,
+        })
+        continue
+      }
+
+      updated += 1
+    }
+
+    lastAllocationId = rows[rows.length - 1]?.id ?? lastAllocationId
+    if (rows.length < PAGE_SIZE) break
+  }
+
+  console.info('[gift-cards][availability-backfill]', {
+    pagesRead,
+    rowsScanned,
+    updated,
+    skipped,
+    failures,
+  })
+
+  return {
+    updated,
+    failures,
+  }
+}
+
 export const runGiftCardJobs = async ({ appOrigin, runId }: { appOrigin: string; runId: string }): Promise<GiftCardJobResult> => {
   const lockAcquired = await tryAcquireGiftCardRunnerLock()
   if (!lockAcquired) {
     return {
       runId,
       allocated: 0,
+      availabilityBackfilled: 0,
       remindersSent: 0,
       remindersSkipped: 0,
       reminderFailures: 0,
@@ -894,6 +1038,17 @@ export const runGiftCardJobs = async ({ appOrigin, runId }: { appOrigin: string;
     allocated = await allocateGiftCards()
   } catch (error) {
     errors.push(error instanceof Error ? error.message : 'allocate step failed')
+  }
+
+  let availabilityBackfilled = 0
+  try {
+    const availabilityBackfillResult = await backfillQualifiedAvailabilityStates()
+    availabilityBackfilled = availabilityBackfillResult.updated
+    if (availabilityBackfillResult.failures > 0) {
+      errors.push(`availability backfill failed for ${availabilityBackfillResult.failures} allocations`)
+    }
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'availability backfill step failed')
   }
 
   let remindersSent = 0
@@ -925,6 +1080,7 @@ export const runGiftCardJobs = async ({ appOrigin, runId }: { appOrigin: string;
   return {
     runId,
     allocated,
+    availabilityBackfilled,
     remindersSent,
     remindersSkipped,
     reminderFailures,

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -106,6 +106,7 @@ type GiftCardAllocationRow = {
     release_ready_at?: string | null
     qualification_since_at?: string | null
     eligible_after_at?: string | null
+    availability_state?: string | null
   } | null
 }
 
@@ -245,6 +246,13 @@ const normalizeGiftCardPreference = (value: string | null | undefined) => {
   if (normalized.includes('sobeys')) return 'Sobeys'
   if (normalized.includes('pc') || normalized.includes('president')) return 'PC'
   return value?.trim() || 'N/A'
+}
+
+const normalizeGiftCardAvailabilityState = (value: string | null | undefined) => {
+  const normalized = (value ?? '').trim().toLowerCase()
+  if (normalized === 'available' || normalized === 'true') return 'true'
+  if (normalized === 'unavailable' || normalized === 'false') return 'false'
+  return 'false'
 }
 
 const fallbackProfileHoverContext = {
@@ -962,6 +970,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       latest_geo: latestGeo || 'N/A',
       gift_card_allocated: giftCardAllocated,
       gift_card_available: giftCardAvailable,
+      gift_card_available_state: normalizeGiftCardAvailabilityState(giftCardAllocation?.metadata?.availability_state),
       gift_card_availability_reason: giftCardAvailabilityReason,
       gift_card_release_source: giftCardRelease.source,
       gift_card_effective_release_at: giftCardRelease.effectiveReleaseAt,
@@ -1023,16 +1032,16 @@ export async function loader({ request }: Route.LoaderArgs) {
       'giftcard_display',
       'gift_card_allocated',
       'gift_card_available',
+      'gift_card_reminder_sent',
+      'gift_card_link_opened',
+      'gift_card_provider',
+      'gift_card_block_action',
       'gift_card_availability_reason',
       'gift_card_release_source',
       'gift_card_effective_release_at',
       'gift_card_release_ready_at',
       'gift_card_qualification_since_at',
       'gift_card_eligible_after_at',
-      'gift_card_reminder_sent',
-      'gift_card_link_opened',
-      'gift_card_provider',
-      'gift_card_block_action',
       'gift_card_join_url',
       'gift_card_value',
       'gift_card_reminder_sent_at',
@@ -1498,7 +1507,65 @@ export async function action({ request }: Route.ActionArgs) {
     }
   }
 
-  if (intent !== 'update-status' && intent !== 'update-photo-status' && intent !== 'update-camera-on') {
+  if (intent === 'update-gift-availability-state') {
+    const classId = formData.get('class_id') as string
+    const profileId = formData.get('profile_id') as string
+    const availabilityState = String(formData.get('gift_card_available_state') ?? '').trim().toLowerCase()
+
+    if (!classId || !profileId) {
+      return new Response('Missing identifiers', { status: 400, headers: auth.headers })
+    }
+
+    if (availabilityState !== 'true' && availabilityState !== 'false') {
+      return new Response('Invalid availability state value', { status: 400, headers: auth.headers })
+    }
+
+    const { supabase } = createClient(request)
+    const { data: allocation, error: allocationError } = await supabase
+      .from('gift_card_allocation')
+      .select('id, metadata')
+      .eq('class_id', classId)
+      .eq('profile_id', profileId)
+      .maybeSingle()
+
+    if (allocationError) {
+      return new Response(allocationError.message, { status: 500, headers: auth.headers })
+    }
+
+    if (!allocation?.id) {
+      return new Response('Gift card allocation not found for class/profile', { status: 409, headers: auth.headers })
+    }
+
+    const metadata =
+      allocation.metadata && typeof allocation.metadata === 'object' && !Array.isArray(allocation.metadata)
+        ? ({ ...allocation.metadata } as Record<string, unknown>)
+        : {}
+
+    metadata.availability_state = availabilityState === 'true' ? 'available' : 'unavailable'
+
+    const { error: updateError } = await supabase
+      .from('gift_card_allocation')
+      .update({ metadata })
+      .eq('id', allocation.id)
+
+    if (updateError) {
+      return new Response(updateError.message, { status: 500, headers: auth.headers })
+    }
+
+    return {
+      ok: true,
+      intent: 'update-gift-availability-state',
+      class_id: classId,
+      profile_id: profileId,
+      gift_card_available_state: availabilityState,
+    }
+  }
+
+  if (
+    intent !== 'update-status' &&
+    intent !== 'update-photo-status' &&
+    intent !== 'update-camera-on'
+  ) {
     return new Response('Unsupported action', { status: 400, headers: auth.headers })
   }
 

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -4,7 +4,14 @@ import { Constants, type Database } from '@/lib/database.types'
 import { loadFamilyContextByProfileIds } from '@/lib/family-context.server'
 import { EXPORT_TYPE_CLASS_ATTENDANCE_CSV } from '@/lib/exports/types'
 import { resolveIpGeolocation } from '@/lib/geoip.server'
-import { resolveGiftCardRelease } from '@/lib/gift-cards/release.server'
+import {
+  eligibleAfterIso,
+  isEligibilityTimingEnabled,
+  nextReleaseAtIso,
+  releaseReadyAtIso,
+  resolveGiftCardRelease,
+  resolveGiftCardReleaseFromTiming,
+} from '@/lib/gift-cards/release.server'
 import { isRoleAtLeast } from '@/lib/roles'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { createClient } from '@/lib/supabase/server'
@@ -1444,6 +1451,184 @@ export async function action({ request }: Route.ActionArgs) {
       intent: 'delete-attendance-row',
       class_id: classId,
       profile_id: profileId,
+    }
+  }
+
+  if (intent === 'allocate-gift-card') {
+    const classId = formData.get('class_id') as string
+    const profileId = formData.get('profile_id') as string
+    const preferredProviderRaw = String(formData.get('gift_card_preferred_provider') ?? '')
+      .trim()
+      .toLowerCase()
+    const preferredProvider =
+      preferredProviderRaw === 'sobeys' ? 'Sobeys' : preferredProviderRaw === 'pc' ? 'PC' : null
+
+    if (!classId || !profileId) {
+      return new Response('Missing identifiers', { status: 400, headers: auth.headers })
+    }
+
+    const { supabase } = createClient(request)
+    const [attendanceResult, allocationResult, classResult] = await Promise.all([
+      supabase
+        .from('class_attendance')
+        .select('id, status, photo_status, camera_on, gift_card_blocked')
+        .eq('class_id', classId)
+        .eq('profile_id', profileId)
+        .maybeSingle<{
+          id: string
+          status: 'unknown' | 'present' | 'absent' | null
+          photo_status: 'uploaded' | 'accepted' | 'rejected' | null
+          camera_on: boolean | null
+          gift_card_blocked: boolean
+        }>(),
+      supabase.from('gift_card_allocation').select('id').eq('class_id', classId).eq('profile_id', profileId).maybeSingle<{ id: string }>(),
+      supabase.from('class').select('starts_at, ends_at').eq('id', classId).maybeSingle<{ starts_at: string | null; ends_at: string | null }>(),
+    ])
+
+    if (attendanceResult.error) {
+      return new Response(attendanceResult.error.message, { status: 500, headers: auth.headers })
+    }
+    if (allocationResult.error) {
+      return new Response(allocationResult.error.message, { status: 500, headers: auth.headers })
+    }
+    if (classResult.error) {
+      return new Response(classResult.error.message, { status: 500, headers: auth.headers })
+    }
+
+    const attendance = attendanceResult.data
+    if (!attendance?.id) {
+      return new Response('Class attendance row not found for class/profile', { status: 409, headers: auth.headers })
+    }
+    if (attendance.gift_card_blocked) {
+      return new Response('Gift card is blocked for this attendance row', { status: 409, headers: auth.headers })
+    }
+
+    if (allocationResult.data?.id) {
+      return {
+        ok: true,
+        intent: 'allocate-gift-card',
+        class_id: classId,
+        profile_id: profileId,
+        already_allocated: true,
+      }
+    }
+
+    const pickAvailableAsset = async (provider: 'PC' | 'Sobeys' | null) => {
+      let query = supabase
+        .from('gift_card_asset')
+        .select('id, provider')
+        .eq('status', 'available')
+        .order('created_at', { ascending: true })
+        .limit(1)
+
+      if (provider) {
+        query = query.eq('provider', provider)
+      }
+
+      return await query.maybeSingle<{ id: string; provider: 'PC' | 'Sobeys' }>()
+    }
+
+    const providerFallbackOrder: Array<'PC' | 'Sobeys'> = preferredProvider
+      ? [preferredProvider, preferredProvider === 'PC' ? 'Sobeys' : 'PC']
+      : ['PC', 'Sobeys']
+
+    let selectedAsset: { id: string; provider: 'PC' | 'Sobeys' } | null = null
+    for (const provider of providerFallbackOrder) {
+      const { data, error } = await pickAvailableAsset(provider)
+      if (error) {
+        return new Response(error.message, { status: 500, headers: auth.headers })
+      }
+      if (data?.id) {
+        selectedAsset = data
+        break
+      }
+    }
+
+    if (!selectedAsset) {
+      return new Response('No available gift card asset found for allocation', { status: 409, headers: auth.headers })
+    }
+
+    const nowIso = new Date().toISOString()
+    const { data: claimedAsset, error: claimError } = await supabase
+      .from('gift_card_asset')
+      .update({
+        status: 'allocated',
+        assigned_profile_id: profileId,
+        allocated_at: nowIso,
+      })
+      .eq('id', selectedAsset.id)
+      .eq('status', 'available')
+      .select('id, provider')
+      .maybeSingle<{ id: string; provider: 'PC' | 'Sobeys' }>()
+
+    if (claimError || !claimedAsset?.id) {
+      return new Response(claimError?.message ?? 'Gift card asset claim failed', { status: 409, headers: auth.headers })
+    }
+
+    const classAt = classResult.data?.starts_at ?? classResult.data?.ends_at ?? null
+    const classEndsAt = classResult.data?.ends_at ?? null
+    const releaseAt = nextReleaseAtIso(classEndsAt)
+    const eligibilityTimingEnabled = isEligibilityTimingEnabled()
+    const hasAttendanceEvidence =
+      attendance.status === 'present' || attendance.camera_on === true || attendance.photo_status === 'accepted' || attendance.photo_status === 'uploaded'
+    const qualificationSinceAt = eligibilityTimingEnabled && hasAttendanceEvidence ? nowIso : null
+    const releaseReadyAt = eligibilityTimingEnabled
+      ? releaseReadyAtIso({ classAtIso: classAt, qualificationSinceAtIso: qualificationSinceAt })
+      : null
+    const timingResolution = resolveGiftCardReleaseFromTiming({
+      metadata: {
+        release_at: releaseAt,
+        release_ready_at: releaseReadyAt,
+        qualification_since_at: qualificationSinceAt,
+      },
+      classAt,
+      classEndsAt,
+      now: Date.parse(nowIso),
+      eligibilityTimingEnabled,
+    })
+
+    const metadata = eligibilityTimingEnabled
+      ? {
+          release_at: releaseAt,
+          qualification_since_at: qualificationSinceAt,
+          eligible_after_at: eligibleAfterIso(qualificationSinceAt),
+          release_ready_at: releaseReadyAt,
+          availability_state: timingResolution.isReleased ? 'available' : 'unavailable',
+        }
+      : {
+          release_at: releaseAt,
+          availability_state: releaseAt && Date.parse(releaseAt) <= Date.parse(nowIso) ? 'available' : 'unavailable',
+        }
+
+    const { error: insertError } = await supabase.from('gift_card_allocation').insert({
+      class_id: classId,
+      profile_id: profileId,
+      class_attendance_id: attendance.id,
+      gift_card_asset_id: claimedAsset.id,
+      status: 'allocated',
+      metadata,
+    })
+
+    if (insertError) {
+      await supabase
+        .from('gift_card_asset')
+        .update({
+          status: 'available',
+          assigned_profile_id: null,
+          allocated_at: null,
+        })
+        .eq('id', claimedAsset.id)
+
+      return new Response(insertError.message, { status: 500, headers: auth.headers })
+    }
+
+    return {
+      ok: true,
+      intent: 'allocate-gift-card',
+      class_id: classId,
+      profile_id: profileId,
+      gift_card_allocated: true,
+      gift_card_provider: claimedAsset.provider,
     }
   }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -2131,6 +2131,26 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     statusFetcher.submit(formData, { method: 'post' })
   }
 
+  const allocateAttendanceGiftCard = (row: Record<string, unknown>) => {
+    if (!isClassAttendance || !canEditStatus) return
+    const classId = typeof row.class_id === 'string' ? row.class_id : ''
+    const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+    if (!classId || !profileId) return
+
+    const preferredProviderRaw = typeof row.giftcard_display === 'string' ? row.giftcard_display.trim().toLowerCase() : ''
+    const preferredProvider =
+      preferredProviderRaw.includes('sobeys') ? 'sobeys' : preferredProviderRaw.includes('pc') ? 'pc' : ''
+
+    const formData = new FormData()
+    formData.set('intent', 'allocate-gift-card')
+    formData.set('class_id', classId)
+    formData.set('profile_id', profileId)
+    if (preferredProvider) {
+      formData.set('gift_card_preferred_provider', preferredProvider)
+    }
+    statusFetcher.submit(formData, { method: 'post' })
+  }
+
   const updateWorkshopEnrollmentStatus = (row: Record<string, unknown>, value: string) => {
     if (!isWorkshopEnrollment || !canEditStatus || !value) return
     const enrollmentId = typeof row.id === 'string' ? row.id : ''
@@ -2893,6 +2913,38 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                             >
                               {isSubmitting ? 'Saving...' : blocked ? 'Unblock' : 'Block'}
                             </button>
+                          </td>
+                        )
+                      }
+
+                      if (isClassAttendance && column === 'gift_card_allocated' && canEditStatus) {
+                        const classId = typeof row.class_id === 'string' ? row.class_id : ''
+                        const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+                        const allocated = row.gift_card_allocated === true || row.gift_card_allocated === 'true'
+                        const blocked = row.gift_card_blocked === true || row.gift_card_blocked === 'true'
+                        const isSubmitting =
+                          statusFetcher.state === 'submitting' &&
+                          statusFetcher.formData?.get('intent') === 'allocate-gift-card' &&
+                          statusFetcher.formData?.get('class_id') === classId &&
+                          statusFetcher.formData?.get('profile_id') === profileId
+
+                        return (
+                          <td key={`cell-${absoluteRowIndex}-${column}`} className="px-4 py-2" title={allocated ? 'gift card allocated' : 'gift card not allocated'}>
+                            {allocated ? (
+                              <span className="font-mono text-xs">true</span>
+                            ) : (
+                              <button
+                                type="button"
+                                disabled={!classId || !profileId || blocked || isSubmitting}
+                                onClick={event => {
+                                  event.stopPropagation()
+                                  allocateAttendanceGiftCard(row)
+                                }}
+                                className="rounded border border-input px-2 py-1 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                {isSubmitting ? 'Allocating...' : blocked ? 'Blocked' : 'Allocate'}
+                              </button>
+                            )}
                           </td>
                         )
                       }

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -2117,6 +2117,20 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
     statusFetcher.submit(formData, { method: 'post' })
   }
 
+  const updateAttendanceGiftCardAvailabilityOverride = (row: Record<string, unknown>, value: string) => {
+    if (!isClassAttendance || !canEditStatus) return
+    const classId = typeof row.class_id === 'string' ? row.class_id : ''
+    const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+    if (!classId || !profileId) return
+
+    const formData = new FormData()
+    formData.set('intent', 'update-gift-availability-state')
+    formData.set('class_id', classId)
+    formData.set('profile_id', profileId)
+    formData.set('gift_card_available_state', value)
+    statusFetcher.submit(formData, { method: 'post' })
+  }
+
   const updateWorkshopEnrollmentStatus = (row: Record<string, unknown>, value: string) => {
     if (!isWorkshopEnrollment || !canEditStatus || !value) return
     const enrollmentId = typeof row.id === 'string' ? row.id : ''
@@ -2879,6 +2893,38 @@ export default function TableDisplay({ headerActions, paginationActions, data }:
                             >
                               {isSubmitting ? 'Saving...' : blocked ? 'Unblock' : 'Block'}
                             </button>
+                          </td>
+                        )
+                      }
+
+                      if (isClassAttendance && column === 'gift_card_available' && canEditStatus) {
+                        const classId = typeof row.class_id === 'string' ? row.class_id : ''
+                        const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+                        const hasAllocation = row.gift_card_allocated === true || row.gift_card_allocated === 'true'
+                        const isSubmitting =
+                          statusFetcher.state === 'submitting' &&
+                          statusFetcher.formData?.get('intent') === 'update-gift-availability-state' &&
+                          statusFetcher.formData?.get('class_id') === classId &&
+                          statusFetcher.formData?.get('profile_id') === profileId
+
+                        const overrideRaw = typeof row.gift_card_available_state === 'string' ? row.gift_card_available_state : 'false'
+                        const overrideValue = overrideRaw === 'true' || overrideRaw === 'false' ? overrideRaw : 'false'
+                        const released = row.gift_card_available === true || row.gift_card_available === 'true'
+
+                        return (
+                          <td key={`cell-${absoluteRowIndex}-${column}`} className="overflow-hidden px-4 py-2 font-mono" title={released ? 'currently available' : 'currently unavailable'}>
+                            <div className="flex items-center gap-2">
+                              <select
+                                value={overrideValue}
+                                disabled={!hasAllocation || !classId || !profileId || isSubmitting}
+                                onChange={event => updateAttendanceGiftCardAvailabilityOverride(row, event.target.value)}
+                                className={TABLE_SELECT_CLASS_NAME}
+                              >
+                                <option value="true">true</option>
+                                <option value="false">false</option>
+                              </select>
+                              <span className="text-[10px] text-muted-foreground">{released ? 'now: true' : 'now: false'}</span>
+                            </div>
                           </td>
                         )
                       }

--- a/web/tests/unit/gift-card-release.spec.ts
+++ b/web/tests/unit/gift-card-release.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test'
 import {
   classWeekFridayNoonTorontoIso,
   isReleaseReadyNow,
+  resolveGiftCardReleaseFromTiming,
   resolveGiftCardRelease,
   releaseReadyAtIso,
 } from '../../app/lib/gift-cards/release.server'
@@ -52,7 +53,7 @@ test('readiness check compares release_ready_at with now', async () => {
   ).toBeTruthy()
 })
 
-test('release resolver uses explicit release_ready_at when present', async () => {
+test('release resolver does not release when availability state is missing even if release_ready_at is present', async () => {
   const release = resolveGiftCardRelease({
     metadata: {
       release_ready_at: '2026-07-10T16:00:00.000Z',
@@ -64,11 +65,11 @@ test('release resolver uses explicit release_ready_at when present', async () =>
     now: Date.parse('2026-07-10T16:00:00.000Z'),
   })
 
-  expect(release.source).toBe('release_ready_at')
-  expect(release.isReleased).toBeTruthy()
+  expect(release.source).toBe('missing_availability_state')
+  expect(release.isReleased).toBeFalsy()
 })
 
-test('release resolver falls back to legacy release when qualification metadata is missing', async () => {
+test('release resolver requires persisted availability state when metadata state is missing', async () => {
   const release = resolveGiftCardRelease({
     metadata: {
       release_at: '2026-07-14T16:00:00.000Z',
@@ -78,6 +79,49 @@ test('release resolver falls back to legacy release when qualification metadata 
     now: Date.parse('2026-07-11T16:00:00.000Z'),
   })
 
-  expect(release.source).toBe('legacy_release')
+  expect(release.source).toBe('missing_availability_state')
   expect(release.isReleased).toBeFalsy()
+})
+
+test('release resolver force-available override always releases', async () => {
+  const release = resolveGiftCardRelease({
+    metadata: {
+      availability_state: 'available',
+      release_at: '2099-07-14T16:00:00.000Z',
+    },
+    classAt: '2026-07-08T12:00:00.000Z',
+    classEndsAt: '2026-07-08T13:00:00.000Z',
+    now: Date.parse('2026-07-11T16:00:00.000Z'),
+  })
+
+  expect(release.source).toBe('availability_state')
+  expect(release.isReleased).toBeTruthy()
+})
+
+test('release resolver force-unavailable override blocks release', async () => {
+  const release = resolveGiftCardRelease({
+    metadata: {
+      availability_state: 'unavailable',
+      release_ready_at: '2026-07-10T16:00:00.000Z',
+    },
+    classAt: '2026-07-08T12:00:00.000Z',
+    classEndsAt: '2026-07-08T13:00:00.000Z',
+    now: Date.parse('2026-07-11T16:00:00.000Z'),
+  })
+
+  expect(release.source).toBe('availability_state')
+  expect(release.isReleased).toBeFalsy()
+})
+
+test('timing resolver still computes release readiness without persisted availability state', async () => {
+  const release = resolveGiftCardReleaseFromTiming({
+    metadata: {
+      release_at: '2026-07-10T16:00:00.000Z',
+    },
+    classAt: '2026-07-08T12:00:00.000Z',
+    classEndsAt: '2026-07-08T13:00:00.000Z',
+    now: Date.parse('2026-07-10T16:00:00.000Z'),
+  })
+
+  expect(release.isReleased).toBeTruthy()
 })


### PR DESCRIPTION
## What\n- enforce gift card release gating on persisted metadata.availability_state\n- add runner backfill step to mark already-qualified allocations as available\n- allow staff to manually allocate a gift card from manage class attendance when allocation is missing\n- keep manage availability control strictly boolean (true/false)\n\n## Validation\n- npm run typecheck\n- npm run test:unit -- tests/unit/gift-card-release.spec.ts\n- npm run build