### PR TITLE
Expire stale photo upload windows and add manage loader instrumentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,41 @@
 # AGENTS.md
 
-## Repo Boundaries
-- Three deployables live in one repo: `web/` (React Router v7 SSR app), `scheduler/` (cron runner), `zoom-api/` (FastAPI service).
-- Run commands in the package directory; repo-root `package.json` has no scripts.
-- Before changing `zoom-api/`, read and follow `zoom-api/CLAUDE.md` (it has stricter workflow + auth checks).
-
-## Local Git Workflow (this clone)
-- Treat `main` as read-only.
-- Use `sai/<topic>` branches, with worktrees under `/Users/saihaansyed/chs/prj/summerlunchplus-app/worktrees/`.
-- Rebase order when landing work: update `sai/main` (`git pull --rebase`) -> rebase `sai/<topic>` onto `sai/main` -> fast-forward `sai/main`.
-- When running `gh` commands from shell, do not include unescaped backticks in inline `--body` text (zsh treats them as command substitution). Use `--body-file`, single-quoted strings, or escape backticks.
+## Repo shape
+- Three deployables share this repo: `web/` (React Router v7 SSR), `scheduler/` (cron container), `zoom-api/` (FastAPI).
+- Run commands inside the relevant package; root `package.json` has dependencies only (no scripts).
+- CI (`.github/workflows/tests.yml`) only runs `web` Playwright tests (with local Supabase); no scheduler/zoom-api CI job here.
 
 ## Web (`web/`)
