### PR TITLE
Implement #445 gift-card inventory alerts and optimize manage loader

### DIFF
--- a/supabase/migrations/20260711091500_gift_card_asset_provider_status_idx.sql
+++ b/supabase/migrations/20260711091500_gift_card_asset_provider_status_idx.sql
@@ -1,0 +1,2 @@
+create index if not exists gift_card_asset_provider_status_idx
+  on public.gift_card_asset(provider, status);

--- a/supabase/schemas/06_gift_cards.sql
+++ b/supabase/schemas/06_gift_cards.sql
@@ -122,6 +122,7 @@ create table public.gift_card_inventory_alert_state (
 
 create index gift_card_asset_upload_id_idx on public.gift_card_asset(upload_id);
 create index gift_card_asset_status_idx on public.gift_card_asset(status);
+create index gift_card_asset_provider_status_idx on public.gift_card_asset(provider, status);
 create index gift_card_upload_status_idx on public.gift_card_upload(status);
 create index gift_card_allocation_status_idx on public.gift_card_allocation(status);
 create index gift_card_allocation_class_profile_idx on public.gift_card_allocation(class_id, profile_id);

--- a/web/app/lib/gift-cards/inventory.server.ts
+++ b/web/app/lib/gift-cards/inventory.server.ts
@@ -1,13 +1,11 @@
-import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
-
-import { scanByIdKeyset } from '@/lib/supabase/keyset-pagination.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 
 export type GiftCardProvider = 'PC' | 'Sobeys'
 
 type GiftCardAssetStatus = 'available' | 'allocated' | 'sent' | 'opened' | 'used' | 'invalid'
 
-const PAGE_SIZE = 500
+const IN_CLAUSE_BATCH_SIZE = 200
+const GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE = 'gift_card_store_preference'
 const PROVIDERS: GiftCardProvider[] = ['PC', 'Sobeys']
 const ASSET_STATUS_ORDER: GiftCardAssetStatus[] = ['available', 'allocated', 'sent', 'opened', 'used', 'invalid']
 
@@ -27,8 +25,6 @@ export const parseGiftCardProviderFromDisplay = (value: string | null | undefine
   if (normalized.includes('pc') || normalized.includes('president')) return 'PC'
   return 'PC'
 }
-
-const allocationPairKey = (classId: string, profileId: string) => `${classId}::${profileId}`
 
 export const resolveGiftCardLowThresholds = () => ({
   PC: parseNonNegativeIntEnv('GIFT_CARD_LOW_THRESHOLD_PC', 0),
@@ -83,89 +79,17 @@ export const loadGiftCardInventorySnapshot = async (): Promise<GiftCardInventory
     Sobeys: emptyStatusCounts(),
   }
 
-  await scanByIdKeyset<{ id: string; provider: GiftCardProvider; status: GiftCardAssetStatus }>({
-    batchSize: PAGE_SIZE,
-    fetchPage: async afterId => {
-      const query = adminClient
-        .from('gift_card_asset')
-        .select('id, provider, status')
-        .order('id', { ascending: true })
-        .limit(PAGE_SIZE)
-
-      const { data, error } = afterId ? await query.gt('id', afterId) : await query
-      if (error) {
-        throw new Error(`Failed to load gift-card inventory rows: ${error.message}`)
-      }
-
-      return (data ?? []) as Array<{ id: string; provider: GiftCardProvider; status: GiftCardAssetStatus }>
-    },
-    onPage: rows => {
-      for (const row of rows) {
-        const provider = row.provider === 'Sobeys' ? 'Sobeys' : 'PC'
-        const status = ASSET_STATUS_ORDER.includes(row.status) ? row.status : 'invalid'
-        statusByProvider[provider][status] += 1
-      }
-    },
-  })
-
-  const candidatePairs = new Set<string>()
-  const nearTermPairs: Array<{ classId: string; profileId: string }> = []
-
-  await scanByIdKeyset<{ id: string; class_id: string; profile_id: string }>({
-    batchSize: PAGE_SIZE,
-    fetchPage: async afterId => {
-      const query = adminClient
-        .from('class_attendance')
-        .select('id, class_id, profile_id')
-        .eq('gift_card_blocked', false)
-        .or('camera_on.eq.true,photo_status.eq.accepted,photo_status.eq.uploaded')
-        .order('id', { ascending: true })
-        .limit(PAGE_SIZE)
-
-      const { data, error } = afterId ? await query.gt('id', afterId) : await query
-      if (error) {
-        throw new Error(`Failed to load near-term demand attendance rows: ${error.message}`)
-      }
-
-      return (data ?? []) as Array<{ id: string; class_id: string; profile_id: string }>
-    },
-    onPage: rows => {
-      for (const row of rows) {
-        const key = allocationPairKey(row.class_id, row.profile_id)
-        if (!candidatePairs.has(key)) {
-          candidatePairs.add(key)
-          nearTermPairs.push({ classId: row.class_id, profileId: row.profile_id })
-        }
-      }
-    },
-  })
-
-  if (candidatePairs.size) {
-    await scanByIdKeyset<{ id: string; class_id: string; profile_id: string }>({
-      batchSize: PAGE_SIZE,
-      fetchPage: async afterId => {
-        const query = adminClient
-          .from('gift_card_allocation')
-          .select('id, class_id, profile_id')
-          .order('id', { ascending: true })
-          .limit(PAGE_SIZE)
-
-        const { data, error } = afterId ? await query.gt('id', afterId) : await query
-        if (error) {
-          throw new Error(`Failed to load allocations for near-term demand: ${error.message}`)
-        }
-
-        return (data ?? []) as Array<{ id: string; class_id: string; profile_id: string }>
-      },
-      onPage: rows => {
-        for (const row of rows) {
-          candidatePairs.delete(allocationPairKey(row.class_id, row.profile_id))
-        }
-      },
-    })
+  const statusCountTasks: Array<Promise<void>> = []
+  for (const provider of PROVIDERS) {
+    for (const status of ASSET_STATUS_ORDER) {
+      statusCountTasks.push(
+        countGiftCardAssets({ provider, status }).then(count => {
+          statusByProvider[provider][status] = count
+        })
+      )
+    }
   }
-
-  const unresolvedNearTermPairs = nearTermPairs.filter(pair => candidatePairs.has(allocationPairKey(pair.classId, pair.profileId)))
+  await Promise.all(statusCountTasks)
 
   const now = new Date()
   const horizonEnd = new Date(now)
@@ -173,84 +97,33 @@ export const loadGiftCardInventorySnapshot = async (): Promise<GiftCardInventory
   const nowIso = now.toISOString()
   const horizonEndIso = horizonEnd.toISOString()
 
-  const upcomingWorkshopIds = new Set<string>()
-  await scanByIdKeyset<{ id: string; workshop_id: string | null }>({
-    batchSize: PAGE_SIZE,
-    fetchPage: async afterId => {
-      const query = adminClient
-        .from('class')
-        .select('id, workshop_id')
-        .gte('starts_at', nowIso)
-        .lte('starts_at', horizonEndIso)
-        .order('id', { ascending: true })
-        .limit(PAGE_SIZE)
+  const { data: classRows, error: classError } = await adminClient
+    .from('class')
+    .select('workshop_id')
+    .gte('starts_at', nowIso)
+    .lte('starts_at', horizonEndIso)
 
-      const { data, error } = afterId ? await query.gt('id', afterId) : await query
-      if (error) {
-        throw new Error(`Failed to load upcoming classes for demand projection: ${error.message}`)
-      }
-
-      return (data ?? []) as Array<{ id: string; workshop_id: string | null }>
-    },
-    onPage: rows => {
-      for (const row of rows) {
-        if (row.workshop_id) {
-          upcomingWorkshopIds.add(row.workshop_id)
-        }
-      }
-    },
-  })
-
-  const upcomingApprovedProfiles = new Set<string>()
-  const workshopIdList = Array.from(upcomingWorkshopIds)
-  for (const workshopIdChunk of chunkArray(workshopIdList, 200)) {
-    if (!workshopIdChunk.length) continue
-
-    await scanByIdKeyset<{ id: string; profile_id: string | null }>({
-      batchSize: PAGE_SIZE,
-      fetchPage: async afterId => {
-        const query = adminClient
-          .from('workshop_enrollment')
-          .select('id, profile_id')
-          .in('workshop_id', workshopIdChunk)
-          .eq('status', 'approved')
-          .order('id', { ascending: true })
-          .limit(PAGE_SIZE)
-
-        const { data, error } = afterId ? await query.gt('id', afterId) : await query
-        if (error) {
-          throw new Error(`Failed to load upcoming approved enrollments: ${error.message}`)
-        }
-
-        return (data ?? []) as Array<{ id: string; profile_id: string | null }>
-      },
-      onPage: rows => {
-        for (const row of rows) {
-          if (row.profile_id) {
-            upcomingApprovedProfiles.add(row.profile_id)
-          }
-        }
-      },
-    })
+  if (classError) {
+    throw new Error(`Failed to load class demand windows: ${classError.message}`)
   }
 
-  const nearTermProfileIds = new Set(unresolvedNearTermPairs.map(pair => pair.profileId))
-  const upcomingProfileIds = Array.from(upcomingApprovedProfiles).filter(profileId => !nearTermProfileIds.has(profileId))
-  const profileIdsForProviderLookup = Array.from(new Set([...nearTermProfileIds, ...upcomingProfileIds]))
-  const enrichmentByProfileId = profileIdsForProviderLookup.length
-    ? await loadWorkshopEnrollmentEnrichment(profileIdsForProviderLookup)
-    : {}
+  const upcomingWorkshopIds = new Set<string>()
+
+  for (const row of classRows ?? []) {
+    if (row.workshop_id) {
+      upcomingWorkshopIds.add(row.workshop_id)
+    }
+  }
+
+  const upcomingApprovedProfiles = await loadApprovedEnrollmentProfilesForWorkshops(upcomingWorkshopIds)
+  const upcomingProfileIds = Array.from(upcomingApprovedProfiles)
+  const providerByProfileId = await resolveProviderByProfileIds(upcomingProfileIds)
 
   const nearTermDemandByProvider: Record<GiftCardProvider, number> = { PC: 0, Sobeys: 0 }
-  for (const pair of unresolvedNearTermPairs) {
-    const provider = parseGiftCardProviderFromDisplay(enrichmentByProfileId[pair.profileId]?.giftcard_display)
-    if (!provider) continue
-    nearTermDemandByProvider[provider] += 1
-  }
 
   const upcomingDemandByProvider: Record<GiftCardProvider, number> = { PC: 0, Sobeys: 0 }
   for (const profileId of upcomingProfileIds) {
-    const provider = parseGiftCardProviderFromDisplay(enrichmentByProfileId[profileId]?.giftcard_display)
+    const provider = providerByProfileId.get(profileId) ?? 'PC'
     if (!provider) continue
     upcomingDemandByProvider[provider] += 1
   }
@@ -293,6 +166,144 @@ export const loadGiftCardInventorySnapshot = async (): Promise<GiftCardInventory
       totalProjectedDemand: providers.PC.projectedDemand + providers.Sobeys.projectedDemand,
     },
   }
+}
+
+const countGiftCardAssets = async ({ provider, status }: { provider: GiftCardProvider; status: GiftCardAssetStatus }) => {
+  const { count, error } = await adminClient
+    .from('gift_card_asset')
+    .select('id', { count: 'exact', head: true })
+    .eq('provider', provider)
+    .eq('status', status)
+
+  if (error) {
+    throw new Error(`Failed to count gift-card assets (${provider}/${status}): ${error.message}`)
+  }
+  return count ?? 0
+}
+
+const loadApprovedEnrollmentProfilesForWorkshops = async (workshopIds: Set<string>) => {
+  const profiles = new Set<string>()
+  const workshopIdList = Array.from(workshopIds)
+
+  for (const workshopIdChunk of chunkArray(workshopIdList, IN_CLAUSE_BATCH_SIZE)) {
+    const { data, error } = await adminClient
+      .from('workshop_enrollment')
+      .select('profile_id')
+      .in('workshop_id', workshopIdChunk)
+      .eq('status', 'approved')
+
+    if (error) {
+      throw new Error(`Failed to load upcoming approved enrollments: ${error.message}`)
+    }
+
+    for (const row of data ?? []) {
+      if (row.profile_id) {
+        profiles.add(row.profile_id)
+      }
+    }
+  }
+
+  return profiles
+}
+
+const resolveProviderByProfileIds = async (profileIds: string[]) => {
+  const normalizedProfileIds = Array.from(new Set(profileIds.filter(Boolean)))
+  const providerByProfileId = new Map<string, GiftCardProvider | null>()
+  if (!normalizedProfileIds.length) return providerByProfileId
+
+  const profileRows: Array<{ id: string; user_id: string | null }> = []
+  for (const chunk of chunkArray(normalizedProfileIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { data, error } = await adminClient.from('profile').select('id, user_id').in('id', chunk)
+    if (error) {
+      throw new Error(`Failed to load profiles for provider preferences: ${error.message}`)
+    }
+    profileRows.push(...((data ?? []) as Array<{ id: string; user_id: string | null }>))
+  }
+
+  const targetProfileIds = new Set(normalizedProfileIds)
+  const profileIdsByUserId = new Map<string, string[]>()
+  for (const row of profileRows) {
+    if (!row.user_id) continue
+    const bucket = profileIdsByUserId.get(row.user_id) ?? []
+    if (!bucket.includes(row.id)) {
+      bucket.push(row.id)
+      profileIdsByUserId.set(row.user_id, bucket)
+    }
+  }
+
+  const submissionsById = new Map<string, { id: string; profile_id: string | null; user_id: string | null; submitted_at: string | null }>()
+
+  for (const chunk of chunkArray(normalizedProfileIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { data, error } = await adminClient.from('form_submission').select('id, profile_id, user_id, submitted_at').in('profile_id', chunk)
+    if (error) {
+      throw new Error(`Failed to load profile form submissions for provider preferences: ${error.message}`)
+    }
+    for (const row of data ?? []) {
+      submissionsById.set(row.id, row)
+    }
+  }
+
+  const userIds = Array.from(profileIdsByUserId.keys())
+  for (const chunk of chunkArray(userIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { data, error } = await adminClient.from('form_submission').select('id, profile_id, user_id, submitted_at').in('user_id', chunk)
+    if (error) {
+      throw new Error(`Failed to load user form submissions for provider preferences: ${error.message}`)
+    }
+    for (const row of data ?? []) {
+      submissionsById.set(row.id, row)
+    }
+  }
+
+  const latestValueByProfileId = new Map<string, { value: string; submittedAtMs: number }>()
+  const submissionIds = Array.from(submissionsById.keys())
+
+  for (const chunk of chunkArray(submissionIds, IN_CLAUSE_BATCH_SIZE)) {
+    const { data: answerRows, error: answerError } = await adminClient
+      .from('form_answer')
+      .select('submission_id, value')
+      .eq('question_code', GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
+      .in('submission_id', chunk)
+
+    if (answerError) {
+      throw new Error(`Failed to load provider preference answers: ${answerError.message}`)
+    }
+
+    for (const answer of answerRows ?? []) {
+      const submission = submissionsById.get(answer.submission_id)
+      if (!submission) continue
+      const value = typeof answer.value === 'string' ? answer.value.trim() : ''
+      if (!value) continue
+
+      const submittedAtMs = Number.isFinite(Date.parse(submission.submitted_at ?? '')) ? Date.parse(submission.submitted_at ?? '') : 0
+      const associatedProfileIds = new Set<string>()
+
+      if (submission.profile_id && targetProfileIds.has(submission.profile_id)) {
+        associatedProfileIds.add(submission.profile_id)
+      }
+
+      if (submission.user_id) {
+        for (const profileId of profileIdsByUserId.get(submission.user_id) ?? []) {
+          if (targetProfileIds.has(profileId)) {
+            associatedProfileIds.add(profileId)
+          }
+        }
+      }
+
+      for (const profileId of associatedProfileIds) {
+        const existing = latestValueByProfileId.get(profileId)
+        if (!existing || submittedAtMs > existing.submittedAtMs) {
+          latestValueByProfileId.set(profileId, { value, submittedAtMs })
+        }
+      }
+    }
+  }
+
+  for (const profileId of normalizedProfileIds) {
+    const preferenceValue = latestValueByProfileId.get(profileId)?.value ?? null
+    providerByProfileId.set(profileId, parseGiftCardProviderFromDisplay(preferenceValue))
+  }
+
+  return providerByProfileId
 }
 
 const summarizeProviderInventory = ({

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -94,6 +94,7 @@ export default [
     route("email-drafts/:draftId", "routes/manage/email-drafts.$draftId.tsx"),
     route("form-answer", "routes/manage/form-answer.tsx"),
     route("gift-cards", "routes/manage/gift-cards.tsx"),
+    route("gift-cards/table-data", "routes/manage/gift-cards.table-data.ts"),
     route("gift-cards/upload", "routes/manage/gift-cards.upload.tsx"),
     route("role-permission", "routes/manage/role-permission.tsx"),
     route("user-roles", "routes/manage/user-roles.tsx"),

--- a/web/app/routes/manage/gift-cards.table-data.ts
+++ b/web/app/routes/manage/gift-cards.table-data.ts
@@ -1,0 +1,14 @@
+import { loader as giftCardsLoader } from './gift-cards'
+
+import type { Route } from './+types/gift-cards.table-data'
+
+export async function loader(args: Route.LoaderArgs) {
+  const url = new URL(args.request.url)
+  const dataUrl = new URL('/manage/gift-cards', url.origin)
+  const sourceSearch = new URLSearchParams(url.search)
+  sourceSearch.set('_deferTable', '1')
+  dataUrl.search = sourceSearch.toString()
+  const request = new Request(dataUrl.toString(), args.request)
+
+  return giftCardsLoader({ ...args, request } as Parameters<typeof giftCardsLoader>[0])
+}

--- a/web/app/routes/manage/gift-cards.tsx
+++ b/web/app/routes/manage/gift-cards.tsx
@@ -1,4 +1,5 @@
-import { Link, useLoaderData } from 'react-router'
+import { useEffect, useMemo, useRef } from 'react'
+import { Link, useFetcher, useLoaderData, useLocation } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { requireAuth } from '@/lib/auth.server'
@@ -31,6 +32,7 @@ type ProfileRow = {
 }
 
 const GIFT_CARD_STATUS_ORDER: GiftCardAssetRow['status'][] = ['available', 'allocated', 'sent', 'opened', 'used', 'invalid']
+const GIFT_CARD_PROVIDERS = ['PC', 'Sobeys'] as const
 
 const TORONTO_TIME_ZONE = 'America/Toronto'
 
@@ -86,6 +88,28 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw new Response('Forbidden', { status: 403 })
   }
 
+  const url = new URL(request.url)
+  const deferTable = url.searchParams.get('_deferTable') === '1'
+  if (!deferTable) {
+    return buildGiftCardShellData()
+  }
+
+  const [tableRowsData, inventorySnapshot] = await Promise.all([
+    loadGiftCardTableRows(request),
+    loadGiftCardInventorySnapshot(),
+  ])
+
+  const statusTotals = GIFT_CARD_STATUS_ORDER.map(status => ({ status, count: inventorySnapshot.statusTotals[status] }))
+
+  return {
+    ...buildGiftCardShellData(),
+    ...tableRowsData,
+    inventorySnapshot,
+    statusTotals,
+  }
+}
+
+const loadGiftCardTableRows = async (request: Request) => {
   const { supabase } = createClient(request)
   const { data: assets, error } = await supabase
     .from('gift_card_asset')
@@ -135,22 +159,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const assignedProfileCount = rows.filter(row => row.profile_id).length
   const totalAssetCount = rows.length
-  const inventorySnapshot = await loadGiftCardInventorySnapshot()
-  const statusTotals = GIFT_CARD_STATUS_ORDER.map(status => ({ status, count: inventorySnapshot.statusTotals[status] }))
-
   return {
-    label: 'Gift card assets',
-    tableName: 'gift-cards',
-    systemTiming: {
-      timezone: TORONTO_TIME_ZONE,
-      release: `Mon/Fri ${formatTorontoClock(RELEASE_HOUR_TORONTO, RELEASE_MINUTE_TORONTO)}`,
-      reminder: `Mon/Fri ${formatTorontoClock(REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)}`,
-    },
-    eligibilityTimingEnabled: isEligibilityTimingEnabled(),
-    inventorySnapshot,
-    statusTotals,
     totalAssetCount,
-    columns: ['provider', 'account_number', 'pin', 'value', 'status', 'asset_url', 'profile_display', 'upload_id', 'created_at'],
+    columns: ['provider', 'account_number', 'pin', 'value', 'status', 'asset_url', 'profile_display', 'upload_id', 'created_at'] as string[],
     rows,
     columnMeta: {
       provider: { label: 'Provider' },
@@ -166,11 +177,142 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 }
 
+const buildGiftCardShellData = () => {
+  const emptyInventorySnapshot = {
+    generatedAt: new Date().toISOString(),
+    horizonDays: 14,
+    providers: {
+      PC: {
+        provider: 'PC' as const,
+        statusCounts: {
+          available: 0,
+          allocated: 0,
+          sent: 0,
+          opened: 0,
+          used: 0,
+          invalid: 0,
+        },
+        total: 0,
+        available: 0,
+        threshold: 0,
+        isLow: false,
+        nearTermDemand: 0,
+        upcomingDemand: 0,
+        projectedDemand: 0,
+        projectedShortfall: 0,
+      },
+      Sobeys: {
+        provider: 'Sobeys' as const,
+        statusCounts: {
+          available: 0,
+          allocated: 0,
+          sent: 0,
+          opened: 0,
+          used: 0,
+          invalid: 0,
+        },
+        total: 0,
+        available: 0,
+        threshold: 0,
+        isLow: false,
+        nearTermDemand: 0,
+        upcomingDemand: 0,
+        projectedDemand: 0,
+        projectedShortfall: 0,
+      },
+    },
+    statusTotals: {
+      available: 0,
+      allocated: 0,
+      sent: 0,
+      opened: 0,
+      used: 0,
+      invalid: 0,
+    },
+    totals: {
+      totalAssets: 0,
+      totalAvailable: 0,
+      totalNearTermDemand: 0,
+      totalUpcomingDemand: 0,
+      totalProjectedDemand: 0,
+    },
+  }
+
+  return {
+    label: 'Gift card assets',
+    tableName: 'gift-cards',
+    systemTiming: {
+      timezone: TORONTO_TIME_ZONE,
+      release: `Mon/Fri ${formatTorontoClock(RELEASE_HOUR_TORONTO, RELEASE_MINUTE_TORONTO)}`,
+      reminder: `Mon/Fri ${formatTorontoClock(REMINDER_HOUR_TORONTO, REMINDER_MINUTE_TORONTO)}`,
+    },
+    eligibilityTimingEnabled: isEligibilityTimingEnabled(),
+    inventorySnapshot: emptyInventorySnapshot,
+    statusTotals: GIFT_CARD_STATUS_ORDER.map(status => ({ status, count: 0 })),
+    totalAssetCount: 0,
+    columns: ['provider', 'account_number', 'pin', 'value', 'status', 'asset_url', 'profile_display', 'upload_id', 'created_at'],
+    rows: [] as Record<string, unknown>[],
+    columnMeta: {
+      provider: { label: 'Provider' },
+      account_number: { label: 'Account' },
+      pin: { label: 'PIN' },
+      value: { label: 'Value' },
+      status: { label: 'Status' },
+      asset_url: { label: 'Link' },
+      profile_display: { label: '0/0 Assigned profile' },
+      upload_id: { label: 'Upload ID' },
+      created_at: { label: 'Created' },
+    },
+  }
+}
+
 export default function GiftCardsPage() {
-  const data = useLoaderData<typeof loader>()
+  const fallbackData = useLoaderData<typeof loader>()
+  const fetcher = useFetcher<typeof loader>()
+  const location = useLocation()
+  const lastRequestedUrlRef = useRef<string | null>(null)
+  const lastResolvedDataRef = useRef<typeof fallbackData | null>(null)
+
+  const dataRequestUrl = useMemo(() => {
+    const next = new URLSearchParams(location.search)
+    next.set('_deferTable', '1')
+    const query = next.toString()
+    return query ? `/manage/gift-cards/table-data?${query}` : '/manage/gift-cards/table-data'
+  }, [location.search])
+
+  useEffect(() => {
+    if (lastRequestedUrlRef.current === dataRequestUrl) return
+    lastRequestedUrlRef.current = dataRequestUrl
+    fetcher.load(dataRequestUrl)
+  }, [dataRequestUrl, fetcher])
+
+  useEffect(() => {
+    if (!fetcher.data) return
+    lastResolvedDataRef.current = fetcher.data
+  }, [fetcher.data])
+
+  const resolvedData = fetcher.data ?? lastResolvedDataRef.current ?? fallbackData
+  const data = {
+    ...resolvedData,
+    label: fallbackData.label,
+    tableName: fallbackData.tableName,
+  }
+
+  const rowLoadingMessage =
+    fetcher.state !== 'idle'
+      ? fetcher.data || lastResolvedDataRef.current
+        ? 'Refreshing gift card rows...'
+        : 'Loading gift card rows...'
+      : null
+
+  const paginationActions = rowLoadingMessage ? (
+    <span className="rounded border border-border bg-muted/30 px-2 py-1 text-[11px] text-muted-foreground">{rowLoadingMessage}</span>
+  ) : undefined
 
   return (
     <TableDisplay
+      data={data}
+      paginationActions={paginationActions}
       headerActions={
         <div className="flex flex-wrap items-center gap-3">
           <div className="flex flex-wrap items-center gap-2 rounded border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
@@ -184,15 +326,15 @@ export default function GiftCardsPage() {
           </div>
           <div className="flex flex-wrap items-center gap-2 rounded border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
             <span className="font-medium text-foreground">Inventory watch</span>
-            {(['PC', 'Sobeys'] as const).map(provider => {
+            {GIFT_CARD_PROVIDERS.map(provider => {
               const summary = data.inventorySnapshot.providers[provider]
               return (
                 <span
                   key={provider}
                   className={`rounded border bg-background px-2 py-1 text-foreground ${summary.isLow ? 'border-red-300 text-red-700' : ''}`}
                 >
-                  {provider} avail: {summary.available} / threshold {summary.threshold} | demand N/U: {summary.nearTermDemand}/
-                  {summary.upcomingDemand}
+                  {provider} available: {summary.available} | needed next {data.inventorySnapshot.horizonDays} days:{' '}
+                  {summary.projectedDemand}
                 </span>
               )
             })}


### PR DESCRIPTION
## What changed
- implement issue #445 inventory monitoring and alert flow
  - provider inventory and demand snapshot support
  - low-inventory alert state tracking and email draft/template wiring
- optimize /manage/gift-cards load path
  - add deferred table-data route and fetcher-driven loading states
  - simplify inventory watch UI to available and needed next 14 days
  - replace expensive full-scan enrichment path with bounded, targeted demand queries
  - add gift_card_asset(provider, status) index for faster status counts

## Validation
- supabase migration up --local
- npm run typecheck (in web/)
- npm run test:unit -- tests/unit/gift-card-inventory.spec.ts tests/unit/gift-card-inventory-alerts.spec.ts tests/unit/keyset-pagination.spec.ts

## Notes
- intentionally excludes unrelated untracked local file web/householdcounts.csv