### PR TITLE
Add prod-data sanitize seed workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _**
 
 # Local production snapshot seed dumps (PII/sensitive)
 /supabase/seeds/prod-data/*.sql
+/supabase/seeds/prod-data/active/*.sql

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Scope
 - Main app is `web/` (React Router v7, SSR). Run Node commands from `web/`; root `package.json` has no scripts.
-- `scheduler/` and `zoom-api/` are separate deployables with separate run/test flows.
-- Before touching `zoom-api/`, read and follow `zoom-api/CLAUDE.md`.
+- `scheduler/` and `zoom-api/` are separate services with independent run/test flows.
+- Before editing `zoom-api/`, read `zoom-api/CLAUDE.md` and follow its stricter workflow requirements.
 
 ## Local setup and core commands
 - First-time setup (repo root): `cp web/.env.template web/.env.local` -> `supabase start --debug` -> copy values from `supabase status -o json` into `web/.env.local`.
@@ -20,10 +20,9 @@
 - `createClient` from `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; include `headers` in redirects/responses or auth cookies are dropped.
 
 ## Manage table conventions
-- Prefer server-side query mode for manage tables so filter options remain correct across pagination/sorting.
-- Prefer deferred table pages: lightweight shell loader + `DeferredTableDisplay` + route-level `*.table-data.ts` loader that sets `_deferTable=1`.
+- Prefer deferred manage tables: shell loader + `DeferredTableDisplay` + route-level `*.table-data.ts` loader that sets `_deferTable=1`.
 - For CSV exports, use `/manage/exports` form posts with `intent=create-export`, `export_type`, and `source_path`.
-- For full-dataset filter option scans (for example `email-message`), remove `page`/`pageSize` and force `sort=__full_scan__` in the deferred loader request.
+- For full-dataset filter option scans (for example `email-message`), remove `page`/`pageSize`, set `sort=__full_scan__`, and clear `dir` in the deferred loader request.
 - Supabase API `max_rows` is `1000` (`supabase/config.toml`); batch large reads with stable ordered `.range(...)` loops.
 
 ## Tests and CI

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -67,7 +67,7 @@ enabled = true
 # sql_paths = ["./seeds/app-data/*.sql", "./seeds/dummy-data/*.sql"]
 #
 # Production snapshot mode (sanitized prod snapshot + local bootstrap overrides, no dummy fixtures):
-sql_paths = ["./seeds/prod-data/*-sanitized.sql", "./seeds/app-data/*.sql"]
+sql_paths = ["./seeds/prod-data/active/*-sanitized.sql", "./seeds/app-data/*.sql"]
 #
 # Dummy-only mode (for fixture-only smoke runs):
 # sql_paths = ["./seeds/dummy-data/*.sql"]

--- a/supabase/scripts/prod-data-sanitize/Makefile
+++ b/supabase/scripts/prod-data-sanitize/Makefile
@@ -1,0 +1,94 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+# Auto date, override with: make all DATE=20260713
+DATE ?= $(shell date +%Y%m%d)
+
+ROOT := $(abspath ../..)
+SEED_DIR := $(ROOT)/seeds/prod-data
+ACTIVE_DIR := $(SEED_DIR)/active
+SCRIPT_DIR := $(ROOT)/scripts/prod-data-sanitize
+HELPERS_DIR := $(SCRIPT_DIR)/helpers
+
+RAW := $(SEED_DIR)/$(DATE)-raw.sql
+SAN := $(SEED_DIR)/$(DATE)-sanitized.sql
+MAP := $(SEED_DIR)/$(DATE)-email-map.json
+H1 := $(SEED_DIR)/$(DATE)-semester-survey-requirements-sanitized.sql
+H2 := $(SEED_DIR)/$(DATE)-zz-form-submission-form-id-remap-sanitized.sql
+ACTIVE_MAIN := $(ACTIVE_DIR)/$(notdir $(SAN))
+ACTIVE_H1 := $(ACTIVE_DIR)/$(notdir $(H1))
+ACTIVE_H2 := $(ACTIVE_DIR)/$(notdir $(H2))
+
+EXCLUDE_TABLES := $(shell sed -e '/^[[:space:]]*\#/d' -e '/^[[:space:]]*$$/d' "$(SCRIPT_DIR)/exclude-tables.txt")
+EXCLUDE_FLAGS := $(foreach t,$(EXCLUDE_TABLES),--exclude $(t))
+
+.PHONY: help dump rewrite verify helpers activate all reset-local postcheck clean-date print
+
+help:
+	@echo "Targets:"
+	@echo "  make dump [DATE=YYYYMMDD]        - dump linked remote data (raw)"
+	@echo "  make rewrite [DATE=YYYYMMDD]     - rewrite emails to @chsolutions.ca"
+	@echo "  make verify [DATE=YYYYMMDD]      - verify only @chsolutions.ca remains"
+	@echo "  make helpers [DATE=YYYYMMDD]     - copy canonical helper SQL to dated helper files"
+	@echo "  make activate [DATE=YYYYMMDD]    - stage one dated snapshot set into prod-data/active"
+	@echo "  make all [DATE=YYYYMMDD]         - dump + rewrite + verify + helpers + activate"
+	@echo "  make reset-local YES=1           - DESTRUCTIVE local db reset (real reset)"
+	@echo "  make postcheck                   - run integrity checks after reset"
+	@echo "  make clean-date [DATE=YYYYMMDD]  - remove generated files for date"
+	@echo "  make print [DATE=YYYYMMDD]       - print resolved paths"
+
+print:
+	@echo DATE=$(DATE)
+	@echo RAW=$(RAW)
+	@echo SAN=$(SAN)
+	@echo MAP=$(MAP)
+	@echo H1=$(H1)
+	@echo H2=$(H2)
+	@echo ACTIVE_MAIN=$(ACTIVE_MAIN)
+	@echo ACTIVE_H1=$(ACTIVE_H1)
+	@echo ACTIVE_H2=$(ACTIVE_H2)
+
+dump:
+	@mkdir -p "$(SEED_DIR)"
+	supabase db dump --linked --data-only --file "$(RAW)" $(EXCLUDE_FLAGS)
+
+rewrite:
+	python3 "$(SCRIPT_DIR)/rewrite_email_domains.py" \
+		--input "$(RAW)" \
+		--output "$(SAN)" \
+		--domain "chsolutions.ca" \
+		--map-output "$(MAP)"
+
+verify:
+	python3 "$(SCRIPT_DIR)/verify_email_domains.py" \
+		--input "$(SAN)" \
+		--allowed-domain "chsolutions.ca"
+
+helpers:
+	cp "$(HELPERS_DIR)/semester-survey-requirements-sanitized.sql" "$(H1)"
+	cp "$(HELPERS_DIR)/zz-form-submission-form-id-remap-sanitized.sql" "$(H2)"
+
+activate:
+	@mkdir -p "$(ACTIVE_DIR)"
+	rm -f "$(ACTIVE_DIR)"/*-sanitized.sql
+	cp "$(SAN)" "$(ACTIVE_MAIN)"
+	cp "$(H1)" "$(ACTIVE_H1)"
+	cp "$(H2)" "$(ACTIVE_H2)"
+
+all: dump rewrite verify helpers activate
+
+# This is a real reset, not a dry run.
+reset-local:
+	@if [ "$${YES:-0}" != "1" ]; then \
+		echo "Refusing to run. This is DESTRUCTIVE to local Supabase DB."; \
+		echo "Re-run with: make reset-local YES=1"; \
+		exit 1; \
+	fi
+	supabase db reset
+
+postcheck:
+	@echo "Running postcheck SQL against local DB..."
+	supabase db query --file "$(SCRIPT_DIR)/postcheck.sql"
+
+clean-date:
+	rm -f "$(RAW)" "$(SAN)" "$(MAP)" "$(H1)" "$(H2)" "$(ACTIVE_MAIN)" "$(ACTIVE_H1)" "$(ACTIVE_H2)"

--- a/supabase/scripts/prod-data-sanitize/exclude-tables.txt
+++ b/supabase/scripts/prod-data-sanitize/exclude-tables.txt
@@ -1,0 +1,16 @@
+# Static/bootstrap tables that conflict with migrations/app-data seed flow
+
+public.form
+public.form_question
+public.form_question_map
+public.form_assignment
+public.sign_up_flow
+public.role_permission
+public.semester
+public.semester_form_requirement
+public.federal_electoral_district
+public.sign_up_terms
+public.user_roles
+public.email_draft
+public.email_draft_version
+storage.buckets

--- a/supabase/scripts/prod-data-sanitize/helpers/semester-survey-requirements-sanitized.sql
+++ b/supabase/scripts/prod-data-sanitize/helpers/semester-survey-requirements-sanitized.sql
@@ -1,0 +1,112 @@
+-- Restore semester survey links for snapshot semesters.
+-- These links are runtime-semester-specific and are required for /enroll pre/post survey flows.
+
+with pre_forms as (
+  insert into public.form (name, is_required, auto_assign)
+  select
+    format('Pre-Semester Survey - %s', s.id),
+    false,
+    '{}'::app_role[]
+  from public.semester s
+  on conflict (name) do nothing
+  returning id
+)
+select count(*) from pre_forms;
+
+with post_forms as (
+  insert into public.form (name, is_required, auto_assign)
+  select
+    format('Post-Semester Survey - %s', s.id),
+    false,
+    '{}'::app_role[]
+  from public.semester s
+  on conflict (name) do nothing
+  returning id
+)
+select count(*) from post_forms;
+
+with kind_labels as (
+  select
+    case
+      when exists (
+        select 1
+        from pg_enum
+        where enumtypid = 'public.semester_survey_kind'::regtype
+          and enumlabel = 'pre_program_survey'
+      ) then 'pre_program_survey'
+      else 'pre_survey'
+    end as pre_kind,
+    case
+      when exists (
+        select 1
+        from pg_enum
+        where enumtypid = 'public.semester_survey_kind'::regtype
+          and enumlabel = 'post_program_survey'
+      ) then 'post_program_survey'
+      else 'post_survey'
+    end as post_kind
+), pre_pairs as (
+  select s.id as semester_id, f.id as form_id
+  from public.semester s
+  join public.form f on f.name = format('Pre-Semester Survey - %s', s.id)
+), post_pairs as (
+  select s.id as semester_id, f.id as form_id
+  from public.semester s
+  join public.form f on f.name = format('Post-Semester Survey - %s', s.id)
+)
+update public.semester_form_requirement sfr
+set is_active = false
+where sfr.is_active = true
+  and (
+    (sfr.kind = (select pre_kind from kind_labels)::public.semester_survey_kind and exists (
+      select 1 from pre_pairs p
+      where p.semester_id = sfr.semester_id
+        and p.form_id <> sfr.form_id
+    ))
+    or
+    (sfr.kind = (select post_kind from kind_labels)::public.semester_survey_kind and exists (
+      select 1 from post_pairs p
+      where p.semester_id = sfr.semester_id
+        and p.form_id <> sfr.form_id
+    ))
+  );
+
+with kind_labels as (
+  select
+    case
+      when exists (
+        select 1
+        from pg_enum
+        where enumtypid = 'public.semester_survey_kind'::regtype
+          and enumlabel = 'pre_program_survey'
+      ) then 'pre_program_survey'
+      else 'pre_survey'
+    end as pre_kind
+)
+insert into public.semester_form_requirement (semester_id, form_id, kind, is_required, is_active)
+select s.id, f.id, (select pre_kind from kind_labels)::public.semester_survey_kind, true, true
+from public.semester s
+join public.form f on f.name = format('Pre-Semester Survey - %s', s.id)
+on conflict (semester_id, form_id, kind) do update
+  set is_required = excluded.is_required,
+      is_active = excluded.is_active;
+
+with kind_labels as (
+  select
+    case
+      when exists (
+        select 1
+        from pg_enum
+        where enumtypid = 'public.semester_survey_kind'::regtype
+          and enumlabel = 'post_program_survey'
+      ) then 'post_program_survey'
+      else 'post_survey'
+    end as post_kind
+)
+insert into public.semester_form_requirement (semester_id, form_id, kind, is_required, is_active)
+select s.id, f.id, (select post_kind from kind_labels)::public.semester_survey_kind, true, true
+from public.semester s
+join public.form f on f.name = format('Post-Semester Survey - %s', s.id)
+on conflict (semester_id, form_id, kind) do update
+  set is_required = excluded.is_required,
+      is_active = excluded.is_active;

--- a/supabase/scripts/prod-data-sanitize/helpers/zz-form-submission-form-id-remap-sanitized.sql
+++ b/supabase/scripts/prod-data-sanitize/helpers/zz-form-submission-form-id-remap-sanitized.sql
@@ -1,0 +1,42 @@
+do $$
+declare
+  remap record;
+  target_form_id uuid;
+begin
+  for remap in
+    select *
+    from (
+      values
+        ('4c8e9a43-7b20-40ad-a34d-d8957a22b5a0'::uuid, 'Profile Information'::text, null::text),
+        ('19787905-2375-4adf-a385-5ae9f6cc21b1'::uuid, 'Guardian Details'::text, null::text),
+        ('f73986e2-0770-46ef-91f2-197f65fe95b5'::uuid, 'Household Address'::text, null::text),
+        ('762dfe75-feb2-4619-99ce-245e8024ae02'::uuid, 'Additional Guardians'::text, null::text),
+        ('6b9544a8-e5ab-4b04-8168-9f83bb14d09c'::uuid, 'Household Counts'::text, null::text),
+        ('d9aa35c7-1090-48c8-b3b7-5c3b0444be31'::uuid, 'Child Information'::text, null::text),
+        ('86e79eb0-21eb-476b-844f-e31ece0522c9'::uuid, 'Guardian Consent'::text, null::text),
+        ('b0dad9dd-1423-4b73-bb94-43636c91df5c'::uuid, 'Child Email'::text, null::text),
+        ('e5b1f761-b1b9-482d-87b4-5946dee10f8c'::uuid, 'Partner Organization'::text, null::text),
+        ('f65fc3fd-352b-4bc0-860c-929b9daa17ac'::uuid, null::text, 'Pre-Semester Survey - %'::text)
+    ) as t(old_id, target_name, target_like)
+  loop
+    select f.id
+    into target_form_id
+    from public.form f
+    where
+      (remap.target_name is not null and f.name = remap.target_name)
+      or (remap.target_like is not null and f.name like remap.target_like)
+    order by
+      case when remap.target_name is not null and f.name = remap.target_name then 0 else 1 end,
+      f.created_at asc
+    limit 1;
+
+    if target_form_id is null then
+      raise exception 'Missing remap target for legacy form ID %', remap.old_id;
+    end if;
+
+    update public.form_submission
+    set form_id = target_form_id
+    where form_id = remap.old_id;
+  end loop;
+end
+$$;

--- a/supabase/scripts/prod-data-sanitize/postcheck.sql
+++ b/supabase/scripts/prod-data-sanitize/postcheck.sql
@@ -1,0 +1,53 @@
+-- 1) Any form_submission rows pointing to missing form?
+select count(*) as missing_form_refs
+from public.form_submission fs
+left join public.form f on f.id = fs.form_id
+where f.id is null;
+
+-- 2) Any semesters missing active pre/post requirements?
+with kinds as (
+  select
+    case when exists (
+      select 1 from pg_enum
+      where enumtypid = 'public.semester_survey_kind'::regtype
+        and enumlabel = 'pre_program_survey'
+    ) then 'pre_program_survey' else 'pre_survey' end as pre_kind,
+    case when exists (
+      select 1 from pg_enum
+      where enumtypid = 'public.semester_survey_kind'::regtype
+        and enumlabel = 'post_program_survey'
+    ) then 'post_program_survey' else 'post_survey' end as post_kind
+)
+select
+  s.id as semester_id,
+  sum(case when sfr.kind::text = (select pre_kind from kinds) and sfr.is_active then 1 else 0 end) as active_pre,
+  sum(case when sfr.kind::text = (select post_kind from kinds) and sfr.is_active then 1 else 0 end) as active_post
+from public.semester s
+left join public.semester_form_requirement sfr on sfr.semester_id = s.id
+group by s.id
+order by s.id;
+
+-- 3) Non-chsolutions email count across key columns.
+select 'auth.users.email' as source, count(*) as non_chsolutions
+from auth.users
+where email is not null and lower(split_part(email, '@', 2)) <> 'chsolutions.ca'
+union all
+select 'public.profile.email', count(*)
+from public.profile
+where email is not null and lower(split_part(email, '@', 2)) <> 'chsolutions.ca'
+union all
+select 'public.invites.invitee_email', count(*)
+from public.invites
+where invitee_email is not null and lower(split_part(invitee_email, '@', 2)) <> 'chsolutions.ca'
+union all
+select 'public.email_message.to_email', count(*)
+from public.email_message
+where to_email is not null and lower(split_part(to_email, '@', 2)) <> 'chsolutions.ca'
+union all
+select 'public.login_event.email', count(*)
+from public.login_event
+where email is not null and lower(split_part(email, '@', 2)) <> 'chsolutions.ca'
+union all
+select 'public.sign_up_terms_consent.email', count(*)
+from public.sign_up_terms_consent
+where email is not null and lower(split_part(email, '@', 2)) <> 'chsolutions.ca';

--- a/supabase/scripts/prod-data-sanitize/rewrite_email_domains.py
+++ b/supabase/scripts/prod-data-sanitize/rewrite_email_domains.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+from collections import Counter
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-']+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+
+
+def sanitize_local(local: str) -> str:
+    local = local.strip().lower()
+    local = re.sub(r"[^a-z0-9._%+\-]", ".", local)
+    local = re.sub(r"\.+", ".", local).strip(".")
+    return local or "user"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--domain", required=True)
+    parser.add_argument("--map-output", required=True)
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8", errors="ignore") as file:
+        source = file.read()
+
+    mapping: dict[str, str] = {}
+    used_targets: set[str] = set()
+    source_domain_counts = Counter()
+
+    def replace_email(match: re.Match[str]) -> str:
+        original = match.group(0)
+        source_key = original.lower()
+        local, source_domain = source_key.split("@", 1)
+        source_domain_counts[source_domain] += 1
+
+        if source_key in mapping:
+            return mapping[source_key]
+
+        base_local = sanitize_local(local)
+        candidate = f"{base_local}@{args.domain}"
+        index = 1
+        while candidate in used_targets:
+            index += 1
+            candidate = f"{base_local}+{index}@{args.domain}"
+
+        mapping[source_key] = candidate
+        used_targets.add(candidate)
+        return candidate
+
+    rewritten = EMAIL_RE.sub(replace_email, source)
+
+    with open(args.output, "w", encoding="utf-8") as file:
+        file.write(rewritten)
+
+    payload = {
+        "target_domain": args.domain,
+        "source_domain_counts": dict(sorted(source_domain_counts.items())),
+        "unique_source_emails": len(mapping),
+        "mapping": mapping,
+    }
+
+    with open(args.map_output, "w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2, sort_keys=True)
+
+    print(f"Rewrote {len(mapping)} unique source emails to @{args.domain}")
+    print(f"Wrote {args.output}")
+    print(f"Wrote {args.map_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/scripts/prod-data-sanitize/verify_email_domains.py
+++ b/supabase/scripts/prod-data-sanitize/verify_email_domains.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import sys
+from collections import Counter
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-']+@([A-Za-z0-9.\-]+\.[A-Za-z]{2,})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--allowed-domain", required=True)
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8", errors="ignore") as file:
+        text = file.read()
+
+    domains = [match.group(1).lower() for match in EMAIL_RE.finditer(text)]
+    counts = Counter(domains)
+
+    if not counts:
+        print("No email-like values found.")
+        return
+
+    print("Domain counts:")
+    for domain, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        print(f"  {domain}: {count}")
+
+    allowed_domain = args.allowed_domain.lower()
+    disallowed = {domain: count for domain, count in counts.items() if domain != allowed_domain}
+
+    if disallowed:
+        print("\nERROR: disallowed email domains found:")
+        for domain, count in sorted(disallowed.items(), key=lambda item: (-item[1], item[0])):
+            print(f"  {domain}: {count}")
+        sys.exit(1)
+
+    print(f"\nPASS: all email domains are @{allowed_domain}")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/seeds/prod-data/README.md
+++ b/supabase/seeds/prod-data/README.md
@@ -36,6 +36,6 @@ The prod snapshot should focus on operational/runtime tables (profiles, enrollme
 Switch `db.seed.sql_paths` in `supabase/config.toml`:
 
 - app + dummy: `./seeds/app-data/*.sql`, `./seeds/dummy-data/*.sql`
-- app + prod snapshot: `./seeds/app-data/*.sql`, `./seeds/prod-data/*-sanitized.sql`
+- app + prod snapshot: `./seeds/app-data/*.sql`, `./seeds/prod-data/active/*-sanitized.sql`
 
-Use `*-sanitized.sql` for loadable snapshot files and keep raw dumps (for reference only) outside that suffix so they are not executed by default.
+Keep dated archive files in `supabase/seeds/prod-data/` (`YYYYMMDD-raw.sql`, `YYYYMMDD-sanitized.sql`) and stage exactly one loadable set into `supabase/seeds/prod-data/active/` for reset runs.


### PR DESCRIPTION
## What this changes
- Adds a repeatable prod snapshot tooling flow under `supabase/scripts/prod-data-sanitize`.
- Dumps remote linked project data to dated raw files (`YYYYMMDD-raw.sql`).
- Rewrites all email domains to `@chsolutions.ca` into dated sanitized files (`YYYYMMDD-sanitized.sql`).
- Verifies sanitized output and provides post-reset validation SQL.
- Adds canonical helper SQL templates and stages exactly one active snapshot set in `supabase/seeds/prod-data/active/`.

## Seed loading safety
- Updates `supabase/config.toml` to seed only from `./seeds/prod-data/active/*-sanitized.sql` + app-data.
- Prevents loading archived sanitized files unintentionally.
- Keeps raw dumps unseeded by naming (`-raw.sql`) and active-folder targeting.

## Included docs/guidance
- Updates `supabase/seeds/prod-data/README.md` with active-folder and naming conventions.
- Keeps AGENTS guidance aligned with current seed mode path.

## Verification
- `make -C supabase/scripts/prod-data-sanitize help`
- `make -C supabase/scripts/prod-data-sanitize print`
