### PR TITLE
Extend class photo upload window to 7 days

### DIFF
--- a/web/app/routes/home.class-photos.upload.ts
+++ b/web/app/routes/home.class-photos.upload.ts
@@ -7,6 +7,7 @@ import type { Route } from './+types/home.class-photos.upload'
 
 const PHOTO_BUCKET = 'class-attendance-photos'
 const PHOTO_UPLOAD_GRACE_MS = 15 * 60_000
+const PHOTO_UPLOAD_WINDOW_MS = 7 * 24 * 60 * 60_000
 const nowMs = () => Date.now()
 
 const sanitizeFileName = (input: string) => {
@@ -82,25 +83,7 @@ export async function action({ request }: Route.ActionArgs) {
     )
   }
 
-  const { data: workshopClassesRaw, error: workshopClassesError } = await adminClient
-    .from('class')
-    .select('id, ends_at')
-    .eq('workshop_id', classRow.workshop_id)
-    .order('ends_at', { ascending: false })
-
-  if (workshopClassesError) {
-    return Response.json(
-      { error: workshopClassesError.message },
-      { status: 500, headers: auth.headers }
-    )
-  }
-
-  const latestClosedClass = (workshopClassesRaw ?? []).find(row => {
-    const endsAtMs = new Date(row.ends_at).getTime()
-    return Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
-  })
-
-  if (!latestClosedClass || latestClosedClass.id !== classId) {
+  if (now > classEndMs + PHOTO_UPLOAD_GRACE_MS + PHOTO_UPLOAD_WINDOW_MS) {
     await adminClient
       .from('class_attendance')
       .update({ photo_status: 'expired' })
@@ -109,26 +92,9 @@ export async function action({ request }: Route.ActionArgs) {
       .is('photo_status', null)
 
     return Response.json(
-      { error: 'Photo upload is only available for the most recent closed class. This class upload window has expired.' },
+      { error: 'Photo upload is available for 7 days after class end. This class upload window has expired.' },
       { status: 409, headers: auth.headers }
     )
-  }
-
-  const staleClosedClassIds = (workshopClassesRaw ?? [])
-    .filter(row => row.id !== classId)
-    .filter(row => {
-      const endsAtMs = new Date(row.ends_at).getTime()
-      return Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
-    })
-    .map(row => row.id)
-
-  if (staleClosedClassIds.length) {
-    await adminClient
-      .from('class_attendance')
-      .update({ photo_status: 'expired' })
-      .in('class_id', staleClosedClassIds)
-      .eq('profile_id', profileId)
-      .is('photo_status', null)
   }
 
   const { data: attendanceRow, error: attendanceError } = await adminClient

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -117,6 +117,7 @@ const shouldLogHomeInstrumentation =
   process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
 
 const PHOTO_UPLOAD_GRACE_MS = 15 * 60_000
+const PHOTO_UPLOAD_WINDOW_MS = 7 * 24 * 60 * 60_000
 
 const sendInvite = async ({
   email,
@@ -429,8 +430,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     if (!selectedProfileIdByClass[classRow.id]) return acc
 
     const endsAtMs = new Date(classRow.ends_at).getTime()
-    const closed = Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
-    if (!closed) return acc
+    const withinUploadWindow =
+      Number.isFinite(endsAtMs) &&
+      now > endsAtMs + PHOTO_UPLOAD_GRACE_MS &&
+      now <= endsAtMs + PHOTO_UPLOAD_GRACE_MS + PHOTO_UPLOAD_WINDOW_MS
+    if (!withinUploadWindow) return acc
 
     const existingClassId = acc[classRow.workshop_id]
     if (!existingClassId) {
@@ -449,15 +453,15 @@ export async function loader({ request }: Route.LoaderArgs) {
   const selectedPhotoStatusByClassFinal = { ...selectedPhotoStatusByClass }
   const staleAttendancePairs = classes
     .map(classRow => {
-      if (!classRow.workshop_id) return null
       const selectedProfileId = selectedProfileIdByClass[classRow.id]
       if (!selectedProfileId) return null
 
-      const activeClassId = activePhotoUploadClassIdByWorkshop[classRow.workshop_id]
-      if (!activeClassId || activeClassId === classRow.id) return null
-
       const currentStatus = selectedPhotoStatusByClassFinal[classRow.id]
       if (currentStatus) return null
+
+      const endsAtMs = new Date(classRow.ends_at).getTime()
+      const expired = Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS + PHOTO_UPLOAD_WINDOW_MS
+      if (!expired) return null
 
       selectedPhotoStatusByClassFinal[classRow.id] = 'expired'
       return { classId: classRow.id, profileId: selectedProfileId }
@@ -1147,8 +1151,8 @@ export default function Home() {
     const now = Date.now()
     const endsAtMs = new Date(classRow.ends_at).getTime()
     const closed = Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS
+    const expired = Number.isFinite(endsAtMs) && now > endsAtMs + PHOTO_UPLOAD_GRACE_MS + PHOTO_UPLOAD_WINDOW_MS
     const selectedProfileId = selectedProfileIdByClass[classRow.id]
-    const activeClassId = classRow.workshop_id ? activePhotoUploadClassIdByWorkshop[classRow.workshop_id] : undefined
     const photoStatus =
       photoStatusOverrideByClass[classRow.id] ?? selectedPhotoStatusByClass[classRow.id] ?? ''
 
@@ -1172,7 +1176,7 @@ export default function Home() {
       )
     }
 
-    if (activeClassId && activeClassId !== classRow.id) {
+    if (expired) {
       return (
         <span className="inline-flex rounded-full border border-slate-300 bg-slate-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-700">
           expired


### PR DESCRIPTION
## What\n- switch class photo upload expiration from "latest closed class only" to a fixed window of 7 days after class end\n- keep the 15-minute post-class grace before uploads are allowed\n- align frontend status rendering and backend enforcement on the same expiry rule\n\n## Validation\n- npm run typecheck (web)