### PR TITLE
Expand meal-kit reminder window to 1pm Toronto

### DIFF
--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -139,6 +139,7 @@ const REMINDER_HOUR_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_HOUR_TORONT
 const REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('GIFT_CARD_REMINDER_MINUTE_TORONTO', isProductionRuntime ? 0 : 15)
 const MEAL_KIT_REMINDER_HOUR_TORONTO = parseHourMinuteEnv('MEAL_KIT_REMINDER_HOUR_TORONTO', 9)
 const MEAL_KIT_REMINDER_MINUTE_TORONTO = parseHourMinuteEnv('MEAL_KIT_REMINDER_MINUTE_TORONTO', 0)
+const MEAL_KIT_REMINDER_WINDOW_END_HOUR_TORONTO = parseHourMinuteEnv('MEAL_KIT_REMINDER_WINDOW_END_HOUR_TORONTO', 13)
 
 const torontoPartsForDate = (date: Date) => {
   const parts = torontoDateTimeFormatter.formatToParts(date)
@@ -199,11 +200,16 @@ const reminderSlotIsoForTorontoDate = (year: number, month: number, day: number)
 
 const currentTorontoMealKitReminderSlotIso = (now: Date) => {
   const toronto = torontoPartsForDate(now)
+
+  const isWithinMealKitWindow =
+    toronto.hour > MEAL_KIT_REMINDER_HOUR_TORONTO && toronto.hour < MEAL_KIT_REMINDER_WINDOW_END_HOUR_TORONTO
+
+  const isStartHourWithinWindow =
+    toronto.hour === MEAL_KIT_REMINDER_HOUR_TORONTO && toronto.minute >= MEAL_KIT_REMINDER_MINUTE_TORONTO
+
   if (
     toronto.weekday !== 'Tue' ||
-    toronto.hour !== MEAL_KIT_REMINDER_HOUR_TORONTO ||
-    toronto.minute < MEAL_KIT_REMINDER_MINUTE_TORONTO ||
-    toronto.minute >= MEAL_KIT_REMINDER_MINUTE_TORONTO + 5
+    (!isWithinMealKitWindow && !isStartHourWithinWindow)
   ) {
     return null
   }


### PR DESCRIPTION
## What
- expand Tuesday meal-kit reminder send window from a 5-minute slot to 9:00 AM through before 1:00 PM Toronto time
- add MEAL_KIT_REMINDER_WINDOW_END_HOUR_TORONTO env override (default 13)

## Why
- avoid same-day reminder misses when the 9:00 run is lock-contended

## Validation
- npm run typecheck (web)