### PR TITLE
Improve participants paging and filter select-none UX

### DIFF
--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -915,8 +915,18 @@ export async function loader({ request }: Route.LoaderArgs) {
       status: { label: 'Attendance', filterable: true },
       latest_geo: { label: 'Geo', filterable: true, truncate: true, fitContentOnLoad: true },
       giftcard_display: { label: 'Provider', filterable: true, truncate: true },
-      gift_card_allocated: { label: 'Gift allocated', filterable: true },
-      gift_card_available: { label: 'Gift available', filterable: true },
+      gift_card_allocated: {
+        label: 'Gift allocated',
+        filterable: true,
+        headerTooltip:
+          'Gift allocated is true when a gift_card_allocation row exists for this class and profile. Allocation can happen from the runner after attendance evidence (camera_on=true or photo_status=accepted), or manually via Allocate in this table.',
+      },
+      gift_card_available: {
+        label: 'Gift available',
+        filterable: true,
+        headerTooltip:
+          'Gift available is true only when a gift has been allocated, the attendance row is not blocked, and release timing has passed. Release timing comes from allocation metadata/class timing and can be overridden by the Gift available dropdown.',
+      },
       gift_card_availability_reason: { label: 'Gift availability reason', filterable: true, truncate: true },
       gift_card_release_source: { label: 'Gift release source', filterable: true },
       gift_card_effective_release_at: { label: 'Gift effective release at', filterable: true },

--- a/web/app/routes/manage/participants.tsx
+++ b/web/app/routes/manage/participants.tsx
@@ -1,17 +1,31 @@
 import type { Route } from './+types/participants'
+import { parseFilterClauseValues, serializeFilterClause } from '@/lib/table-filter-params'
 import TableDisplay from './table-display'
 import { createTableLoader } from './table-loader'
 
 const baseLoader = createTableLoader('profile')
 
-const PARTICIPANT_ROLES = new Set(['guardian', 'student', 'unassigned'])
+const PARTICIPANT_ROLE_VALUES = ['guardian', 'student', 'unassigned'] as const
+const PARTICIPANT_ROLES = new Set(PARTICIPANT_ROLE_VALUES)
+const isParticipantRole = (value: string): value is (typeof PARTICIPANT_ROLE_VALUES)[number] =>
+  PARTICIPANT_ROLES.has(value as (typeof PARTICIPANT_ROLE_VALUES)[number])
 
 export async function loader(args: Route.LoaderArgs) {
-  const base = await baseLoader(args)
-  const filteredRows = (base.rows as Record<string, unknown>[]).filter(row =>
-    PARTICIPANT_ROLES.has(String(row.role ?? ''))
-  )
-  const rows = filteredRows.map(row => ({
+  const url = new URL(args.request.url)
+  const requestedRoleClause = parseFilterClauseValues(url.searchParams.getAll('f_role'))
+  const effectiveRoleValues: string[] =
+    requestedRoleClause?.op === 'in'
+      ? requestedRoleClause.values.filter(isParticipantRole)
+      : requestedRoleClause?.op === 'not_in'
+        ? PARTICIPANT_ROLE_VALUES.filter(value => !requestedRoleClause.values.includes(value))
+        : [...PARTICIPANT_ROLE_VALUES]
+
+  url.searchParams.delete('f_role')
+  url.searchParams.append('f_role', serializeFilterClause({ op: 'in', values: effectiveRoleValues }))
+
+  const request = new Request(url.toString(), args.request)
+  const base = await baseLoader({ ...args, request })
+  const rows = (base.rows as Record<string, unknown>[]).map(row => ({
     ...row,
     is_user: row.user_id ? 'TRUE' : 'FALSE',
   }))
@@ -25,6 +39,10 @@ export async function loader(args: Route.LoaderArgs) {
     label: 'Participants',
     columns,
     rows,
+    columnMeta: {
+      ...(base.columnMeta ?? {}),
+      is_user: { label: 'Is user', filterable: true },
+    },
   }
 }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -150,6 +150,7 @@ export type LoaderData = {
   enableCellClickFilter?: boolean
   columnMeta?: Record<string, {
     label?: string
+    headerTooltip?: string
     truncate?: boolean
     filterable?: boolean
     numeric?: boolean
@@ -2913,6 +2914,7 @@ export default function TableDisplay({
                 return (
                   <th
                     key={`head-${column}`}
+                    title={columnMeta[column]?.headerTooltip}
                     className={`${isNumericColumn(column) ? 'w-24' : ''} relative px-4 py-2 text-left ${hasStickyTopBar ? 'sticky top-0 z-10 bg-muted/95 backdrop-blur supports-[backdrop-filter]:bg-muted/80' : ''}`}
                   >
                     <div className="relative flex items-center gap-1">

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -2746,6 +2746,9 @@ export default function TableDisplay({
   const shouldHideOptionsList =
     (openFilterCacheEntry?.totalCount ?? 0) > FILTER_OPTION_MAX_VISIBLE_LIST && !hasFilterSearchQuery
   const canRenderFilterOptionsList = openFilterCacheEntry?.status === 'loaded' && !shouldHideOptionsList
+  const hasAnySelectionInCurrentFilterScope = canRenderFilterOptionsList
+    ? visibleFilterOptions.some(option => openFilterDraftValues.includes(option))
+    : openFilterDraftValues.length > 0
   const openFilterStatusText = isOpenFilterLoading
     ? 'Loading...'
     : shouldHideOptionsList
@@ -2763,10 +2766,10 @@ export default function TableDisplay({
     setOpenFilterDraft(next)
   }
 
-  const clearVisibleFilterOptions = () => {
+  const selectNoneForVisibleFilterOptions = () => {
     if (!openFilterColumn) return
     if (!canRenderFilterOptionsList) {
-      clearOpenFilter()
+      setOpenFilterDraft([])
       return
     }
     const current = openFilterDraftValues
@@ -4094,12 +4097,12 @@ export default function TableDisplay({
                 </button>
                 <button
                   type="button"
-                  onClick={clearVisibleFilterOptions}
-                  disabled={!canRenderFilterOptionsList && openFilterDraftValues.length === openFilterOptions.length}
-                  aria-label="Clear visible options"
+                  onClick={selectNoneForVisibleFilterOptions}
+                  disabled={!hasAnySelectionInCurrentFilterScope}
+                  aria-label="Select none for visible options"
                   className="rounded border border-input px-2 py-1 hover:bg-muted"
                 >
-                  Clear
+                  Select none
                 </button>
               </div>
 


### PR DESCRIPTION
## What
- add header tooltip support to table column meta and use it for gift-card columns in class attendance
- update participants loader to apply participant-role filtering server-side for correct pagination/counts
- change filter popover action from Clear to Select none
- make Select none work even when options are not fully loaded (>1500 unique values with empty search)

## Validation
- cd web && npm run typecheck
