### PR TITLE
Fix class registrant filters and pagination

### DIFF
--- a/web/app/routes/manage/class-zoom-registrant.tsx
+++ b/web/app/routes/manage/class-zoom-registrant.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'react-router'
 import { createClient } from '@/lib/supabase/server'
 import type { Route } from './+types/class-zoom-registrant'
 import TableDisplay from './table-display'
@@ -5,6 +6,34 @@ import { createTableAction } from './table-actions.server'
 import { createTableLoader } from './table-loader'
 
 const baseLoader = createTableLoader('class-zoom-registrant')
+const IN_CLAUSE_BATCH_SIZE = 150
+
+const UNSUPPORTED_FILTER_COLUMNS = new Set([
+  'workshop_description',
+  'class_starts_at',
+  'class_ends_at',
+  'class_display',
+  'profile_display',
+  'class_zoom_meeting_display',
+])
+
+const UNSUPPORTED_SORT_COLUMNS = new Set([
+  'workshop_description',
+  'class_starts_at',
+  'class_ends_at',
+  'class_display',
+  'profile_display',
+  'class_zoom_meeting_display',
+])
+
+const chunkArray = <T,>(items: T[], size: number) => {
+  if (size <= 0 || !items.length) return [] as T[][]
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
 
 type RegistrantRow = Record<string, unknown> & {
   class_id?: string
@@ -24,6 +53,29 @@ const classTimestamp = (value: RegistrantRow['class_display']) => {
 }
 
 export async function loader(args: Route.LoaderArgs) {
+  const url = new URL(args.request.url)
+  let normalized = false
+
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (!key.startsWith('f_')) continue
+    const column = key.slice(2)
+    if (!UNSUPPORTED_FILTER_COLUMNS.has(column)) continue
+    url.searchParams.delete(key)
+    normalized = true
+  }
+
+  const sortColumn = (url.searchParams.get('sort') ?? '').trim()
+  if (sortColumn && UNSUPPORTED_SORT_COLUMNS.has(sortColumn)) {
+    url.searchParams.delete('sort')
+    url.searchParams.delete('dir')
+    normalized = true
+  }
+
+  if (normalized) {
+    const nextSearch = url.searchParams.toString()
+    throw redirect(nextSearch ? `${url.pathname}?${nextSearch}` : url.pathname)
+  }
+
   const base = await baseLoader(args)
   const rows = (base.rows ?? []) as RegistrantRow[]
   const classIds = Array.from(new Set(rows.map(row => (typeof row.class_id === 'string' ? row.class_id : '')).filter(Boolean)))
@@ -32,17 +84,46 @@ export async function loader(args: Route.LoaderArgs) {
   )
   const { supabase } = createClient(args.request)
 
-  const [{ data: classRows }, { data: meetingRows }] = await Promise.all([
-    classIds.length
-      ? supabase.from('class').select('id, ends_at').in('id', classIds)
-      : Promise.resolve({ data: [] as Array<{ id: string; ends_at: string | null }> }),
+  const fetchClasses = async () => {
+    const classRows: Array<{ id: string; ends_at: string | null }> = []
+    for (const classIdChunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
+      const { data, error } = await supabase.from('class').select('id, ends_at').in('id', classIdChunk)
+      if (error) throw new Response(error.message, { status: 500 })
+      classRows.push(...((data ?? []) as typeof classRows))
+    }
+    return classRows
+  }
+
+  const fetchMeetings = async () => {
+    const meetingRows: Array<{
+      id: string
+      zoom_meeting_id: string | null
+      topic: string | null
+      host_zoom_user_email: string | null
+      start_time: string | null
+      duration_minutes: number | null
+      status: string
+      join_url: string | null
+    }> = []
+
+    for (const meetingIdChunk of chunkArray(meetingIds, IN_CLAUSE_BATCH_SIZE)) {
+      const { data, error } = await supabase
+        .from('class_zoom_meeting')
+        .select('id, zoom_meeting_id, topic, host_zoom_user_email, start_time, duration_minutes, status, join_url')
+        .in('id', meetingIdChunk)
+      if (error) throw new Response(error.message, { status: 500 })
+      meetingRows.push(...((data ?? []) as typeof meetingRows))
+    }
+
+    return meetingRows
+  }
+
+  const [classRows, meetingRows] = await Promise.all([
+    classIds.length ? fetchClasses() : Promise.resolve([] as Array<{ id: string; ends_at: string | null }>),
     meetingIds.length
-      ? supabase
-          .from('class_zoom_meeting')
-          .select('id, zoom_meeting_id, topic, host_zoom_user_email, start_time, duration_minutes, status, join_url')
-          .in('id', meetingIds)
-      : Promise.resolve({
-          data: [] as Array<{
+      ? fetchMeetings()
+      : Promise.resolve(
+          [] as Array<{
             id: string
             zoom_meeting_id: string | null
             topic: string | null
@@ -51,12 +132,16 @@ export async function loader(args: Route.LoaderArgs) {
             duration_minutes: number | null
             status: string
             join_url: string | null
-          }>,
-        }),
+          }>
+        ),
   ])
 
   const classById = new Map((classRows ?? []).map(row => [row.id, row]))
   const meetingById = new Map((meetingRows ?? []).map(row => [row.id, row]))
+  const baseProfileMeta =
+    base.columnMeta && typeof base.columnMeta === 'object'
+      ? (base.columnMeta as Record<string, Record<string, unknown>>).profile_display
+      : undefined
 
   return {
     ...base,
@@ -87,12 +172,16 @@ export async function loader(args: Route.LoaderArgs) {
     ],
     columnMeta: {
       ...(base.columnMeta ?? {}),
-      workshop_description: { label: 'Workshop', filterable: true },
-      class_starts_at: { label: 'Class starts', filterable: true },
-      class_ends_at: { label: 'Class ends', filterable: true },
+      workshop_description: { label: 'Workshop', filterable: false },
+      class_starts_at: { label: 'Class starts', filterable: false },
+      class_ends_at: { label: 'Class ends', filterable: false },
+      profile_display: {
+        ...(baseProfileMeta && typeof baseProfileMeta === 'object' ? baseProfileMeta : {}),
+        filterable: false,
+      },
       class_zoom_meeting_display: {
         label: 'Class zoom meeting',
-        filterable: true,
+        filterable: false,
         hoverCard: {
           titleField: 'hover_zoom_topic',
           titleFallback: 'Meeting details',

--- a/web/app/routes/manage/class.tsx
+++ b/web/app/routes/manage/class.tsx
@@ -21,6 +21,23 @@ type ActionData = {
   classSyncError?: string
   classMeetingSuccess?: string
   classMeetingError?: string
+  classRecoverySuccess?: string
+  classRecoveryError?: string
+  classRecoveryResult?: {
+    classId: string
+    attendanceRowsEnsured: number
+    meetingCreated: boolean
+    meetingRecreated: boolean
+    registrantsCreated: number
+    registrantsUpdated: number
+    registrantsRemoved: number
+    registrantsSkipped: number
+    registrantFailureCount: number
+    lockWaitMs: number
+    skipped: boolean
+    skipReason: string | null
+    error: string | null
+  }
 }
 
 type ClassRow = Record<string, unknown> & {
@@ -28,6 +45,18 @@ type ClassRow = Record<string, unknown> & {
   workshop_id?: string | null
   starts_at?: string | null
   ends_at?: string | null
+}
+
+const IN_CLAUSE_BATCH_SIZE = 150
+const RELATED_FETCH_BATCH_SIZE = 1000
+
+const chunkArray = <T,>(items: T[], size: number) => {
+  if (size <= 0 || !items.length) return [] as T[][]
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
 }
 
 export async function loader(args: Route.LoaderArgs) {
@@ -86,25 +115,106 @@ export async function loader(args: Route.LoaderArgs) {
 
   const { supabase } = createClient(args.request)
 
-  const [{ data: meetings }, { data: registrants }, { data: enrollments }, { data: attendanceRows }] = await Promise.all([
-    supabase
-      .from('class_zoom_meeting')
-      .select('id, class_id, status, join_url, host_zoom_user_email, zoom_meeting_id, start_time, duration_minutes, topic')
-      .in('class_id', classIds),
-    supabase
-      .from('class_zoom_registrant')
-      .select('class_id, profile_id, zoom_registrant_id, zoom_join_url, last_sent_at')
-      .in('class_id', classIds),
-    workshopIds.length
-      ? supabase
+  const fetchMeetingsByClassId = async () => {
+    const meetings: Array<{
+      id: string
+      class_id: string
+      status: string
+      join_url: string | null
+      host_zoom_user_email: string | null
+      zoom_meeting_id: string | null
+      start_time: string | null
+      duration_minutes: number | null
+      topic: string | null
+    }> = []
+
+    for (const classIdChunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
+      const { data, error } = await supabase
+        .from('class_zoom_meeting')
+        .select('id, class_id, status, join_url, host_zoom_user_email, zoom_meeting_id, start_time, duration_minutes, topic')
+        .in('class_id', classIdChunk)
+      if (error) throw new Response(error.message, { status: 500 })
+      meetings.push(...((data ?? []) as typeof meetings))
+    }
+
+    return meetings
+  }
+
+  const fetchRegistrantsByClassId = async () => {
+    const registrants: Array<{
+      class_id: string
+      profile_id: string | null
+      zoom_registrant_id: string | null
+      zoom_join_url: string | null
+      last_sent_at: string | null
+    }> = []
+
+    for (const classIdChunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
+      for (let offset = 0; ; offset += RELATED_FETCH_BATCH_SIZE) {
+        const { data, error } = await supabase
+          .from('class_zoom_registrant')
+          .select('class_id, profile_id, zoom_registrant_id, zoom_join_url, last_sent_at')
+          .in('class_id', classIdChunk)
+          .order('class_id', { ascending: true })
+          .order('profile_id', { ascending: true })
+          .range(offset, offset + RELATED_FETCH_BATCH_SIZE - 1)
+        if (error) throw new Response(error.message, { status: 500 })
+        const chunk = (data ?? []) as typeof registrants
+        registrants.push(...chunk)
+        if (chunk.length < RELATED_FETCH_BATCH_SIZE) break
+      }
+    }
+
+    return registrants
+  }
+
+  const fetchApprovedEnrollmentsByWorkshopId = async () => {
+    const enrollments: Array<{ workshop_id: string; profile_id: string | null; status: string }> = []
+    if (!workshopIds.length) return enrollments
+
+    for (const workshopIdChunk of chunkArray(workshopIds, IN_CLAUSE_BATCH_SIZE)) {
+      for (let offset = 0; ; offset += RELATED_FETCH_BATCH_SIZE) {
+        const { data, error } = await supabase
           .from('workshop_enrollment')
           .select('workshop_id, profile_id, status')
-          .in('workshop_id', workshopIds)
+          .in('workshop_id', workshopIdChunk)
           .eq('status', 'approved')
-      : Promise.resolve({ data: [] as Array<{ workshop_id: string; profile_id: string | null; status: string }> }),
-    classIds.length
-      ? supabase.from('class_attendance').select('class_id, profile_id').in('class_id', classIds)
-      : Promise.resolve({ data: [] as Array<{ class_id: string; profile_id: string | null }> }),
+          .order('workshop_id', { ascending: true })
+          .range(offset, offset + RELATED_FETCH_BATCH_SIZE - 1)
+        if (error) throw new Response(error.message, { status: 500 })
+        const chunk = (data ?? []) as typeof enrollments
+        enrollments.push(...chunk)
+        if (chunk.length < RELATED_FETCH_BATCH_SIZE) break
+      }
+    }
+
+    return enrollments
+  }
+
+  const fetchAttendanceRowsByClassId = async () => {
+    const attendanceRows: Array<{ class_id: string; profile_id: string | null }> = []
+    for (const classIdChunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
+      for (let offset = 0; ; offset += RELATED_FETCH_BATCH_SIZE) {
+        const { data, error } = await supabase
+          .from('class_attendance')
+          .select('class_id, profile_id')
+          .in('class_id', classIdChunk)
+          .order('class_id', { ascending: true })
+          .range(offset, offset + RELATED_FETCH_BATCH_SIZE - 1)
+        if (error) throw new Response(error.message, { status: 500 })
+        const chunk = (data ?? []) as typeof attendanceRows
+        attendanceRows.push(...chunk)
+        if (chunk.length < RELATED_FETCH_BATCH_SIZE) break
+      }
+    }
+    return attendanceRows
+  }
+
+  const [meetings, registrants, enrollments, attendanceRows] = await Promise.all([
+    fetchMeetingsByClassId(),
+    fetchRegistrantsByClassId(),
+    fetchApprovedEnrollmentsByWorkshopId(),
+    fetchAttendanceRowsByClassId(),
   ])
 
   const meetingByClassId = new Map<
@@ -135,16 +245,26 @@ export async function loader(args: Route.LoaderArgs) {
   }
 
   const meetingIds = Array.from(new Set(Array.from(meetingByClassId.values()).map(item => item.id)))
-  const { data: syncRuns } = meetingIds.length
-    ? await supabase
-        .from('class_zoom_participant_sync')
-        .select('class_zoom_meeting_id, status, created_at')
-        .in('class_zoom_meeting_id', meetingIds)
-        .order('created_at', { ascending: false })
-    : { data: [] as Array<{ class_zoom_meeting_id: string; status: string; created_at: string }> }
+  const syncRuns: Array<{ class_zoom_meeting_id: string; status: string; created_at: string }> = []
+  if (meetingIds.length) {
+    for (const meetingIdChunk of chunkArray(meetingIds, IN_CLAUSE_BATCH_SIZE)) {
+      for (let offset = 0; ; offset += RELATED_FETCH_BATCH_SIZE) {
+        const { data, error } = await supabase
+          .from('class_zoom_participant_sync')
+          .select('class_zoom_meeting_id, status, created_at')
+          .in('class_zoom_meeting_id', meetingIdChunk)
+          .order('created_at', { ascending: false })
+          .range(offset, offset + RELATED_FETCH_BATCH_SIZE - 1)
+        if (error) throw new Response(error.message, { status: 500 })
+        const chunk = (data ?? []) as typeof syncRuns
+        syncRuns.push(...chunk)
+        if (chunk.length < RELATED_FETCH_BATCH_SIZE) break
+      }
+    }
+  }
 
   const latestSyncByMeetingId = new Map<string, { status: string; created_at: string }>()
-  for (const syncRun of syncRuns ?? []) {
+  for (const syncRun of syncRuns) {
     if (!latestSyncByMeetingId.has(syncRun.class_zoom_meeting_id)) {
       latestSyncByMeetingId.set(syncRun.class_zoom_meeting_id, {
         status: syncRun.status,
@@ -156,7 +276,7 @@ export async function loader(args: Route.LoaderArgs) {
   const approvedCountByWorkshopId = new Map<string, number>()
   const approvedProfileIdsByWorkshopId = new Map<string, Set<string>>()
   const seenWorkshopProfile = new Set<string>()
-  for (const enrollment of enrollments ?? []) {
+  for (const enrollment of enrollments) {
     if (!enrollment.workshop_id || !enrollment.profile_id) continue
     const key = `${enrollment.workshop_id}::${enrollment.profile_id}`
     if (seenWorkshopProfile.has(key)) continue
@@ -168,7 +288,7 @@ export async function loader(args: Route.LoaderArgs) {
   }
 
   const attendanceProfileIdsByClassId = new Map<string, Set<string>>()
-  for (const row of attendanceRows ?? []) {
+  for (const row of attendanceRows) {
     if (!row.class_id || !row.profile_id) continue
     const classProfiles = attendanceProfileIdsByClassId.get(row.class_id) ?? new Set<string>()
     classProfiles.add(row.profile_id)
@@ -179,7 +299,7 @@ export async function loader(args: Route.LoaderArgs) {
     string,
     Array<{ profile_id: string; zoom_registrant_id: string | null; zoom_join_url: string | null; last_sent_at: string | null }>
   >()
-  for (const registrant of registrants ?? []) {
+  for (const registrant of registrants) {
     if (!registrant.class_id || !registrant.profile_id) continue
     const bucket = registrantsByClassId.get(registrant.class_id) ?? []
     bucket.push({
@@ -240,12 +360,13 @@ export async function loader(args: Route.LoaderArgs) {
 
     const registrantProfileIds = new Set(
       classRegistrants
+        .filter(entry => Boolean(entry.zoom_registrant_id && entry.zoom_join_url))
         .map(entry => entry.profile_id)
         .filter(profileId => expectedProfileIds.has(profileId))
     )
     const registrantsReady = registrantProfileIds.size
     const attendanceRowsReady = Array.from(expectedProfileIds).filter(profileId => attendanceProfileIds.has(profileId)).length
-    const remindersSent = classRegistrants.filter(entry => Boolean(entry.last_sent_at)).length
+    const remindersSent = classRegistrants.filter(entry => expectedProfileIds.has(entry.profile_id) && Boolean(entry.last_sent_at)).length
 
     const endsAt = typeof row.ends_at === 'string' ? new Date(row.ends_at) : null
     const classEnded = Boolean(endsAt && Number.isFinite(endsAt.getTime()) && endsAt.getTime() <= Date.now())
@@ -286,6 +407,7 @@ export async function loader(args: Route.LoaderArgs) {
         zoomDurationMinutes: meeting?.duration_minutes ?? null,
       }),
       sync_class: 'Sync class',
+      recover_class: 'Recover class',
       zoom_host_email: meeting?.host_zoom_user_email ?? row.zoom_host_email ?? '',
       zoom_join_url: meeting?.join_url ?? row.zoom_join_url ?? '',
       step_meeting: meetingComplete ? meeting?.start_time ?? 'Generated' : 'Generate',
@@ -316,7 +438,7 @@ export async function loader(args: Route.LoaderArgs) {
     displayColumns.splice(meetingColumnIndex, 0, 'step_attendance_rows')
   }
 
-  displayColumns.push('ends_at', 'sync_class')
+  displayColumns.push('ends_at', 'recover_class', 'sync_class')
 
   const fitAllColumnsMeta = Object.fromEntries(
     displayColumns.map(column => [
@@ -373,6 +495,7 @@ export async function loader(args: Route.LoaderArgs) {
       step_attendance_rows: { label: 'Attendance Rows', filterable: true },
       step_reminder: { label: 'Reminder', filterable: true },
       step_attendance: { label: 'Attendance Sync', filterable: true },
+      recover_class: { label: 'Recover', filterable: false },
       sync_class: { label: 'Sync', filterable: false },
       zoom_host_email: { label: 'Zoom Host', filterable: true, fitContentOnLoad: true },
       zoom_join_url: { label: 'Zoom Join Link', truncate: true },
@@ -479,6 +602,66 @@ export async function action(args: Route.ActionArgs) {
     } satisfies ActionData
   }
 
+  if (intent === 'reconcile-class') {
+    const auth = await requireAuth(args.request)
+    if (!isRoleAtLeast(auth.claims.role, 'staff')) {
+      return new Response('Unauthorized', { status: 403, headers: auth.headers })
+    }
+
+    const classId = String(formData.get('class_id') ?? '')
+    if (!classId) {
+      return { classRecoveryError: 'Missing class id.' } satisfies ActionData
+    }
+
+    const runId = `manual-reconcile-${Date.now().toString(36)}`
+    const result = await provisionClassById(classId, {
+      lockOwnerRunId: runId,
+      lockOwnerKind: 'class_reconcile',
+      auditContext: {
+        runId,
+        triggerSource: 'ui',
+        triggerKind: 'sync_button',
+        actorUserId: auth.user.id,
+        actorRole: auth.claims.role,
+      },
+    })
+
+    const classRecoveryResult = {
+      classId,
+      attendanceRowsEnsured: result.attendanceRowsEnsured,
+      meetingCreated: result.meetingCreated,
+      meetingRecreated: result.meetingRecreated,
+      registrantsCreated: result.registrantsCreated,
+      registrantsUpdated: result.registrantsUpdated,
+      registrantsRemoved: result.registrantsRemoved,
+      registrantsSkipped: result.registrantsSkipped,
+      registrantFailureCount: result.registrantFailures.length,
+      lockWaitMs: result.lockWaitMs,
+      skipped: Boolean(result.skipped),
+      skipReason: result.skipReason ?? null,
+      error: result.error ?? null,
+    }
+
+    if (result.error) {
+      return {
+        classRecoveryError: result.error,
+        classRecoveryResult,
+      } satisfies ActionData
+    }
+
+    if (result.skipped) {
+      return {
+        classRecoveryError: `Recovery skipped (${result.skipReason ?? 'unknown'}).`,
+        classRecoveryResult,
+      } satisfies ActionData
+    }
+
+    return {
+      classRecoverySuccess: `Class recovery completed for ${classId}.`,
+      classRecoveryResult,
+    } satisfies ActionData
+  }
+
   return baseAction(args)
 }
 
@@ -519,6 +702,12 @@ export default function ClassTablePage() {
           ) : null}
           {actionData?.classMeetingError ? (
             <p className="text-sm text-destructive">{actionData.classMeetingError}</p>
+          ) : null}
+          {actionData?.classRecoverySuccess ? (
+            <p className="text-sm text-emerald-700">{actionData.classRecoverySuccess}</p>
+          ) : null}
+          {actionData?.classRecoveryError ? (
+            <p className="text-sm text-destructive">{actionData.classRecoveryError}</p>
           ) : null}
         </div>
       }

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -177,6 +177,29 @@ type RegisterStudentActionResult = {
   error?: string
 }
 
+type ClassActionResult = {
+  classSyncSuccess?: string
+  classSyncError?: string
+  classMeetingSuccess?: string
+  classMeetingError?: string
+  classRecoverySuccess?: string
+  classRecoveryError?: string
+  classRecoveryResult?: {
+    classId: string
+    attendanceRowsEnsured: number
+    meetingCreated: boolean
+    meetingRecreated: boolean
+    registrantsCreated: number
+    registrantsUpdated: number
+    registrantsRemoved: number
+    registrantsSkipped: number
+    registrantFailureCount: number
+    skipped: boolean
+    skipReason: string | null
+    error: string | null
+  }
+}
+
 type RegisterStatusResponse = {
   state?: 'no_attempt' | 'attempt_found'
   message?: string
@@ -588,13 +611,8 @@ const personLinkForCell = (
     })
   }
   if (tableName === 'class' && column === 'step_registrants' && typeof row.id === 'string' && row.id) {
-    const workshopDescription = typeof row.workshop_description === 'string' ? row.workshop_description : ''
-    const startsAt = typeof row.starts_at === 'string' ? row.starts_at : ''
     return withReturnTo('/manage/class-zoom-registrant', {
       f_class_id: row.id,
-      ...(workshopDescription ? { f_workshop_description: workshopDescription } : {}),
-      ...(startsAt ? { f_class_starts_at: formatTimestamp(startsAt) } : {}),
-      ...(typeof row.ends_at === 'string' && row.ends_at ? { f_class_ends_at: formatTimestamp(row.ends_at) } : {}),
     })
   }
   if (tableName === 'class' && column === 'step_attendance_rows' && typeof row.id === 'string' && row.id) {
@@ -609,13 +627,9 @@ const personLinkForCell = (
     })
   }
   if (tableName === 'class' && column === 'step_reminder') {
-    const workshopDescription = typeof row.workshop_description === 'string' ? row.workshop_description : ''
-    const startsAt = typeof row.starts_at === 'string' ? row.starts_at : ''
-    const endsAt = typeof row.ends_at === 'string' ? row.ends_at : ''
+    const classId = typeof row.id === 'string' ? row.id : ''
     return withReturnTo('/manage/class-zoom-registrant', {
-      ...(workshopDescription ? { f_workshop_description: workshopDescription } : {}),
-      ...(startsAt ? { f_class_starts_at: formatTimestamp(startsAt) } : {}),
-      ...(endsAt ? { f_class_ends_at: formatTimestamp(endsAt) } : {}),
+      ...(classId ? { f_class_id: classId } : {}),
     })
   }
   if (tableName === 'class' && column === 'step_attendance') {
@@ -912,7 +926,9 @@ export default function TableDisplay({
   const [workshopEditGiftcardValue, setWorkshopEditGiftcardValue] = useState('')
   const [workshopEditStatusValue, setWorkshopEditStatusValue] = useState('')
   const [workshopEditRidingValue, setWorkshopEditRidingValue] = useState('')
+  const [classActionToast, setClassActionToast] = useState<{ tone: 'success' | 'error'; message: string } | null>(null)
   const isClassAttendance = tableName === 'class-attendance'
+  const isClassTable = tableName === 'class'
   const isWorkshopEnrollmentTable = tableName === 'class-enrollment'
   const supportsFamilyContextHover = isWorkshopEnrollmentTable || isClassAttendance
   const isFederalDistrictTable = tableName === 'federal-electoral-district'
@@ -2151,6 +2167,51 @@ export default function TableDisplay({
     }))
   }, [isClassAttendance, statusFetcher.data])
 
+  useEffect(() => {
+    if (!isClassTable) return
+    const result = statusFetcher.data as ClassActionResult | undefined
+    if (!result) return
+
+    if (result.classRecoveryResult) {
+      const recovery = result.classRecoveryResult
+      const meetingStep = recovery.meetingRecreated ? 'recreated' : recovery.meetingCreated ? 'created' : 'verified'
+      const recoveryMessage = [
+        `Class ${recovery.classId} recovery`,
+        `Meeting ${meetingStep}`,
+        `Attendance +${recovery.attendanceRowsEnsured}`,
+        `Registrants +${recovery.registrantsCreated}/~${recovery.registrantsUpdated}/-${recovery.registrantsRemoved}/=${recovery.registrantsSkipped}`,
+        `Failures ${recovery.registrantFailureCount}`,
+      ].join(' | ')
+
+      setClassActionToast({
+        tone: result.classRecoveryError || recovery.error || recovery.registrantFailureCount > 0 ? 'error' : 'success',
+        message: result.classRecoveryError ?? result.classRecoverySuccess ?? recoveryMessage,
+      })
+      return
+    }
+
+    if (result.classSyncError || result.classMeetingError) {
+      setClassActionToast({
+        tone: 'error',
+        message: result.classSyncError ?? result.classMeetingError ?? 'Class action failed.',
+      })
+      return
+    }
+
+    if (result.classSyncSuccess || result.classMeetingSuccess) {
+      setClassActionToast({
+        tone: 'success',
+        message: result.classSyncSuccess ?? result.classMeetingSuccess ?? 'Class action completed.',
+      })
+    }
+  }, [isClassTable, statusFetcher.data])
+
+  useEffect(() => {
+    if (!classActionToast) return
+    const timer = window.setTimeout(() => setClassActionToast(null), 5000)
+    return () => window.clearTimeout(timer)
+  }, [classActionToast])
+
   const tableWidth = useMemo(() => {
     const totalColumnWidth = columns.reduce(
       (sum, column) => sum + (columnWidths[column] ?? (columnMeta[column]?.numeric ? DEFAULT_NUMERIC_COLUMN_WIDTH : DEFAULT_COLUMN_WIDTH)),
@@ -2801,6 +2862,17 @@ export default function TableDisplay({
 
   return (
     <div className="-mx-6 flex min-w-0 flex-col gap-4">
+      {classActionToast ? (
+        <div
+          className={`fixed bottom-4 right-4 z-50 max-w-[min(92vw,44rem)] rounded border px-3 py-2 text-sm shadow-md ${
+            classActionToast.tone === 'success'
+              ? 'border-emerald-300 bg-emerald-50 text-emerald-800'
+              : 'border-destructive/40 bg-destructive/10 text-destructive'
+          }`}
+        >
+          {classActionToast.message}
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-start justify-between gap-3 px-6">
         <div>
           <h1 className="text-2xl font-semibold">{label}</h1>
@@ -3465,7 +3537,10 @@ export default function TableDisplay({
 
                       if (tableName === 'class' && column === 'sync_class') {
                         const classId = typeof row.id === 'string' ? row.id : ''
-                        const isBusy = statusFetcher.state === 'submitting'
+                        const isBusy =
+                          statusFetcher.state === 'submitting' &&
+                          statusFetcher.formData?.get('intent') === 'sync-class' &&
+                          statusFetcher.formData?.get('class_id') === classId
                         return (
                           <td key={`cell-${absoluteRowIndex}-${column}`} className="px-4 py-2" title="Run full sync for this class">
                             <button
@@ -3482,6 +3557,33 @@ export default function TableDisplay({
                               className="rounded border border-input px-2 py-1 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               {isBusy ? 'Syncing...' : 'Sync'}
+                            </button>
+                          </td>
+                        )
+                      }
+
+                      if (tableName === 'class' && column === 'recover_class') {
+                        const classId = typeof row.id === 'string' ? row.id : ''
+                        const isRecovering =
+                          statusFetcher.state === 'submitting' &&
+                          statusFetcher.formData?.get('intent') === 'reconcile-class' &&
+                          statusFetcher.formData?.get('class_id') === classId
+                        return (
+                          <td key={`cell-${absoluteRowIndex}-${column}`} className="px-4 py-2" title="Reconcile attendance and registrants for this class">
+                            <button
+                              type="button"
+                              disabled={!classId || isRecovering}
+                              onClick={event => {
+                                event.stopPropagation()
+                                if (!classId) return
+                                const formData = new FormData()
+                                formData.set('intent', 'reconcile-class')
+                                formData.set('class_id', classId)
+                                statusFetcher.submit(formData, { method: 'post' })
+                              }}
+                              className="rounded border border-input px-2 py-1 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {isRecovering ? 'Recovering...' : 'Recover'}
                             </button>
                           </td>
                         )


### PR DESCRIPTION
## What\n- add class-level recovery action and per-row Recover button in manage class\n- align class progress counts with valid registrant rows (requires registrant id + join url)\n- batch class loader queries to avoid max_rows truncation\n- fix class -> class-zoom-registrant links to apply reliable class filters\n- normalize unsupported derived filters/sorts in class-zoom-registrant loader and batch enrichment fetches\n\n## Validation\n- npm run typecheck (web)