### PR TITLE
Use configured giftcard provider filter values

### DIFF
--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -5,6 +5,10 @@ import { Constants, type Database } from '@/lib/database.types'
 import { EXPORT_TYPE_CLASS_ATTENDANCE_CSV } from '@/lib/exports/types'
 import { createLoaderProfile } from '@/lib/loader-profile.server'
 import {
+  GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE,
+  loadEditableQuestionOptions,
+} from '@/lib/admin-form-answers.server'
+import {
   eligibleAfterIso,
   isEligibilityTimingEnabled,
   nextReleaseAtIso,
@@ -210,6 +214,12 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   const url = new URL(request.url)
   const deferTable = url.searchParams.get('_deferTable') === '1'
+  let giftCardOptions: string[] = []
+  try {
+    giftCardOptions = await loadEditableQuestionOptions(GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
+  } catch (error) {
+    console.error('[class attendance] unable to load gift card question options', error)
+  }
   if (shouldLogClassAttendanceInstrumentation) {
     console.info('[manage-class-attendance-loader]', {
       event: 'start',
@@ -265,6 +275,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         giftcard_display: { label: 'Provider', filterable: true, truncate: true },
       },
       canEditStatus: isRoleAtLeast(auth.claims.role, 'staff'),
+      giftCardOptions,
     }
     profile.complete({
       deferredShell: true,
@@ -1008,6 +1019,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       state_action: { label: 'State action', filterable: false },
     },
     canEditStatus: isRoleAtLeast(auth.claims.role, 'staff'),
+    giftCardOptions,
   }
 }
 

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -248,7 +248,8 @@ const FILTER_CACHE_MAX_ENTRIES = 40
 const FILTER_CACHE_TTL_MS = 5 * 60 * 1000
 const FILTER_OPTION_MAX_VISIBLE_LIST = 1500
 const FILTER_EMPTY_LABEL = '(empty)'
-const GIFT_CARD_FILTER_FAST_OPTIONS = ['N/A', '...', 'PC', 'Sobeys', 'Meal Kit'] as const
+const GIFT_CARD_FILTER_BASE_OPTIONS = ['N/A', '...', 'Meal Kit'] as const
+const GIFT_CARD_FILTER_PROVIDER_FALLBACK_OPTIONS = ['PC', 'Sobeys'] as const
 const ENABLE_PERSISTED_COLUMN_WIDTHS = false
 const WORKSHOP_ENRICHMENT_BATCH_SIZE = 40
 const WORKSHOP_ENRICHMENT_FILTER_BOOTSTRAP_BATCH_SIZE = 200
@@ -1007,15 +1008,22 @@ export default function TableDisplay({
       )
     : []
   const fastGiftCardFilterOptions = useMemo(() => {
-    const base: string[] = [...GIFT_CARD_FILTER_FAST_OPTIONS]
-    for (const option of giftCardOptions) {
-      const trimmed = option.trim()
-      if (!trimmed) continue
-      if (!base.includes(trimmed)) {
-        base.push(trimmed)
+    const base = new Set<string>(GIFT_CARD_FILTER_BASE_OPTIONS)
+    const normalizedQuestionOptions = giftCardOptions
+      .map(option => option.trim())
+      .filter(option => Boolean(option))
+
+    if (normalizedQuestionOptions.length > 0) {
+      for (const option of normalizedQuestionOptions) {
+        base.add(option)
+      }
+    } else {
+      for (const fallbackOption of GIFT_CARD_FILTER_PROVIDER_FALLBACK_OPTIONS) {
+        base.add(fallbackOption)
       }
     }
-    return sortFilterOptions(base)
+
+    return sortFilterOptions(Array.from(base))
   }, [giftCardOptions])
   const debugPerf = searchParams.get('debugPerf') === '1'
   const timezoneOptions = useMemo(() => {

--- a/web/app/routes/manage/table-filter-options.ts
+++ b/web/app/routes/manage/table-filter-options.ts
@@ -1,6 +1,10 @@
 import { createClient } from '@/lib/supabase/server'
 import { loadFamilyContextByProfileIds } from '@/lib/family-context.server'
 import {
+  GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE,
+  loadEditableQuestionOptions,
+} from '@/lib/admin-form-answers.server'
+import {
   matchesFilterClause,
   parseFilterClausesFromSearchParams,
   type FilterClause,
@@ -32,7 +36,8 @@ const CLASS_ENROLLMENT_FAMILY_CONTEXT_COLUMNS = new Set([
   'profile_hover_student_submitted_address',
   'profile_hover_parent_address',
 ])
-const GIFT_CARD_FILTER_FAST_OPTIONS = ['N/A', '...', 'PC', 'Sobeys', 'Meal Kit'] as const
+const GIFT_CARD_FILTER_BASE_OPTIONS = ['N/A', '...', 'Meal Kit'] as const
+const GIFT_CARD_FILTER_PROVIDER_FALLBACK_OPTIONS = ['PC', 'Sobeys'] as const
 
 const parseTopLevelSelectColumns = (select: string) => {
   const columns: string[] = []
@@ -246,7 +251,26 @@ export async function loader({ request }: LoaderFunctionArgs) {
     column === 'giftcard_display' &&
     (tableName === 'class-enrollment' || tableName === 'class-attendance')
   ) {
-    const allOptions = sortFilterOptions([...GIFT_CARD_FILTER_FAST_OPTIONS])
+    let configuredOptions: string[] = []
+    try {
+      configuredOptions = await loadEditableQuestionOptions(GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
+    } catch (error) {
+      console.error('[table-filter-options] failed to load gift card question options', error)
+    }
+
+    const optionSet = new Set<string>(GIFT_CARD_FILTER_BASE_OPTIONS)
+    const normalizedConfiguredOptions = configuredOptions.map(option => option.trim()).filter(Boolean)
+    if (normalizedConfiguredOptions.length > 0) {
+      for (const option of normalizedConfiguredOptions) {
+        optionSet.add(option)
+      }
+    } else {
+      for (const fallbackOption of GIFT_CARD_FILTER_PROVIDER_FALLBACK_OPTIONS) {
+        optionSet.add(fallbackOption)
+      }
+    }
+
+    const allOptions = sortFilterOptions(Array.from(optionSet))
     return Response.json(
       {
         status: 'loaded',

--- a/web/app/routes/manage/workshop-enrollment.tsx
+++ b/web/app/routes/manage/workshop-enrollment.tsx
@@ -75,6 +75,16 @@ export async function loader(args: Route.LoaderArgs) {
     deferTable,
   })
 
+  let giftCardOptions: string[] = []
+  try {
+    giftCardOptions = await loadEditableQuestionOptions(GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
+  } catch (error) {
+    console.error('[workshop enrollment] unable to load gift card question options', error)
+  }
+  profile.mark('load_gift_card_options', {
+    optionCount: giftCardOptions.length,
+  })
+
   if (!deferTable) {
     const auth = await requireAuth(args.request)
     const shell = {
@@ -102,6 +112,7 @@ export async function loader(args: Route.LoaderArgs) {
         prior_participation_display: { label: 'been before?', filterable: true },
       },
       canEditStatus: isRoleAtLeast(auth.claims.role, 'staff'),
+      giftCardOptions,
     }
 
     profile.complete({
@@ -128,16 +139,7 @@ export async function loader(args: Route.LoaderArgs) {
     totalRows: base.totalRows ?? base.rows.length,
   })
 
-  let giftCardOptions: string[] = []
   let federalDistrictOptions: Array<{ value: string; label: string }> = []
-  try {
-    giftCardOptions = await loadEditableQuestionOptions(GIFT_CARD_STORE_PREFERENCE_QUESTION_CODE)
-  } catch (error) {
-    console.error('[workshop enrollment] unable to load gift card question options', error)
-  }
-  profile.mark('load_gift_card_options', {
-    optionCount: giftCardOptions.length,
-  })
 
   try {
     const { data, error } = await adminClient


### PR DESCRIPTION
## What
- source fast-path giftcard_display filter options from configured gift_card_store_preference question options
- keep only stable base placeholders (N/A, ..., Meal Kit) hardcoded
- use provider fallback (PC, Sobeys) only when no configured options exist
- expose gift card options on non-deferred workshop-enrollment and class-attendance shells so client fast-path has immediate source-of-truth values

## Validation
- npm run typecheck (web)