### PR TITLE
Improve class-attendance provider reliability

### DIFF
--- a/web/app/routes/manage/class-attendance-enrichment.server.ts
+++ b/web/app/routes/manage/class-attendance-enrichment.server.ts
@@ -291,9 +291,8 @@ const getClassAttendanceEnrichmentFoundation = async (normalizedProfileIds: stri
 }
 
 const loadGiftCardLane = async (
-  foundation: ClassAttendanceEnrichmentFoundation
+  normalizedProfileIds: string[]
 ): Promise<Record<string, Partial<ClassAttendanceEnrichment>>> => {
-  const { normalizedProfileIds } = foundation
   const workshopEnrichmentByProfileId = await loadWorkshopEnrollmentEnrichment(normalizedProfileIds)
 
   return normalizedProfileIds.reduce<Record<string, Partial<ClassAttendanceEnrichment>>>((acc, profileId) => {
@@ -455,7 +454,7 @@ export async function loadClassAttendanceEnrichment(
     (lane, index, array) => CLASS_ATTENDANCE_ENRICHMENT_LANES.includes(lane) && array.indexOf(lane) === index
   )
 
-  const needsFoundation = lanes.includes('giftcard') || lanes.includes('geo')
+  const needsFoundation = lanes.includes('geo')
   const foundationPromise = needsFoundation
     ? getClassAttendanceEnrichmentFoundation(normalizedProfileIds)
     : Promise.resolve(null)
@@ -463,9 +462,7 @@ export async function loadClassAttendanceEnrichment(
   const laneResults = await Promise.all(
     lanes.map(async lane => {
       if (lane === 'giftcard') {
-        const foundation = await foundationPromise
-        if (!foundation) return {} as Record<string, Partial<ClassAttendanceEnrichment>>
-        return loadGiftCardLane(foundation)
+        return loadGiftCardLane(normalizedProfileIds)
       }
       if (lane === 'geo') {
         const foundation = await foundationPromise

--- a/web/app/routes/manage/class-attendance-enrichment.server.ts
+++ b/web/app/routes/manage/class-attendance-enrichment.server.ts
@@ -443,9 +443,9 @@ const loadFamilyLane = async (
 export async function loadClassAttendanceEnrichment(
   profileIds: string[],
   options: ClassAttendanceEnrichmentOptions = {}
-) {
+): Promise<Record<string, Partial<ClassAttendanceEnrichment>>> {
   const normalizedProfileIds = normalizeProfileIds(profileIds)
-  const byProfileId: Record<string, ClassAttendanceEnrichment> = {}
+  const byProfileId: Record<string, Partial<ClassAttendanceEnrichment>> = {}
 
   if (!normalizedProfileIds.length) {
     return byProfileId
@@ -477,10 +477,19 @@ export async function loadClassAttendanceEnrichment(
   )
 
   for (const profileId of normalizedProfileIds) {
+    const laneScopedFallback: Partial<ClassAttendanceEnrichment> = {}
+    if (lanes.includes('giftcard')) {
+      laneScopedFallback.giftcard_display = 'N/A'
+    }
+    if (lanes.includes('geo')) {
+      laneScopedFallback.latest_geo = 'N/A'
+    }
+    if (lanes.includes('family')) {
+      Object.assign(laneScopedFallback, fallbackProfileHoverContext)
+    }
+
     byProfileId[profileId] = {
-      ...fallbackProfileHoverContext,
-      latest_geo: 'N/A',
-      giftcard_display: 'N/A',
+      ...laneScopedFallback,
     }
   }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -1942,26 +1942,11 @@ export default function TableDisplay({
         }
 
         if (shouldLoadClassAttendanceValues) {
-          const classAttendanceGiftcardSearch = new URLSearchParams(searchParams)
-          classAttendanceGiftcardSearch.append('lane', 'giftcard')
+          const classAttendanceSearch = new URLSearchParams(searchParams)
+          classAttendanceSearch.append('lane', 'giftcard')
+          classAttendanceSearch.append('lane', 'geo')
           pendingLaneRequests.push(
-            fetch(`/manage/class-attendance/enrichment?${classAttendanceGiftcardSearch.toString()}`, {
-              signal: abortController.signal,
-            })
-              .then(async response =>
-                response.ok
-                  ? ((await response.json()) as ClassAttendanceEnrichmentResponse)
-                  : ({ byProfileId: {} } as ClassAttendanceEnrichmentResponse)
-              )
-              .then(payload => {
-                mergeEnrichmentPayload(payload.byProfileId)
-              })
-          )
-
-          const classAttendanceGeoSearch = new URLSearchParams(searchParams)
-          classAttendanceGeoSearch.append('lane', 'geo')
-          pendingLaneRequests.push(
-            fetch(`/manage/class-attendance/enrichment?${classAttendanceGeoSearch.toString()}`, {
+            fetch(`/manage/class-attendance/enrichment?${classAttendanceSearch.toString()}`, {
               signal: abortController.signal,
             })
               .then(async response =>

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -1565,32 +1565,19 @@ export default function TableDisplay({
                 : Promise.resolve({ byProfileId: {} } as FamilyContextEnrichmentResponse),
             ])
 
-            const fallbackEnrichment: ProfileEnrichment = {
-              riding_display: 'Not looked up',
-              geo_locations_display: 'N/A',
-              giftcard_display: 'N/A',
-              prior_participation_display: 'N/A',
-              latest_geo: 'N/A',
-              profile_hover_top_discrepancy: '',
-              profile_hover_more_discrepancies: '',
-              profile_hover_name: '',
-              profile_hover_parent_name: '',
-              profile_hover_email: '',
-              profile_hover_student_phone: '',
-              profile_hover_parent_email: '',
-              profile_hover_parent_phone: '',
-              profile_hover_student_geo: '',
-              profile_hover_parent_geo: '',
-              profile_hover_student_submitted_address: '',
-              profile_hover_parent_address: '',
-            }
-
             requestProfileIds.forEach(profileId => {
+              const workshopEnrichment = workshopPayload?.byProfileId?.[profileId]
+              const classAttendanceEnrichment = classAttendancePayload?.byProfileId?.[profileId]
+              const familyEnrichment = familyPayload?.byProfileId?.[profileId]
+              if (!workshopEnrichment && !classAttendanceEnrichment && !familyEnrichment) {
+                return
+              }
+
               fetchedByProfileId[profileId] = {
-                ...fallbackEnrichment,
-                ...(workshopPayload?.byProfileId?.[profileId] ?? {}),
-                ...(classAttendancePayload?.byProfileId?.[profileId] ?? {}),
-                ...(familyPayload?.byProfileId?.[profileId] ?? {}),
+                ...(mergedEnrichmentByProfileId[profileId] ?? {}),
+                ...(workshopEnrichment ?? {}),
+                ...(classAttendanceEnrichment ?? {}),
+                ...(familyEnrichment ?? {}),
               }
             })
 
@@ -1912,26 +1899,6 @@ export default function TableDisplay({
     const abortController = new AbortController()
     void (async () => {
       const startedAt = Date.now()
-      const fallbackEnrichment: ProfileEnrichment = {
-        riding_display: 'Not looked up',
-        geo_locations_display: 'N/A',
-        giftcard_display: 'N/A',
-        prior_participation_display: 'N/A',
-        latest_geo: 'N/A',
-        profile_hover_top_discrepancy: '',
-        profile_hover_more_discrepancies: '',
-        profile_hover_name: '',
-        profile_hover_parent_name: '',
-        profile_hover_email: '',
-        profile_hover_student_phone: '',
-        profile_hover_parent_email: '',
-        profile_hover_parent_phone: '',
-        profile_hover_student_geo: '',
-        profile_hover_parent_geo: '',
-        profile_hover_student_submitted_address: '',
-        profile_hover_parent_address: '',
-      }
-
       const mergeEnrichmentPayload = (
         payloadByProfileId:
           | WorkshopEnrollmentEnrichmentResponse['byProfileId']
@@ -1941,10 +1908,11 @@ export default function TableDisplay({
         setEnrichmentByProfileId(prev => {
           const next = { ...prev }
           for (const profileId of requestProfileIds) {
+            const payload = payloadByProfileId?.[profileId]
+            if (!payload) continue
             next[profileId] = {
-              ...fallbackEnrichment,
               ...(next[profileId] ?? {}),
-              ...(payloadByProfileId?.[profileId] ?? {}),
+              ...payload,
             }
           }
           return next

--- a/web/app/routes/manage/team.tsx
+++ b/web/app/routes/manage/team.tsx
@@ -8,7 +8,7 @@ import { isRoleAtLeast } from '@/lib/roles'
 import { cn } from '@/lib/utils'
 
 import type { Route } from './+types/team'
-import { manageSections, overviewPage } from './nav'
+import { manageSections, overviewPage, teamPages } from './nav'
 
 const shouldLogManageTeamServerInstrumentation =
   process.env.NODE_ENV !== 'production' || process.env.VITE_ENABLE_ROUTER_INSTRUMENTATION === 'true'
@@ -43,6 +43,41 @@ const TEAM_ALLOWED_MANAGE_PREFIXES = Array.from(TEAM_ALLOWED_MANAGE_PATHS).filte
 const isTeamAllowedManagePath = (pathname: string) => {
   if (TEAM_ALLOWED_MANAGE_PATHS.has(pathname)) return true
   return TEAM_ALLOWED_MANAGE_PREFIXES.some(prefix => pathname.startsWith(`${prefix}/`))
+}
+
+const MANAGE_TITLE_SUFFIX = ' | Summer Lunch Plus'
+
+const toTitleCase = (value: string) =>
+  value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+const personSubpageTitleByPath: Record<string, string> = {
+  '/manage/person': 'Person',
+  '/manage/person/family': 'Person - Family',
+  '/manage/person/enrollments': 'Person - Enrollments',
+  '/manage/person/form-submissions': 'Person - Form Submissions',
+  '/manage/person/activity': 'Person - Activity and IP Logs',
+  '/manage/person/attendance': 'Person - Attendance',
+  '/manage/person/discrepancies': 'Person - Discrepancies',
+}
+
+const resolveManagePageTitle = (pathname: string) => {
+  if (personSubpageTitleByPath[pathname]) {
+    return personSubpageTitleByPath[pathname]
+  }
+
+  const bestMatch = teamPages
+    .filter(item => pathname === item.to || pathname.startsWith(`${item.to}/`))
+    .sort((left, right) => right.to.length - left.to.length)[0]
+
+  if (bestMatch) {
+    return toTitleCase(bestMatch.label)
+  }
+
+  return 'Manage'
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -167,6 +202,11 @@ export default function TeamLayout() {
       navFromRef.current = ''
     }
   }, [location.pathname, location.search, navigation.location, navigation.state])
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    document.title = `${resolveManagePageTitle(location.pathname)}${MANAGE_TITLE_SUFFIX}`
+  }, [location.pathname])
 
   const logSidebarNavClick = (target: string) => {
     logManageTeamClientEvent('sidebar_nav_click', {


### PR DESCRIPTION
## What\n- avoid freezing fallback enrichment values when class-attendance enrichment payload is empty\n- set manage page browser titles from route/nav context\n- scope class-attendance enrichment defaults by requested lane to prevent lane overwrite\n- speed up class-attendance provider enrichment by removing unnecessary foundation work for giftcard lane\n- combine class-attendance enrichment requests for giftcard + geo into a single request\n\n## Verification\n- npm run typecheck (web)