### PR TITLE
Fix Toronto meal-kit reminder slot conversion

### DIFF
--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -155,7 +155,7 @@ const torontoPartsForDate = (date: Date) => {
 }
 
 const torontoTimeUtcForDate = (year: number, month: number, day: number, hour: number, minute: number) => {
-  for (const utcHour of [16, 17, 15, 18]) {
+  for (let utcHour = 0; utcHour < 24; utcHour += 1) {
     const candidate = new Date(Date.UTC(year, month - 1, day, utcHour, minute, 0, 0))
     const toronto = torontoPartsForDate(candidate)
     if (


### PR DESCRIPTION
## What
- fix Toronto-to-UTC slot resolution to search all UTC hours instead of a hardcoded subset
- this restores valid slot resolution for 9:00 AM Toronto (meal-kit reminder slot)

## Why
- meal-kit reminders were skipping because slot resolution returned null for 9:00 AM Toronto

## Validation
- npm run typecheck (web)
- spot-checked 2026-07-21 09:00 Toronto resolves to 2026-07-21T13:00:00Z