### PR TITLE
Update zoom attempt ID column ordering

### DIFF
--- a/web/app/routes/manage/class-zoom-participant-sync.tsx
+++ b/web/app/routes/manage/class-zoom-participant-sync.tsx
@@ -19,8 +19,23 @@ export async function loader(args: Route.LoaderArgs) {
 
   const { supabase } = createClient(args.request)
   const { data: meetingRows } = meetingIds.length
-    ? await supabase.from('class_zoom_meeting').select('id, class_id').in('id', meetingIds)
-    : { data: [] as Array<{ id: string; class_id: string }> }
+    ? await supabase
+        .from('class_zoom_meeting')
+        .select('id, class_id, zoom_meeting_id, topic, host_zoom_user_email, start_time, duration_minutes, status, join_url')
+        .in('id', meetingIds)
+    : {
+        data: [] as Array<{
+          id: string
+          class_id: string
+          zoom_meeting_id: string | null
+          topic: string | null
+          host_zoom_user_email: string | null
+          start_time: string | null
+          duration_minutes: number | null
+          status: string
+          join_url: string | null
+        }>,
+      }
 
   const classIds = Array.from(new Set((meetingRows ?? []).map(row => row.class_id).filter((id): id is string => Boolean(id))))
   const { data: classRows } = classIds.length
@@ -32,11 +47,14 @@ export async function loader(args: Route.LoaderArgs) {
 
   const classById = new Map((classRows ?? []).map(row => [row.id, row]))
   const classIdByMeetingId = new Map((meetingRows ?? []).map(row => [row.id, row.class_id]))
+  const meetingById = new Map((meetingRows ?? []).map(row => [row.id, row]))
 
   return {
     ...base,
     rows: rows.map(row => {
-      const classId = typeof row.class_zoom_meeting_id === 'string' ? classIdByMeetingId.get(row.class_zoom_meeting_id) : null
+      const meetingId = typeof row.class_zoom_meeting_id === 'string' ? row.class_zoom_meeting_id : ''
+      const classId = meetingId ? classIdByMeetingId.get(meetingId) : null
+      const meeting = meetingId ? meetingById.get(meetingId) : null
       const classRow = classId ? classById.get(classId) : null
       const workshopRelation = Array.isArray(classRow?.workshop) ? classRow.workshop[0] : classRow?.workshop
       return {
@@ -44,6 +62,12 @@ export async function loader(args: Route.LoaderArgs) {
         workshop_description: workshopRelation?.description ?? 'Workshop',
         class_starts_at: classRow?.starts_at ?? null,
         class_ends_at: classRow?.ends_at ?? null,
+        hover_zoom_topic: meeting?.topic ?? '',
+        hover_zoom_status: meeting?.status ?? '',
+        hover_zoom_host_email: meeting?.host_zoom_user_email ?? '',
+        hover_zoom_start_at: meeting?.start_time ?? '',
+        hover_zoom_duration_minutes: typeof meeting?.duration_minutes === 'number' ? String(meeting.duration_minutes) : '',
+        hover_zoom_join_url: meeting?.join_url ?? '',
       }
     }),
     columns: ['workshop_description', 'class_starts_at', 'class_ends_at', ...(base.columns ?? [])],
@@ -52,6 +76,22 @@ export async function loader(args: Route.LoaderArgs) {
       workshop_description: { label: 'Workshop', filterable: true },
       class_starts_at: { label: 'Class starts', filterable: true },
       class_ends_at: { label: 'Class ends', filterable: true },
+      class_zoom_meeting_display: {
+        label: 'Class zoom meeting',
+        filterable: true,
+        hoverCard: {
+          titleField: 'hover_zoom_topic',
+          titleFallback: 'Meeting details',
+          fields: [
+            { label: 'Meeting ID', field: 'class_zoom_meeting_display', fallback: 'Loading...' },
+            { label: 'Status', field: 'hover_zoom_status', fallback: 'Loading...' },
+            { label: 'Host', field: 'hover_zoom_host_email', fallback: 'Loading...' },
+            { label: 'Start', field: 'hover_zoom_start_at', fallback: 'Loading...' },
+            { label: 'Duration min', field: 'hover_zoom_duration_minutes', fallback: 'Loading...' },
+            { label: 'Join URL', field: 'hover_zoom_join_url', fallback: 'Loading...' },
+          ],
+        },
+      },
     },
   }
 }

--- a/web/app/routes/manage/class-zoom-participant.tsx
+++ b/web/app/routes/manage/class-zoom-participant.tsx
@@ -1,8 +1,117 @@
+import { createClient } from '@/lib/supabase/server'
+import type { Route } from './+types/class-zoom-participant'
 import TableDisplay from './table-display'
 import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
 
-export const loader = createTableLoader('class-zoom-participant')
+const baseLoader = createTableLoader('class-zoom-participant')
+
+type ParticipantRow = Record<string, unknown> & {
+  class_id?: string
+  class_zoom_meeting_id?: string
+  class_display?: { label?: unknown; timestamp?: unknown } | string | null
+}
+
+const classLabel = (value: ParticipantRow['class_display']) => {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object' && typeof value.label === 'string') return value.label
+  return 'Workshop'
+}
+
+const classTimestamp = (value: ParticipantRow['class_display']) => {
+  if (value && typeof value === 'object' && typeof value.timestamp === 'string') return value.timestamp
+  return null
+}
+
+export async function loader(args: Route.LoaderArgs) {
+  const base = await baseLoader(args)
+  const rows = (base.rows ?? []) as ParticipantRow[]
+
+  const classIds = Array.from(new Set(rows.map(row => (typeof row.class_id === 'string' ? row.class_id : '')).filter(Boolean)))
+  const meetingIds = Array.from(
+    new Set(rows.map(row => (typeof row.class_zoom_meeting_id === 'string' ? row.class_zoom_meeting_id : '')).filter(Boolean))
+  )
+
+  const { supabase } = createClient(args.request)
+
+  const [{ data: classRows }, { data: meetingRows }] = await Promise.all([
+    classIds.length
+      ? supabase.from('class').select('id, ends_at').in('id', classIds)
+      : Promise.resolve({ data: [] as Array<{ id: string; ends_at: string | null }> }),
+    meetingIds.length
+      ? supabase
+          .from('class_zoom_meeting')
+          .select('id, zoom_meeting_id, topic, host_zoom_user_email, start_time, duration_minutes, status, join_url')
+          .in('id', meetingIds)
+      : Promise.resolve({
+          data: [] as Array<{
+            id: string
+            zoom_meeting_id: string | null
+            topic: string | null
+            host_zoom_user_email: string | null
+            start_time: string | null
+            duration_minutes: number | null
+            status: string
+            join_url: string | null
+          }>,
+        }),
+  ])
+
+  const classById = new Map((classRows ?? []).map(row => [row.id, row]))
+  const meetingById = new Map((meetingRows ?? []).map(row => [row.id, row]))
+
+  return {
+    ...base,
+    rows: rows.map(row => {
+      const meetingId = typeof row.class_zoom_meeting_id === 'string' ? row.class_zoom_meeting_id : ''
+      const meeting = meetingById.get(meetingId)
+      return {
+        ...row,
+        workshop_description: classLabel(row.class_display),
+        class_starts_at: classTimestamp(row.class_display),
+        class_ends_at:
+          typeof row.class_id === 'string' && classById.get(row.class_id)?.ends_at
+            ? classById.get(row.class_id)?.ends_at ?? null
+            : null,
+        hover_zoom_topic: meeting?.topic ?? '',
+        hover_zoom_status: meeting?.status ?? '',
+        hover_zoom_host_email: meeting?.host_zoom_user_email ?? '',
+        hover_zoom_start_at: meeting?.start_time ?? '',
+        hover_zoom_duration_minutes: typeof meeting?.duration_minutes === 'number' ? String(meeting.duration_minutes) : '',
+        hover_zoom_join_url: meeting?.join_url ?? '',
+      }
+    }),
+    columns: [
+      'workshop_description',
+      'class_starts_at',
+      'class_ends_at',
+      ...(base.columns ?? []).filter(column => column !== 'class_display'),
+    ],
+    columnMeta: {
+      ...(base.columnMeta ?? {}),
+      workshop_description: { label: 'Workshop', filterable: true },
+      class_starts_at: { label: 'Class starts', filterable: true },
+      class_ends_at: { label: 'Class ends', filterable: true },
+      class_zoom_meeting_display: {
+        label: 'Class zoom meeting',
+        filterable: true,
+        hoverCard: {
+          titleField: 'hover_zoom_topic',
+          titleFallback: 'Meeting details',
+          fields: [
+            { label: 'Meeting ID', field: 'class_zoom_meeting_display', fallback: 'Loading...' },
+            { label: 'Status', field: 'hover_zoom_status', fallback: 'Loading...' },
+            { label: 'Host', field: 'hover_zoom_host_email', fallback: 'Loading...' },
+            { label: 'Start', field: 'hover_zoom_start_at', fallback: 'Loading...' },
+            { label: 'Duration min', field: 'hover_zoom_duration_minutes', fallback: 'Loading...' },
+            { label: 'Join URL', field: 'hover_zoom_join_url', fallback: 'Loading...' },
+          ],
+        },
+      },
+    },
+  }
+}
+
 export const action = createTableAction('class-zoom-participant')
 
 export default function ClassZoomParticipantTablePage() {

--- a/web/app/routes/manage/class-zoom-registrant.tsx
+++ b/web/app/routes/manage/class-zoom-registrant.tsx
@@ -8,6 +8,7 @@ const baseLoader = createTableLoader('class-zoom-registrant')
 
 type RegistrantRow = Record<string, unknown> & {
   class_id?: string
+  class_zoom_meeting_id?: string
   class_display?: { label?: unknown; timestamp?: unknown } | string | null
 }
 
@@ -26,24 +27,58 @@ export async function loader(args: Route.LoaderArgs) {
   const base = await baseLoader(args)
   const rows = (base.rows ?? []) as RegistrantRow[]
   const classIds = Array.from(new Set(rows.map(row => (typeof row.class_id === 'string' ? row.class_id : '')).filter(Boolean)))
+  const meetingIds = Array.from(
+    new Set(rows.map(row => (typeof row.class_zoom_meeting_id === 'string' ? row.class_zoom_meeting_id : '')).filter(Boolean))
+  )
   const { supabase } = createClient(args.request)
 
-  const { data: classRows } = classIds.length
-    ? await supabase.from('class').select('id, ends_at').in('id', classIds)
-    : { data: [] as Array<{ id: string; ends_at: string | null }> }
+  const [{ data: classRows }, { data: meetingRows }] = await Promise.all([
+    classIds.length
+      ? supabase.from('class').select('id, ends_at').in('id', classIds)
+      : Promise.resolve({ data: [] as Array<{ id: string; ends_at: string | null }> }),
+    meetingIds.length
+      ? supabase
+          .from('class_zoom_meeting')
+          .select('id, zoom_meeting_id, topic, host_zoom_user_email, start_time, duration_minutes, status, join_url')
+          .in('id', meetingIds)
+      : Promise.resolve({
+          data: [] as Array<{
+            id: string
+            zoom_meeting_id: string | null
+            topic: string | null
+            host_zoom_user_email: string | null
+            start_time: string | null
+            duration_minutes: number | null
+            status: string
+            join_url: string | null
+          }>,
+        }),
+  ])
+
   const classById = new Map((classRows ?? []).map(row => [row.id, row]))
+  const meetingById = new Map((meetingRows ?? []).map(row => [row.id, row]))
 
   return {
     ...base,
-    rows: rows.map(row => ({
-      ...row,
-      workshop_description: classLabel(row.class_display),
-      class_starts_at: classTimestamp(row.class_display),
-      class_ends_at:
-        typeof row.class_id === 'string' && classById.get(row.class_id)?.ends_at
-          ? classById.get(row.class_id)?.ends_at ?? null
-          : null,
-    })),
+    rows: rows.map(row => {
+      const meetingId = typeof row.class_zoom_meeting_id === 'string' ? row.class_zoom_meeting_id : ''
+      const meeting = meetingById.get(meetingId)
+      return {
+        ...row,
+        workshop_description: classLabel(row.class_display),
+        class_starts_at: classTimestamp(row.class_display),
+        class_ends_at:
+          typeof row.class_id === 'string' && classById.get(row.class_id)?.ends_at
+            ? classById.get(row.class_id)?.ends_at ?? null
+            : null,
+        hover_zoom_topic: meeting?.topic ?? '',
+        hover_zoom_status: meeting?.status ?? '',
+        hover_zoom_host_email: meeting?.host_zoom_user_email ?? '',
+        hover_zoom_start_at: meeting?.start_time ?? '',
+        hover_zoom_duration_minutes: typeof meeting?.duration_minutes === 'number' ? String(meeting.duration_minutes) : '',
+        hover_zoom_join_url: meeting?.join_url ?? '',
+      }
+    }),
     columns: [
       'workshop_description',
       'class_starts_at',
@@ -55,6 +90,22 @@ export async function loader(args: Route.LoaderArgs) {
       workshop_description: { label: 'Workshop', filterable: true },
       class_starts_at: { label: 'Class starts', filterable: true },
       class_ends_at: { label: 'Class ends', filterable: true },
+      class_zoom_meeting_display: {
+        label: 'Class zoom meeting',
+        filterable: true,
+        hoverCard: {
+          titleField: 'hover_zoom_topic',
+          titleFallback: 'Meeting details',
+          fields: [
+            { label: 'Meeting ID', field: 'class_zoom_meeting_display', fallback: 'Loading...' },
+            { label: 'Status', field: 'hover_zoom_status', fallback: 'Loading...' },
+            { label: 'Host', field: 'hover_zoom_host_email', fallback: 'Loading...' },
+            { label: 'Start', field: 'hover_zoom_start_at', fallback: 'Loading...' },
+            { label: 'Duration min', field: 'hover_zoom_duration_minutes', fallback: 'Loading...' },
+            { label: 'Join URL', field: 'hover_zoom_join_url', fallback: 'Loading...' },
+          ],
+        },
+      },
     },
   }
 }

--- a/web/app/routes/manage/zoom-job-attempt.tsx
+++ b/web/app/routes/manage/zoom-job-attempt.tsx
@@ -184,12 +184,16 @@ export async function loader(args: Route.LoaderArgs) {
       'external_request_payload',
       'external_response_payload',
       'created_at',
+      'class_id',
+      'profile_id',
     ],
     columnMeta: {
       ...(base.columnMeta ?? {}),
       workshop_description: { label: 'Workshop', filterable: true },
       class_starts_at: { label: 'Class starts', filterable: true },
       class_ends_at: { label: 'Class ends', filterable: true },
+      class_id: { label: 'Class ID', filterable: true },
+      profile_id: { label: 'Profile ID', filterable: true },
       profile_display: { label: 'Profile', filterable: true },
       class_zoom_meeting_display: {
         label: 'Class zoom meeting',

--- a/web/app/routes/manage/zoom-job-attempt.tsx
+++ b/web/app/routes/manage/zoom-job-attempt.tsx
@@ -53,19 +53,13 @@ export async function loader(args: Route.LoaderArgs) {
 
   const { supabase } = createClient(args.request)
 
-  const [{ data: classRows }, { data: profileRows }, { data: meetingRows }, { data: registrantRows }] = await Promise.all([
+  const [{ data: classRows }, { data: meetingRows }, { data: registrantRows }] = await Promise.all([
     classIds.length
       ? supabase
           .from('class')
           .select('id, starts_at, ends_at, workshop:workshop_id ( description )')
           .in('id', classIds)
       : Promise.resolve({ data: [] as Array<{ id: string; starts_at: string | null; ends_at: string | null; workshop: { description: string | null } | null }> }),
-    profileIds.length
-      ? supabase
-          .from('profile')
-          .select('id, firstname, surname, email')
-          .in('id', profileIds)
-      : Promise.resolve({ data: [] as Array<{ id: string; firstname: string | null; surname: string | null; email: string | null }> }),
     meetingIds.length
       ? supabase
           .from('class_zoom_meeting')
@@ -102,6 +96,20 @@ export async function loader(args: Route.LoaderArgs) {
         }),
   ])
 
+  const enrichedProfileIds = new Set(profileIds)
+  for (const registrant of registrantRows ?? []) {
+    if (typeof registrant.profile_id === 'string' && registrant.profile_id) {
+      enrichedProfileIds.add(registrant.profile_id)
+    }
+  }
+
+  const { data: profileRows } = enrichedProfileIds.size
+    ? await supabase
+        .from('profile')
+        .select('id, firstname, surname, email')
+        .in('id', Array.from(enrichedProfileIds))
+    : { data: [] as Array<{ id: string; firstname: string | null; surname: string | null; email: string | null }> }
+
   const classById = new Map((classRows ?? []).map(row => [row.id, row]))
   const profileById = new Map((profileRows ?? []).map(row => [row.id, row]))
   const meetingById = new Map((meetingRows ?? []).map(row => [row.id, row]))
@@ -117,9 +125,10 @@ export async function loader(args: Route.LoaderArgs) {
 
       const classRow = classById.get(classId)
       const workshopRelation = Array.isArray(classRow?.workshop) ? classRow.workshop[0] : classRow?.workshop
-      const profileRow = profileById.get(profileId)
       const meetingRow = meetingById.get(meetingId)
       const registrantRow = registrantById.get(registrantId)
+      const effectiveProfileId = profileId || (typeof registrantRow?.profile_id === 'string' ? registrantRow.profile_id : '')
+      const profileRow = profileById.get(effectiveProfileId)
       const registrantProfile = registrantRow?.profile_id ? profileById.get(registrantRow.profile_id) : null
 
       return {
@@ -127,7 +136,7 @@ export async function loader(args: Route.LoaderArgs) {
         workshop_description: workshopRelation?.description ?? '',
         class_starts_at: classRow?.starts_at ?? null,
         class_ends_at: classRow?.ends_at ?? null,
-        profile_display: profileRow ? profileDisplay(profileRow, profileId) : profileId,
+        profile_display: profileRow ? profileDisplay(profileRow, effectiveProfileId) : effectiveProfileId ? `ID ${effectiveProfileId}` : '',
         class_zoom_meeting_display: meetingRow?.zoom_meeting_id ?? meetingId,
         class_zoom_registrant_display: registrantRow?.zoom_registrant_id ?? registrantId,
         skip_reason: toSkipReason(row),

--- a/web/app/routes/manage/zoom-job-attempt.tsx
+++ b/web/app/routes/manage/zoom-job-attempt.tsx
@@ -1,8 +1,224 @@
+import { createClient } from '@/lib/supabase/server'
+import type { Route } from './+types/zoom-job-attempt'
 import TableDisplay from './table-display'
 import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
 
-export const loader = createTableLoader('zoom-job-attempt')
+const baseLoader = createTableLoader('zoom-job-attempt')
+
+type AttemptRow = Record<string, unknown> & {
+  class_id?: string
+  profile_id?: string
+  class_zoom_meeting_id?: string
+  class_zoom_registrant_id?: string
+  status?: string
+  error_message?: string | null
+  result_payload?: Record<string, unknown> | null
+}
+
+const profileDisplay = (row: { firstname: string | null; surname: string | null; email: string | null }, fallbackId: string) => {
+  const first = (row.firstname ?? '').trim()
+  const last = (row.surname ?? '').trim()
+  const fullName = [first, last].filter(Boolean).join(' ').trim()
+  if (fullName) return fullName
+  const email = (row.email ?? '').trim()
+  return email || `ID ${fallbackId}`
+}
+
+const toSkipReason = (row: AttemptRow) => {
+  if (row.status !== 'skipped') return ''
+  const payload = row.result_payload
+  if (payload && typeof payload === 'object') {
+    const reason = payload.reason
+    if (typeof reason === 'string' && reason.trim()) return reason.trim()
+    const skipReason = payload.skipReason
+    if (typeof skipReason === 'string' && skipReason.trim()) return skipReason.trim()
+  }
+  if (typeof row.error_message === 'string' && row.error_message.trim()) return row.error_message.trim()
+  return 'No skip reason recorded'
+}
+
+export async function loader(args: Route.LoaderArgs) {
+  const base = await baseLoader(args)
+  const rows = (base.rows ?? []) as AttemptRow[]
+
+  const classIds = Array.from(new Set(rows.map(row => (typeof row.class_id === 'string' ? row.class_id : '')).filter(Boolean)))
+  const profileIds = Array.from(new Set(rows.map(row => (typeof row.profile_id === 'string' ? row.profile_id : '')).filter(Boolean)))
+  const meetingIds = Array.from(
+    new Set(rows.map(row => (typeof row.class_zoom_meeting_id === 'string' ? row.class_zoom_meeting_id : '')).filter(Boolean))
+  )
+  const registrantIds = Array.from(
+    new Set(rows.map(row => (typeof row.class_zoom_registrant_id === 'string' ? row.class_zoom_registrant_id : '')).filter(Boolean))
+  )
+
+  const { supabase } = createClient(args.request)
+
+  const [{ data: classRows }, { data: profileRows }, { data: meetingRows }, { data: registrantRows }] = await Promise.all([
+    classIds.length
+      ? supabase
+          .from('class')
+          .select('id, starts_at, ends_at, workshop:workshop_id ( description )')
+          .in('id', classIds)
+      : Promise.resolve({ data: [] as Array<{ id: string; starts_at: string | null; ends_at: string | null; workshop: { description: string | null } | null }> }),
+    profileIds.length
+      ? supabase
+          .from('profile')
+          .select('id, firstname, surname, email')
+          .in('id', profileIds)
+      : Promise.resolve({ data: [] as Array<{ id: string; firstname: string | null; surname: string | null; email: string | null }> }),
+    meetingIds.length
+      ? supabase
+          .from('class_zoom_meeting')
+          .select('id, class_id, zoom_meeting_id, topic, host_zoom_user_email, start_time, duration_minutes, status, join_url')
+          .in('id', meetingIds)
+      : Promise.resolve({
+          data: [] as Array<{
+            id: string
+            class_id: string | null
+            zoom_meeting_id: string | null
+            topic: string | null
+            host_zoom_user_email: string | null
+            start_time: string | null
+            duration_minutes: number | null
+            status: string
+            join_url: string | null
+          }>,
+        }),
+    registrantIds.length
+      ? supabase
+          .from('class_zoom_registrant')
+          .select('id, class_id, profile_id, class_zoom_meeting_id, zoom_registrant_id, zoom_join_url, last_sent_at')
+          .in('id', registrantIds)
+      : Promise.resolve({
+          data: [] as Array<{
+            id: string
+            class_id: string
+            profile_id: string
+            class_zoom_meeting_id: string
+            zoom_registrant_id: string | null
+            zoom_join_url: string | null
+            last_sent_at: string | null
+          }>,
+        }),
+  ])
+
+  const classById = new Map((classRows ?? []).map(row => [row.id, row]))
+  const profileById = new Map((profileRows ?? []).map(row => [row.id, row]))
+  const meetingById = new Map((meetingRows ?? []).map(row => [row.id, row]))
+  const registrantById = new Map((registrantRows ?? []).map(row => [row.id, row]))
+
+  return {
+    ...base,
+    rows: rows.map(row => {
+      const classId = typeof row.class_id === 'string' ? row.class_id : ''
+      const profileId = typeof row.profile_id === 'string' ? row.profile_id : ''
+      const meetingId = typeof row.class_zoom_meeting_id === 'string' ? row.class_zoom_meeting_id : ''
+      const registrantId = typeof row.class_zoom_registrant_id === 'string' ? row.class_zoom_registrant_id : ''
+
+      const classRow = classById.get(classId)
+      const workshopRelation = Array.isArray(classRow?.workshop) ? classRow.workshop[0] : classRow?.workshop
+      const profileRow = profileById.get(profileId)
+      const meetingRow = meetingById.get(meetingId)
+      const registrantRow = registrantById.get(registrantId)
+      const registrantProfile = registrantRow?.profile_id ? profileById.get(registrantRow.profile_id) : null
+
+      return {
+        ...row,
+        workshop_description: workshopRelation?.description ?? '',
+        class_starts_at: classRow?.starts_at ?? null,
+        class_ends_at: classRow?.ends_at ?? null,
+        profile_display: profileRow ? profileDisplay(profileRow, profileId) : profileId,
+        class_zoom_meeting_display: meetingRow?.zoom_meeting_id ?? meetingId,
+        class_zoom_registrant_display: registrantRow?.zoom_registrant_id ?? registrantId,
+        skip_reason: toSkipReason(row),
+        outcome_message:
+          row.status === 'skipped'
+            ? toSkipReason(row)
+            : typeof row.error_message === 'string' && row.error_message.trim()
+              ? row.error_message
+              : '',
+
+        hover_zoom_topic: meetingRow?.topic ?? '',
+        hover_zoom_host_email: meetingRow?.host_zoom_user_email ?? '',
+        hover_zoom_status: meetingRow?.status ?? '',
+        hover_zoom_start_at: meetingRow?.start_time ?? '',
+        hover_zoom_duration_minutes: typeof meetingRow?.duration_minutes === 'number' ? String(meetingRow.duration_minutes) : '',
+        hover_zoom_join_url: meetingRow?.join_url ?? '',
+        hover_zoom_class_workshop: workshopRelation?.description ?? '',
+        hover_zoom_class_starts_at: classRow?.starts_at ?? '',
+
+        hover_registrant_profile: registrantProfile ? profileDisplay(registrantProfile, registrantRow?.profile_id ?? '') : '',
+        hover_registrant_profile_id: registrantRow?.profile_id ?? '',
+        hover_registrant_join_url: registrantRow?.zoom_join_url ?? '',
+        hover_registrant_last_sent_at: registrantRow?.last_sent_at ?? '',
+      }
+    }),
+    columns: [
+      'run_id',
+      'action_type',
+      'trigger_source',
+      'trigger_kind',
+      'status',
+      'workshop_description',
+      'class_starts_at',
+      'class_ends_at',
+      'profile_display',
+      'class_zoom_meeting_display',
+      'class_zoom_registrant_display',
+      'duration_ms',
+      'outcome_message',
+      'started_at',
+      'completed_at',
+      'request_payload',
+      'result_payload',
+      'error_payload',
+      'external_request_payload',
+      'external_response_payload',
+      'created_at',
+    ],
+    columnMeta: {
+      ...(base.columnMeta ?? {}),
+      workshop_description: { label: 'Workshop', filterable: true },
+      class_starts_at: { label: 'Class starts', filterable: true },
+      class_ends_at: { label: 'Class ends', filterable: true },
+      profile_display: { label: 'Profile', filterable: true },
+      class_zoom_meeting_display: {
+        label: 'Class zoom meeting',
+        filterable: true,
+        hoverCard: {
+          titleField: 'hover_zoom_topic',
+          titleFallback: 'Meeting details',
+          fields: [
+            { label: 'Meeting ID', field: 'class_zoom_meeting_display', fallback: 'Loading...' },
+            { label: 'Status', field: 'hover_zoom_status', fallback: 'Loading...' },
+            { label: 'Host', field: 'hover_zoom_host_email', fallback: 'Loading...' },
+            { label: 'Workshop', field: 'hover_zoom_class_workshop', fallback: 'Loading...' },
+            { label: 'Class start', field: 'hover_zoom_class_starts_at', fallback: 'Loading...' },
+            { label: 'Zoom start', field: 'hover_zoom_start_at', fallback: 'Loading...' },
+            { label: 'Duration min', field: 'hover_zoom_duration_minutes', fallback: 'Loading...' },
+            { label: 'Join URL', field: 'hover_zoom_join_url', fallback: 'Loading...' },
+          ],
+        },
+      },
+      class_zoom_registrant_display: {
+        label: 'Class zoom registrant',
+        filterable: true,
+        hoverCard: {
+          titleField: 'hover_registrant_profile',
+          titleFallback: 'Registrant details',
+          fields: [
+            { label: 'Registrant ID', field: 'class_zoom_registrant_display', fallback: 'Loading...' },
+            { label: 'Profile', field: 'hover_registrant_profile', fallback: 'Loading...' },
+            { label: 'Profile ID', field: 'hover_registrant_profile_id', fallback: 'Loading...' },
+            { label: 'Join URL', field: 'hover_registrant_join_url', fallback: 'Loading...' },
+            { label: 'Last sent', field: 'hover_registrant_last_sent_at', fallback: 'Loading...' },
+          ],
+        },
+      },
+      outcome_message: { label: 'Error / skip reason', filterable: true },
+    },
+  }
+}
 
 export const action = createTableAction('zoom-job-attempt')
 

--- a/web/app/routes/manage/zoom-job-run.tsx
+++ b/web/app/routes/manage/zoom-job-run.tsx
@@ -1,8 +1,85 @@
+import { createClient } from '@/lib/supabase/server'
+import type { Route } from './+types/zoom-job-run'
 import TableDisplay from './table-display'
 import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
 
-export const loader = createTableLoader('zoom-job-run')
+const baseLoader = createTableLoader('zoom-job-run')
+
+type RunRow = Record<string, unknown> & {
+  actor_user_id?: string | null
+  status?: string
+  error_message?: string | null
+  summary?: Record<string, unknown> | null
+}
+
+const actorDisplay = (row: { firstname: string | null; surname: string | null; email: string | null }, fallback: string) => {
+  const first = (row.firstname ?? '').trim()
+  const last = (row.surname ?? '').trim()
+  const fullName = [first, last].filter(Boolean).join(' ').trim()
+  if (fullName) return fullName
+  const email = (row.email ?? '').trim()
+  return email || fallback
+}
+
+const toOutcomeMessage = (row: RunRow) => {
+  if (typeof row.error_message === 'string' && row.error_message.trim()) return row.error_message
+  if (row.status !== 'skipped') return ''
+  const summary = row.summary
+  if (summary && typeof summary === 'object') {
+    const skipReason = summary.skipReason
+    if (typeof skipReason === 'string' && skipReason.trim()) return skipReason
+  }
+  return 'No skip reason recorded'
+}
+
+export async function loader(args: Route.LoaderArgs) {
+  const base = await baseLoader(args)
+  const rows = (base.rows ?? []) as RunRow[]
+
+  const actorUserIds = Array.from(
+    new Set(rows.map(row => (typeof row.actor_user_id === 'string' ? row.actor_user_id : '')).filter(Boolean))
+  )
+
+  const { supabase } = createClient(args.request)
+  const { data: actorRows } = actorUserIds.length
+    ? await supabase.from('profile').select('user_id, firstname, surname, email').in('user_id', actorUserIds)
+    : { data: [] as Array<{ user_id: string; firstname: string | null; surname: string | null; email: string | null }> }
+
+  const actorByUserId = new Map((actorRows ?? []).map(row => [row.user_id, row]))
+
+  return {
+    ...base,
+    rows: rows.map(row => {
+      const userId = typeof row.actor_user_id === 'string' ? row.actor_user_id : ''
+      const actor = actorByUserId.get(userId)
+      return {
+        ...row,
+        actor_display: actor ? actorDisplay(actor, userId) : userId,
+        outcome_message: toOutcomeMessage(row),
+      }
+    }),
+    columns: [
+      'run_id',
+      'trigger_source',
+      'trigger_kind',
+      'actor_display',
+      'actor_role',
+      'status',
+      'outcome_message',
+      'started_at',
+      'completed_at',
+      'summary',
+      'context',
+      'created_at',
+    ],
+    columnMeta: {
+      ...(base.columnMeta ?? {}),
+      actor_display: { label: 'Actor', filterable: true },
+      outcome_message: { label: 'Error / skip reason', filterable: true },
+    },
+  }
+}
 
 export const action = createTableAction('zoom-job-run')
 


### PR DESCRIPTION
Moves class_id and profile_id to the end of the zoom job attempt table columns so raw IDs remain available for debugging without crowding the primary context columns.