-- Primary commands: `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, `npm run test`.
-- There is no lint script; do not run `npm run lint`.
-- Routes are manually registered in `web/app/routes.ts`; adding only a route file causes 404s.
-- After touching `web/app/routes.ts`, run `npm run typecheck` to regenerate `.react-router/types`.
-- `createClient` in `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; propagate `headers` on redirects/responses or auth cookies are dropped.
-- Onboarding/auth behavior is split across `web/app/root.tsx`, `web/app/lib/auth.server.ts`, and `web/app/routes/auth/sign-up-details.tsx`; change them together.
-- Staff `/manage` access is exact-path allowlisted in `STAFF_ALLOWED_MANAGE_PATHS` in `web/app/routes/manage/team.tsx`.
-- `ONBOARDING_MODE` defaults to `role`; only literal `permission` enables permission-gated mode.
+- Core commands: `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, `npm run test`.
+- No lint script exists in `web/package.json`.
+- Routing is manually declared in `web/app/routes.ts`; adding a route file without adding it there will 404.
+- After editing `web/app/routes.ts`, run `npm run typecheck` to regenerate `.react-router/types`.
+- `createClient` in `web/app/lib/supabase/server.ts` returns `{ supabase, headers }`; always pass `headers` through redirects/responses or auth cookies are lost.
+- Onboarding/auth flow is coupled across `web/app/root.tsx`, `web/app/lib/auth.server.ts`, and `web/app/routes/auth/sign-up-details.tsx`.
+- `ONBOARDING_MODE` is effectively defaulted to `role` unless exactly `permission`.
 
-## Web Tests
-- Playwright is the only test runner here (`npm run test` runs `web/tests` unit + e2e together).
-- Focused runs: `npm run test:e2e -- tests/e2e/<spec>.spec.ts` and `npm run test:unit -- tests/unit/<spec>.spec.ts`.
-- If `PLAYWRIGHT_BASE_URL` is unset, Playwright auto-starts `npm run dev -- --port 5173`.
-- Some admin e2e specs skip unless `SUPABASE_URL` and `SUPABASE_SECRET_KEY` are set (env or `web/.env.local`).
+## Web tests
+- Playwright is the only JS test runner; `npm run test` runs both `web/tests/e2e` and `web/tests/unit`.
+- Focused runs: `npm run test:e2e -- tests/e2e/<file>.spec.ts` and `npm run test:unit -- tests/unit/<file>.spec.ts`.
+- If `PLAYWRIGHT_BASE_URL` is unset, Playwright starts `npm run dev -- --port 5173` automatically.
+- Several admin e2e specs auto-skip without `SUPABASE_URL` and `SUPABASE_SECRET_KEY` (env or `web/.env.local`).
 
-## Supabase / DB Flow
-- First local boot (from repo root): `cp web/.env.template web/.env.local` -> `supabase start --debug` -> fill env values from `supabase status -o json`.
-- Treat `supabase/schemas/*.sql` as source of truth; do not hand-edit existing generated files in `supabase/migrations/`.
-- Standard schema change flow: edit schema SQL -> `supabase db diff -f <name>` -> `supabase migration up`.
-- Regenerate DB types after schema changes:
+## Supabase + DB
+- Schema source of truth is `supabase/schemas/*.sql`; treat `supabase/migrations/*.sql` as generated artifacts.
+- Normal schema flow: edit schema SQL -> `supabase db diff -f <name>` -> `supabase migration up` (run from repo root).
+- Regenerate TS DB types after schema edits:
   `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`
-- Local seeds are configured to sanitized prod snapshot + app seeds in `supabase/config.toml`.
-- Supabase API row cap is `1000` (`supabase/config.toml`), and over-cap reads can be silently truncated.
-- For `/manage` loaders, exports, and any status/count derivation, never rely on a single unpaginated related-row query (`.in(...).select(...)`) when result size can exceed `max_rows`.
-- Required pattern for high-cardinality reads: deterministic `.order(...)` + `.range(...)` pagination loop, fetch until page size is below batch size, then derive aggregates from the fully collected dataset.
-- Treat paginated-read mistakes as data-integrity bugs (for example status/count mismatches like `photo_status` vs `photo_count` caused by partial reads).
-- `CODE_STANDARDS.md` is the DB/auth convention source of truth.
+- `supabase/config.toml` seeds local DB from sanitized prod snapshot + app seeds, and sets API `max_rows = 1000`; large reads must be batched/paginated to avoid silent truncation.
+- `CODE_STANDARDS.md` is the enforced DB/auth convention reference.
 
 ## Scheduler (`scheduler/`)
-- Cron schedule source of truth: `scheduler/crontab`.
-- `INTERNAL_RUNNER_SECRET` must match values used by `web` internal routes.
-- Main local commands: `make cron`, `make cron-bg`, `make logs`, `make down`, `make smoke-all`.
-- `make smoke-all` runs zoom/gift-card/export/cleanup once each.
+- Schedule source of truth: `scheduler/crontab`.
+- `INTERNAL_RUNNER_SECRET` must match the `web` service secret for `/internal/*` routes.
+- Local commands: `make cron`, `make cron-bg`, `make logs`, `make down`, `make smoke-all`.
 
 ## Zoom API (`zoom-api/`)
-- Use Make targets: `make setup`, `make dev`, `make test` (these use `.venv/bin/...`).
-- `zoom-api/.venv/` exists in this repo; scope searches to `zoom-api/app/` and `zoom-api/tests/` when possible.
+- Read `zoom-api/CLAUDE.md` before making changes; it contains stricter service-specific rules.
+- Preferred commands: `make setup`, `make dev`, `make test`.
+- `make setup` installs runtime deps only (`requirements.txt`); install dev deps (`pip install -r requirements-dev.txt`) before running tests in a fresh venv.
+- Auth/OpenAPI requirement is enforced by tests: keep `HTTPBearer`-based auth in `zoom-api/app/auth.py` so `test_openapi_declares_security_scheme` stays green.
+- Scope searches to `zoom-api/app/` and `zoom-api/tests/` to avoid `.venv/` noise.

--- a/supabase/migrations/20260714143000_class_attendance_photo_status_expired.sql
+++ b/supabase/migrations/20260714143000_class_attendance_photo_status_expired.sql
@@ -1,0 +1,11 @@
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_enum
+    where enumtypid = 'public.class_attendance_photo_status'::regtype
+      and enumlabel = 'expired'
+  ) then
+    alter type public.class_attendance_photo_status add value 'expired';
+  end if;
+end $$;

--- a/supabase/schemas/03_semesters_cohorts_classes.sql
+++ b/supabase/schemas/03_semesters_cohorts_classes.sql
@@ -17,7 +17,8 @@ create type public.class_attendance_status as enum (
 create type public.class_attendance_photo_status as enum (
   'uploaded',
   'accepted',
-  'rejected'
+  'rejected',
+  'expired'
 );
 
 create table public.semester (

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -2377,7 +2377,7 @@ export type Database = {
         | "instructor"
         | "student"
         | "guardian"
-      class_attendance_photo_status: "uploaded" | "accepted" | "rejected"
+      class_attendance_photo_status: "uploaded" | "accepted" | "rejected" | "expired"
       class_attendance_status: "unknown" | "present" | "absent"
       email_draft_channel: "transactional" | "auth"
       email_draft_status: "draft" | "published" | "archived"
@@ -2632,7 +2632,7 @@ export const Constants = {
         "student",
         "guardian",
       ],
-      class_attendance_photo_status: ["uploaded", "accepted", "rejected"],
+      class_attendance_photo_status: ["uploaded", "accepted", "rejected", "expired"],
       class_attendance_status: ["unknown", "present", "absent"],
       email_draft_channel: ["transactional", "auth"],
       email_draft_status: ["draft", "published", "archived"],

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -732,7 +732,7 @@ const allocateGiftCards = async (): Promise<AllocationSummary> => {
     class_id: string
     profile_id: string
     camera_on: boolean | null
-    photo_status: 'uploaded' | 'accepted' | 'rejected' | null
+    photo_status: 'uploaded' | 'accepted' | 'rejected' | 'expired' | null
     gift_card_blocked: boolean | null
     class: { starts_at: string | null; ends_at: string | null } | Array<{ starts_at: string | null; ends_at: string | null }> | null
     profile: { email: string | null } | Array<{ email: string | null }> | null
@@ -759,7 +759,7 @@ const allocateGiftCards = async (): Promise<AllocationSummary> => {
         class_id: string
         profile_id: string
         camera_on: boolean | null
-        photo_status: 'uploaded' | 'accepted' | 'rejected' | null
+        photo_status: 'uploaded' | 'accepted' | 'rejected' | 'expired' | null
         gift_card_blocked: boolean | null
         class: { starts_at: string | null; ends_at: string | null } | Array<{ starts_at: string | null; ends_at: string | null }> | null
         profile: { email: string | null } | Array<{ email: string | null }> | null

--- a/web/app/routes/home.class-photos.upload.ts
+++ b/web/app/routes/home.class-photos.upload.ts
@@ -6,6 +6,7 @@ import { adminClient } from '@/lib/supabase/adminClient'
 import type { Route } from './+types/home.class-photos.upload'
 
 const PHOTO_BUCKET = 'class-attendance-photos'
+const PHOTO_UPLOAD_GRACE_MS = 15 * 60_000
 const nowMs = () => Date.now()
 
 const sanitizeFileName = (input: string) => {
@@ -57,7 +58,8 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   const classEndMs = new Date(classRow.ends_at).getTime()
-  if (!Number.isFinite(classEndMs) || Date.now() <= classEndMs + 15 * 60_000) {
+  const now = Date.now()
+  if (!Number.isFinite(classEndMs) || now <= classEndMs + PHOTO_UPLOAD_GRACE_MS) {
     return Response.json(
       { error: 'Photos can only be uploaded after class is closed (15 minutes after end time).' },
       { status: 409, headers: auth.headers }
@@ -78,6 +80,55 @@ export async function action({ request }: Route.ActionArgs) {
       { error: enrollmentError?.message ?? 'Profile is not approved for this workshop.' },
       { status: 403, headers: auth.headers }
     )
+  }
+
+  const { data: workshopClassesRaw, error: workshopClassesError } = await adminClient
+    .from('class')
+    .select('id, ends_at')
+    .eq('workshop_id', classRow.workshop_id)
+    .order('ends_at', { ascending: false })
+
+  if (workshopClassesError) {
+    return Response.json(
+      { error: workshopClassesError.message },
+      { status: 500, headers: auth.headers }
+    )
+  }
+
+  const latestClosedClass = (workshopClassesRaw ?? []).find(row => {
+    const endsAtMs = new Date(row.ends_at).getTime()
+    return Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
+  })
+
+  if (!latestClosedClass || latestClosedClass.id !== classId) {
+    await adminClient
+      .from('class_attendance')
+      .update({ photo_status: 'expired' })
+      .eq('class_id', classId)
+      .eq('profile_id', profileId)
+      .is('photo_status', null)
+
+    return Response.json(
+      { error: 'Photo upload is only available for the most recent closed class. This class upload window has expired.' },
+      { status: 409, headers: auth.headers }
+    )
+  }
+
+  const staleClosedClassIds = (workshopClassesRaw ?? [])
+    .filter(row => row.id !== classId)
+    .filter(row => {
+      const endsAtMs = new Date(row.ends_at).getTime()
+      return Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
+    })
+    .map(row => row.id)
+
+  if (staleClosedClassIds.length) {
+    await adminClient
+      .from('class_attendance')
+      .update({ photo_status: 'expired' })
+      .in('class_id', staleClosedClassIds)
+      .eq('profile_id', profileId)
+      .is('photo_status', null)
   }
 
   const { data: attendanceRow, error: attendanceError } = await adminClient

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -73,6 +73,7 @@ type LoaderData = {
   giftCardLinkByClass: Record<string, string>
   selectedProfileIdByClass: Record<string, string>
   selectedPhotoStatusByClass: Record<string, string>
+  activePhotoUploadClassIdByWorkshop: Record<string, string>
   nextClass:
       | {
         classId: string
@@ -114,6 +115,8 @@ const personName = (profile: { firstname: string | null; surname: string | null;
 
 const shouldLogHomeInstrumentation =
   process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
+
+const PHOTO_UPLOAD_GRACE_MS = 15 * 60_000
 
 const sendInvite = async ({
   email,
@@ -273,6 +276,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       giftCardLinkByClass: {},
       selectedProfileIdByClass: {},
       selectedPhotoStatusByClass: {},
+      activePhotoUploadClassIdByWorkshop: {},
       nextClass: null,
     } satisfies LoaderData
   }
@@ -419,6 +423,60 @@ export async function loader({ request }: Route.LoaderArgs) {
     return acc
   }, {})
 
+  const activePhotoUploadClassIdByWorkshop = classes.reduce<Record<string, string>>((acc, classRow) => {
+    if (!classRow.workshop_id) return acc
+    if (!approvedWorkshopIds.has(classRow.workshop_id)) return acc
+    if (!selectedProfileIdByClass[classRow.id]) return acc
+
+    const endsAtMs = new Date(classRow.ends_at).getTime()
+    const closed = Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
+    if (!closed) return acc
+
+    const existingClassId = acc[classRow.workshop_id]
+    if (!existingClassId) {
+      acc[classRow.workshop_id] = classRow.id
+      return acc
+    }
+
+    const existingEndsAtMs = new Date(classEndsAtById[existingClassId] ?? '').getTime()
+    if (!Number.isFinite(existingEndsAtMs) || endsAtMs > existingEndsAtMs) {
+      acc[classRow.workshop_id] = classRow.id
+    }
+
+    return acc
+  }, {})
+
+  const selectedPhotoStatusByClassFinal = { ...selectedPhotoStatusByClass }
+  const staleAttendancePairs = classes
+    .map(classRow => {
+      if (!classRow.workshop_id) return null
+      const selectedProfileId = selectedProfileIdByClass[classRow.id]
+      if (!selectedProfileId) return null
+
+      const activeClassId = activePhotoUploadClassIdByWorkshop[classRow.workshop_id]
+      if (!activeClassId || activeClassId === classRow.id) return null
+
+      const currentStatus = selectedPhotoStatusByClassFinal[classRow.id]
+      if (currentStatus) return null
+
+      selectedPhotoStatusByClassFinal[classRow.id] = 'expired'
+      return { classId: classRow.id, profileId: selectedProfileId }
+    })
+    .filter((row): row is { classId: string; profileId: string } => Boolean(row))
+
+  if (staleAttendancePairs.length) {
+    await Promise.all(
+      staleAttendancePairs.map(({ classId, profileId }) =>
+        adminClient
+          .from('class_attendance')
+          .update({ photo_status: 'expired' })
+          .eq('class_id', classId)
+          .eq('profile_id', profileId)
+          .is('photo_status', null)
+      )
+    )
+  }
+
   const { data: allocationRowsRaw } = classIds.length
     ? await adminClient
         .from('gift_card_allocation')
@@ -508,7 +566,8 @@ export async function loader({ request }: Route.LoaderArgs) {
     joinUrlByClass,
     giftCardLinkByClass: giftCardLinkByClassFinal,
     selectedProfileIdByClass,
-    selectedPhotoStatusByClass,
+    selectedPhotoStatusByClass: selectedPhotoStatusByClassFinal,
+    activePhotoUploadClassIdByWorkshop,
     nextClass,
   } satisfies LoaderData
 }
@@ -823,6 +882,7 @@ export default function Home() {
     giftCardLinkByClass,
     selectedProfileIdByClass,
     selectedPhotoStatusByClass,
+    activePhotoUploadClassIdByWorkshop,
     nextClass,
   } = useLoaderData<LoaderData>()
   const actionData = useActionData<ActionData>()
@@ -1086,8 +1146,9 @@ export default function Home() {
   }) => {
     const now = Date.now()
     const endsAtMs = new Date(classRow.ends_at).getTime()
-    const closed = Number.isFinite(endsAtMs) && now > endsAtMs + 15 * 60_000
+    const closed = Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
     const selectedProfileId = selectedProfileIdByClass[classRow.id]
+    const activeClassId = classRow.workshop_id ? activePhotoUploadClassIdByWorkshop[classRow.workshop_id] : undefined
     const photoStatus =
       photoStatusOverrideByClass[classRow.id] ?? selectedPhotoStatusByClass[classRow.id] ?? ''
 
@@ -1101,10 +1162,20 @@ export default function Home() {
           ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
           : photoStatus === 'rejected'
             ? 'border-destructive/40 bg-destructive/10 text-destructive'
+            : photoStatus === 'expired'
+              ? 'border-slate-300 bg-slate-100 text-slate-700'
             : 'border-amber-300 bg-amber-50 text-amber-700'
       return (
         <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusToneClass}`}>
           {photoStatus}
+        </span>
+      )
+    }
+
+    if (activeClassId && activeClassId !== classRow.id) {
+      return (
+        <span className="inline-flex rounded-full border border-slate-300 bg-slate-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-700">
+          expired
         </span>
       )
     }

--- a/web/app/routes/manage/class-attendance-raw.tsx
+++ b/web/app/routes/manage/class-attendance-raw.tsx
@@ -12,7 +12,7 @@ type RawAttendanceRow = {
   class_id: string
   profile_id: string
   status: 'unknown' | 'present' | 'absent' | null
-  photo_status: 'uploaded' | 'accepted' | 'rejected' | null
+  photo_status: 'uploaded' | 'accepted' | 'rejected' | 'expired' | null
   camera_on: boolean | null
   recorded_by: string | null
   created_at: string

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -133,6 +133,8 @@ type GiftCardClickRow = {
 const IN_CLAUSE_BATCH_SIZE = 150
 const CLASS_ATTENDANCE_FETCH_BATCH_SIZE = 1000
 const RELATED_FETCH_BATCH_SIZE = 1000
+const shouldLogClassAttendanceInstrumentation =
+  process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
 const nowMs = () => Date.now()
 
 const isSchemaMismatchError = (error: { code?: string | null; message?: string | null } | null) => {
@@ -195,6 +197,7 @@ const fallbackProfileHoverContext = {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
+  const startedAt = Date.now()
   const profile = createLoaderProfile({
     name: 'class_attendance_loader',
     request,
@@ -203,6 +206,17 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   const url = new URL(request.url)
   const deferTable = url.searchParams.get('_deferTable') === '1'
+  if (shouldLogClassAttendanceInstrumentation) {
+    console.info('[manage-class-attendance-loader]', {
+      event: 'start',
+      at: new Date().toISOString(),
+      pathname: url.pathname,
+      search: url.search,
+      role: auth.claims.role,
+      emailHint: auth.emailHint,
+      deferTable,
+    })
+  }
   const scopedClassId = (url.searchParams.get('scopeClassId') ?? '').trim()
   const isScopedToSingleClass = scopedClassId.length > 0
   profile.mark('require_auth', {
@@ -247,6 +261,15 @@ export async function loader({ request }: Route.LoaderArgs) {
       emailHint: auth.emailHint,
       role: auth.claims.role,
     })
+    if (shouldLogClassAttendanceInstrumentation) {
+      console.info('[manage-class-attendance-loader]', {
+        event: 'shell_complete',
+        at: new Date().toISOString(),
+        pathname: url.pathname,
+        role: auth.claims.role,
+        durationMs: Date.now() - startedAt,
+      })
+    }
     return shell
   }
 
@@ -780,6 +803,17 @@ export async function loader({ request }: Route.LoaderArgs) {
     role: auth.claims.role,
     scopedClassId: scopedClassId || null,
   })
+  if (shouldLogClassAttendanceInstrumentation) {
+    console.info('[manage-class-attendance-loader]', {
+      event: 'data_complete',
+      at: new Date().toISOString(),
+      pathname: url.pathname,
+      role: auth.claims.role,
+      rowCount: rows.length,
+      durationMs: Date.now() - startedAt,
+      scopedClassId: scopedClassId || null,
+    })
+  }
 
   return {
     label: 'Class attendance',

--- a/web/app/routes/manage/deferred-table-display.tsx
+++ b/web/app/routes/manage/deferred-table-display.tsx
@@ -11,6 +11,9 @@ type DeferredTableDisplayProps = {
   paginationActions?: ReactNode
 }
 
+const shouldLogDeferredTableInstrumentation =
+  import.meta.env.DEV || import.meta.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
+
 export default function DeferredTableDisplay({
   dataPath,
   fallbackData,
@@ -36,13 +39,44 @@ export default function DeferredTableDisplay({
   useEffect(() => {
     if (lastRequestedUrlRef.current === dataRequestUrl) return
     lastRequestedUrlRef.current = dataRequestUrl
+    if (shouldLogDeferredTableInstrumentation) {
+      console.info('[manage-deferred-table]', {
+        event: 'fetcher_load',
+        at: new Date().toISOString(),
+        routePath: location.pathname,
+        routeSearch: location.search,
+        dataRequestUrl,
+      })
+    }
     fetcher.load(dataRequestUrl)
   }, [dataRequestUrl, fetcher])
 
   useEffect(() => {
     if (!fetcher.data) return
     lastResolvedDataRef.current = fetcher.data
+    if (shouldLogDeferredTableInstrumentation) {
+      console.info('[manage-deferred-table]', {
+        event: 'fetcher_data',
+        at: new Date().toISOString(),
+        routePath: location.pathname,
+        routeSearch: location.search,
+        tableName: fetcher.data.tableName,
+        rowCount: Array.isArray(fetcher.data.rows) ? fetcher.data.rows.length : null,
+      })
+    }
   }, [fetcher.data])
+
+  useEffect(() => {
+    if (!shouldLogDeferredTableInstrumentation) return
+    console.info('[manage-deferred-table]', {
+      event: 'fetcher_state',
+      at: new Date().toISOString(),
+      routePath: location.pathname,
+      routeSearch: location.search,
+      fetcherState: fetcher.state,
+      dataRequestUrl,
+    })
+  }, [dataRequestUrl, fetcher.state, location.pathname, location.search])
 
   const resolvedData = fetcher.data ?? lastResolvedDataRef.current ?? fallbackData
   const data: LoaderData = {

--- a/web/app/routes/manage/families.tsx
+++ b/web/app/routes/manage/families.tsx
@@ -1,7 +1,36 @@
 import TableDisplay from './table-display'
+import type { Route } from './+types/families'
 import { createTableLoader } from './table-loader'
 
-export const loader = createTableLoader('person-guardian-child')
+const shouldLogFamiliesInstrumentation =
+  process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
+
+const baseLoader = createTableLoader('person-guardian-child')
+
+export async function loader(args: Route.LoaderArgs) {
+  const startedAt = Date.now()
+  if (shouldLogFamiliesInstrumentation) {
+    console.info('[manage-families-loader]', {
+      event: 'start',
+      at: new Date().toISOString(),
+      pathname: new URL(args.request.url).pathname,
+    })
+  }
+
+  const result = await baseLoader(args)
+
+  if (shouldLogFamiliesInstrumentation) {
+    console.info('[manage-families-loader]', {
+      event: 'complete',
+      at: new Date().toISOString(),
+      pathname: new URL(args.request.url).pathname,
+      durationMs: Date.now() - startedAt,
+      rowCount: Array.isArray(result?.rows) ? result.rows.length : null,
+    })
+  }
+
+  return result
+}
 
 export default function FamiliesTablePage() {
   return <TableDisplay />

--- a/web/app/routes/manage/team-members.tsx
+++ b/web/app/routes/manage/team-members.tsx
@@ -23,6 +23,8 @@ type ActionData = {
 
 const TEAM_ROLES = ['instructor', 'staff', 'manager', 'admin'] as const
 const TEAM_ROLE_SET = new Set<string>(TEAM_ROLES)
+const shouldLogTeamMembersInstrumentation =
+  process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
 
 const allowedInviteRolesFor = (role: string | null | undefined): string[] => {
   if (role === 'admin') return ['instructor', 'staff', 'manager', 'admin']
@@ -32,8 +34,26 @@ const allowedInviteRolesFor = (role: string | null | undefined): string[] => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
+  const startedAt = Date.now()
   const auth = await requireAuth(request)
+  if (shouldLogTeamMembersInstrumentation) {
+    console.info('[manage-team-members-loader]', {
+      event: 'start',
+      at: new Date().toISOString(),
+      pathname: new URL(request.url).pathname,
+      role: auth.claims.role,
+      emailHint: auth.emailHint,
+    })
+  }
   if (!isRoleAtLeast(auth.claims.role, 'instructor')) {
+    if (shouldLogTeamMembersInstrumentation) {
+      console.info('[manage-team-members-loader]', {
+        event: 'unauthorized',
+        at: new Date().toISOString(),
+        pathname: new URL(request.url).pathname,
+        role: auth.claims.role,
+      })
+    }
     throw new Response('Unauthorized', { status: 403, headers: auth.headers })
   }
 
@@ -49,7 +69,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw new Response(error.message, { status: 500, headers: auth.headers })
   }
 
-  return {
+  const result = {
     columns: ['role', 'email', 'firstname', 'surname', 'phone', 'postcode', 'password_set'],
     rows: (data ?? []).filter(row => TEAM_ROLE_SET.has(String(row.role ?? ''))),
     label: 'Team',
@@ -57,6 +77,19 @@ export async function loader({ request }: Route.LoaderArgs) {
     role: auth.claims.role,
     allowedInviteRoles: allowedInviteRolesFor(auth.claims.role),
   }
+
+  if (shouldLogTeamMembersInstrumentation) {
+    console.info('[manage-team-members-loader]', {
+      event: 'complete',
+      at: new Date().toISOString(),
+      pathname: new URL(request.url).pathname,
+      role: auth.claims.role,
+      rowCount: result.rows.length,
+      durationMs: Date.now() - startedAt,
+    })
+  }
+
+  return result
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -25,6 +25,8 @@ import {
 } from '@/lib/admin-form-answers.server'
 
 const isLikelyEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+const shouldLogWorkshopEnrollmentInstrumentation =
+  process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
 
 const parseEnrollmentField = (
   formData: FormData,
@@ -52,6 +54,7 @@ const parseEnrollmentField = (
 }
 
 export async function loader(args: Route.LoaderArgs) {
+  const startedAt = Date.now()
   const profile = createLoaderProfile({
     name: 'workshop_enrollment_loader',
     request: args.request,
@@ -59,6 +62,15 @@ export async function loader(args: Route.LoaderArgs) {
 
   const url = new URL(args.request.url)
   const deferTable = url.searchParams.get('_deferTable') === '1'
+  if (shouldLogWorkshopEnrollmentInstrumentation) {
+    console.info('[manage-workshop-enrollment-loader]', {
+      event: 'start',
+      at: new Date().toISOString(),
+      pathname: url.pathname,
+      search: url.search,
+      deferTable,
+    })
+  }
   profile.mark('defer_table_mode', {
     deferTable,
   })
@@ -98,6 +110,15 @@ export async function loader(args: Route.LoaderArgs) {
       emailHint: auth.emailHint,
       role: auth.claims.role,
     })
+    if (shouldLogWorkshopEnrollmentInstrumentation) {
+      console.info('[manage-workshop-enrollment-loader]', {
+        event: 'shell_complete',
+        at: new Date().toISOString(),
+        pathname: url.pathname,
+        role: auth.claims.role,
+        durationMs: Date.now() - startedAt,
+      })
+    }
     return shell
   }
 
@@ -150,6 +171,16 @@ export async function loader(args: Route.LoaderArgs) {
     giftCardOptionCount: giftCardOptions.length,
     districtOptionCount: federalDistrictOptions.length,
   })
+  if (shouldLogWorkshopEnrollmentInstrumentation) {
+    console.info('[manage-workshop-enrollment-loader]', {
+      event: 'data_complete',
+      at: new Date().toISOString(),
+      pathname: url.pathname,
+      rowCount: result.rows.length,
+      totalRows: result.totalRows ?? result.rows.length,
+      durationMs: Date.now() - startedAt,
+    })
+  }
 
   return result
 }


### PR DESCRIPTION
## What
- add expired to class_attendance_photo_status schema plus migration
- enforce one active family photo upload row per workshop (latest closed class only)
- mark older class attendance photo rows as expired in loader and upload flows
- update home UI badge and backend upload guardrails
- include current manage route instrumentation updates and AGENTS guidance refresh on sai/main

## Validation
- cd web && npm run typecheck
