### PR TITLE
Fix stale class-attendance gift-card allocation state

### DIFF
--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -415,20 +415,29 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   for (const chunk of chunkArray(classIds, IN_CLAUSE_BATCH_SIZE)) {
-    const { data, error } = await adminClient
-      .from('gift_card_allocation')
-      .select('id, class_id, profile_id, gift_card_asset_id, status, blocked, blocked_reason, reminder_sent_at, first_opened_at, last_opened_at, open_count, metadata')
-      .in('class_id', chunk)
+    for (let offset = 0; ; offset += RELATED_FETCH_BATCH_SIZE) {
+      const { data, error } = await adminClient
+        .from('gift_card_allocation')
+        .select('id, class_id, profile_id, gift_card_asset_id, status, blocked, blocked_reason, reminder_sent_at, first_opened_at, last_opened_at, open_count, metadata')
+        .in('class_id', chunk)
+        .order('class_id', { ascending: true })
+        .order('profile_id', { ascending: true })
+        .range(offset, offset + RELATED_FETCH_BATCH_SIZE - 1)
 
-    if (error) {
-      if (isSchemaMismatchError(error)) {
-        giftCardSchemaAvailable = false
-        break
+      if (error) {
+        if (isSchemaMismatchError(error)) {
+          giftCardSchemaAvailable = false
+          break
+        }
+        throw new Response(error.message, { status: 500 })
       }
-      throw new Response(error.message, { status: 500 })
+
+      const rows = (data ?? []) as GiftCardAllocationRow[]
+      allocationRowsRaw.push(...rows)
+      if (rows.length < RELATED_FETCH_BATCH_SIZE) break
     }
 
-    allocationRowsRaw.push(...((data ?? []) as GiftCardAllocationRow[]))
+    if (!giftCardSchemaAvailable) break
   }
   profile.mark('fetch_class_related_records', {
     classIds: classIds.length,
@@ -1471,7 +1480,7 @@ export async function action({ request }: Route.ActionArgs) {
         class_id: classId,
         profile_id: profileId,
         already_allocated: true,
-        message: 'Gift card already allocated for this class/profile.',
+        message: 'Gift card already allocated for this class/profile (possibly allocated in another session).',
       }
     }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import { createPortal } from 'react-dom'
-import { Link, useFetcher, useLoaderData, useLocation, useSearchParams } from 'react-router'
+import { Link, useFetcher, useLoaderData, useLocation, useRevalidator, useSearchParams } from 'react-router'
 import { Filter, Plus } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -919,6 +919,7 @@ export default function TableDisplay({
     tableName === 'federal-electoral-district' ||
     tableName === 'gift-cards'
   const location = useLocation()
+  const revalidator = useRevalidator()
 
   const statusFetcher = useFetcher()
   const editorFetcher = useFetcher<{ error?: string; success?: boolean }>()
@@ -2324,11 +2325,13 @@ export default function TableDisplay({
     const key = `${result.class_id}::${result.profile_id}`
     if (!key) return
 
+    revalidator.revalidate()
+
     if (result.ok) {
       const successMessage =
         result.message ??
         (result.already_allocated
-          ? 'Gift card already allocated for this class/profile.'
+          ? 'Gift card already allocated for this class/profile (possibly allocated in another session).'
           : result.gift_card_provider
             ? `Gift card allocated (${result.gift_card_provider}).`
             : 'Gift card allocated.')
@@ -2343,7 +2346,7 @@ export default function TableDisplay({
       ...prev,
       [key]: { type: 'error', message: result.error ?? result.message ?? 'Gift card allocation failed.' },
     }))
-  }, [isClassAttendance, statusFetcher.data])
+  }, [isClassAttendance, revalidator, statusFetcher.data])
 
   useEffect(() => {
     if (!isClassTable) return


### PR DESCRIPTION
## What\n- paginate class-attendance loader reads for gift_card_allocation to avoid row-cap misses\n- revalidate class-attendance table after allocate action so row state refreshes immediately\n- clarify already-allocated message for concurrent/session-lag cases\n\n## Validation\n- npm run typecheck (web)