### PR TITLE
Speed up gift-card provider filter options

### DIFF
--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -248,6 +248,7 @@ const FILTER_CACHE_MAX_ENTRIES = 40
 const FILTER_CACHE_TTL_MS = 5 * 60 * 1000
 const FILTER_OPTION_MAX_VISIBLE_LIST = 1500
 const FILTER_EMPTY_LABEL = '(empty)'
+const GIFT_CARD_FILTER_FAST_OPTIONS = ['N/A', '...', 'PC', 'Sobeys', 'Meal Kit'] as const
 const ENABLE_PERSISTED_COLUMN_WIDTHS = false
 const WORKSHOP_ENRICHMENT_BATCH_SIZE = 40
 const WORKSHOP_ENRICHMENT_FILTER_BOOTSTRAP_BATCH_SIZE = 200
@@ -1005,6 +1006,17 @@ export default function TableDisplay({
         option => option && typeof option.value === 'string' && typeof option.label === 'string'
       )
     : []
+  const fastGiftCardFilterOptions = useMemo(() => {
+    const base: string[] = [...GIFT_CARD_FILTER_FAST_OPTIONS]
+    for (const option of giftCardOptions) {
+      const trimmed = option.trim()
+      if (!trimmed) continue
+      if (!base.includes(trimmed)) {
+        base.push(trimmed)
+      }
+    }
+    return sortFilterOptions(base)
+  }, [giftCardOptions])
   const debugPerf = searchParams.get('debugPerf') === '1'
   const timezoneOptions = useMemo(() => {
     const supported =
@@ -1426,6 +1438,21 @@ export default function TableDisplay({
       return
     }
 
+    if (
+      openFilterColumn === 'giftcard_display' &&
+      (tableName === 'class-enrollment' || tableName === 'class-attendance')
+    ) {
+      const loadedEntry: FilterOptionsCacheEntry = {
+        status: 'loaded',
+        allOptions: fastGiftCardFilterOptions,
+        totalCount: fastGiftCardFilterOptions.length,
+        updatedAt: Date.now(),
+      }
+      writeFilterCache(openFilterCacheKey, loadedEntry)
+      setOpenFilterCacheEntry(loadedEntry)
+      return
+    }
+
     const cached = readFilterCache(openFilterCacheKey)
     if (cached) {
       setOpenFilterCacheEntry(cached)
@@ -1668,6 +1695,7 @@ export default function TableDisplay({
     isWorkshopEnrollmentTable,
     openFilterCacheKey,
     openFilterColumn,
+    fastGiftCardFilterOptions,
     rowsWithEnrichment,
     serverSideQuery,
     tableName,

--- a/web/app/routes/manage/table-filter-options.ts
+++ b/web/app/routes/manage/table-filter-options.ts
@@ -32,6 +32,7 @@ const CLASS_ENROLLMENT_FAMILY_CONTEXT_COLUMNS = new Set([
   'profile_hover_student_submitted_address',
   'profile_hover_parent_address',
 ])
+const GIFT_CARD_FILTER_FAST_OPTIONS = ['N/A', '...', 'PC', 'Sobeys', 'Meal Kit'] as const
 
 const parseTopLevelSelectColumns = (select: string) => {
   const columns: string[] = []
@@ -240,6 +241,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
 
   const { supabase, headers } = createClient(request)
+
+  if (
+    column === 'giftcard_display' &&
+    (tableName === 'class-enrollment' || tableName === 'class-attendance')
+  ) {
+    const allOptions = sortFilterOptions([...GIFT_CARD_FILTER_FAST_OPTIONS])
+    return Response.json(
+      {
+        status: 'loaded',
+        allOptions,
+        totalCount: allOptions.length,
+      },
+      { headers }
+    )
+  }
+
   const selectableColumns = new Set(parseTopLevelSelectColumns(definition.select))
   const parsedFilters = parseFilterClausesFromSearchParams(url.searchParams, definition.columns)
 


### PR DESCRIPTION
## What
- add a fast-path gift-card provider option list for giftcard_display in class enrollment and class attendance
- avoid enrichment/full-scan filter option loading for this bounded field
- add matching server-side fast-path in table-filter-options route

## Validation
- npm run typecheck (web)