### PR TITLE
Fix federal district metrics and table controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,35 @@
 # AGENTS.md
 
 ## Scope
-- Treat `repo/` as the working root. Main services: `web/` (React Router SSR app), `scheduler/` (cron runner), `zoom-api/` (FastAPI service).
-- Run commands from each service directory unless a command explicitly targets repo root.
-- Root `package.json` has no scripts (dependency-only), so do not run `npm run ...` at repo root.
+- Use `repo/` as the working root. Its deployable services are `web/` (React Router SSR), `scheduler/` (Docker cron runner), and `zoom-api/` (FastAPI).
+- Run service commands from that service directory. The root `package.json` is dependency-only and defines no scripts.
 
-## High-value command map
-- `web/`: `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, `npm run test`.
-- `scheduler/`: `make cron`, `make cron-bg`, `make logs`, `make down`, `make smoke-all`.
-- `zoom-api/`: `make setup`, `make dev`, `make test`.
-- CI (`.github/workflows/tests.yml`) runs only `web` Playwright tests (Node 22) and starts local Supabase first.
+## Web (`web/`)
+- Use `npm ci`, `npm run dev`, `npm run typecheck`, `npm run build && npm run start`, and `npm run test`; there is no lint script.
+- Routes are manual: register each new `app/routes` file in `app/routes.ts`, then run `npm run typecheck` to regenerate React Router types.
+- `createClient(request)` returns response cookie headers. Pass `headers` to redirects and responses so Supabase session changes persist.
+- Add staff-visible `/manage/*` pages to `TEAM_ALLOWED_MANAGE_PATHS` in `app/routes/manage/team.tsx`; route registration alone does not grant team access.
+- `ONBOARDING_MODE` is `role` unless its value is exactly `permission`.
+- Tests use Playwright only. Run one spec with `npm run test -- tests/e2e/<file>.spec.ts` or `tests/unit/<file>.spec.ts`; `test:e2e` and `test:unit` only target their directories.
+- Without `PLAYWRIGHT_BASE_URL`, Playwright starts `npm run dev -- --port 5173`. Admin setup specs skip without `SUPABASE_URL` and `SUPABASE_SECRET_KEY`.
+- Do not edit generated `build/**` or `.react-router/types/**`.
 
-## Web app (`web/`)
-- There is no lint script in `web/package.json`; do not invent `npm run lint`.
-- Routing is manual: adding a route file is not enough; register it in `web/app/routes.ts` or you will ship a 404.
-- After route edits, run `npm run typecheck` (it runs `react-router typegen` and refreshes `web/.react-router/types`).
-- Keep auth headers on redirects/responses: `createClient(request)` returns `{ supabase, headers }` and redirects should pass `headers`.
-- Staff-visible `/manage/*` access is enforced by `TEAM_ALLOWED_MANAGE_PATHS` in `web/app/routes/manage/team.tsx`.
-- `ONBOARDING_MODE` is role mode unless the value is exactly `permission`.
-
-## Web tests (Playwright only)
-- `npm run test` uses Playwright (`web/tests`); no Vitest/Jest setup exists.
-- Run one spec with `npm run test -- tests/e2e/<file>.spec.ts` (or `tests/unit/<file>.spec.ts`).
-- `test:e2e` and `test:unit` are directory shortcuts, not single-file wrappers.
-- If `PLAYWRIGHT_BASE_URL` is unset, Playwright auto-starts `npm run dev -- --port 5173`.
-- Some admin-oriented specs intentionally skip unless `SUPABASE_URL` and `SUPABASE_SECRET_KEY` are set.
-
-## Supabase workflow
-- Follow repo convention from `CODE_STANDARDS.md`: edit `supabase/schemas/*.sql`; do not hand-edit existing `supabase/migrations/*.sql`.
-- Schema change order (repo root): edit schema -> `supabase db diff -f <name>` -> `supabase migration up`.
-- Regenerate DB types after schema edits:
+## Supabase
+- Change declarative SQL in `supabase/schemas/`, not existing `supabase/migrations/`. From the repo root: `supabase db diff -f <name>`, then `supabase migration up`; commit the schema and generated migration together.
+- Schema changes require regenerated `web/app/lib/database.types.ts`:
   `supabase gen types typescript --project-ref "$(cat supabase/.temp/project-ref)" --schema public > web/app/lib/database.types.ts`
-- Local seed mode in `supabase/config.toml` uses sanitized prod snapshot + app-data bootstrap (`./seeds/prod-data/active/*-sanitized.sql`, `./seeds/app-data/*.sql`).
-- API row cap is `api.max_rows = 1000`; large reads must batch/paginate.
+- New user-facing tables need RLS and policies. New app permissions must be mapped in `role_permission` for at least admin and manager, or RLS will deny them.
+- Local seeds use the sanitized production snapshot and app bootstrap (`supabase/config.toml`); the API caps responses at 1,000 rows, so batch large reads.
 
 ## Scheduler (`scheduler/`)
-- Schedule source of truth is `scheduler/crontab` (deployed via `scheduler/railway.toml`).
-- `make` targets require `scheduler/.env.local`; at minimum set `APP_BASE_URL` and `INTERNAL_RUNNER_SECRET`.
-- Cron-to-web auth uses `x-internal-runner-secret`; its value must match `web`'s `INTERNAL_RUNNER_SECRET`.
+- `crontab` is the schedule source of truth and Railway runs it through `railway.toml`.
+- Copy `.env.template` to `.env.local` before `make cron`, `make cron-bg`, or `make smoke-all`; set `APP_BASE_URL` and `INTERNAL_RUNNER_SECRET`.
+- Cron calls use `x-internal-runner-secret`; it must equal the web service's `INTERNAL_RUNNER_SECRET`.
 
 ## Zoom API (`zoom-api/`)
-- Read `zoom-api/CLAUDE.md` before changing this service.
-- `make setup` installs runtime deps only (`requirements.txt`), not pytest/dev tooling.
-- Keep auth implemented via FastAPI `HTTPBearer` in `zoom-api/app/auth.py`; `zoom-api/tests/test_main.py::test_openapi_declares_security_scheme` guards this.
+- Read and follow `zoom-api/CLAUDE.md` before changing this service.
+- `make setup` installs only `requirements.txt`; install `requirements-dev.txt` before `make test` on a fresh environment.
+- Keep API-key auth on FastAPI `HTTPBearer` in `app/auth.py`; `tests/test_main.py::test_openapi_declares_security_scheme` protects the OpenAPI security scheme.
 
-## Generated artifacts
-- Do not edit generated outputs directly: `web/build/**` and `web/.react-router/types/**`.
+## CI
+- `.github/workflows/tests.yml` runs only web Playwright tests on Node 22 after starting local Supabase; it does not run a separate lint or typecheck job.

--- a/web/app/lib/exports/federal-electoral-district-snapshot.server.ts
+++ b/web/app/lib/exports/federal-electoral-district-snapshot.server.ts
@@ -1,17 +1,17 @@
-import { loader as federalElectoralDistrictEnrichmentLoader } from '@/routes/manage/federal-electoral-district.enrichment'
+import { action as federalElectoralDistrictEnrichmentAction } from '@/routes/manage/federal-electoral-district.enrichment'
 import { loader as federalElectoralDistrictLoader } from '@/routes/manage/federal-electoral-district'
 
 import { parseFiltersFromSearchParams } from './table-filtering.server'
 import { EXPORT_MAX_ROWS } from './types'
 
 const EXPORT_PAGE_SIZE = 1500
-const ENRICHMENT_RIDING_BATCH_SIZE = 30
 const EXPORT_COLUMNS = [
   'code',
   'name',
   'whitelist',
   'meal_kit',
   'total',
+  'families',
   'accepted',
   'pending',
   'waitlisted',
@@ -25,6 +25,7 @@ const EXPORT_COLUMNS = [
 
 type DistrictCounts = {
   total: number
+  families: number
   accepted: number
   pending: number
   waitlisted: number
@@ -43,15 +44,6 @@ const buildPagedRequest = ({ request, page }: { request: Request; page: number }
   return new Request(url.toString(), request)
 }
 
-const chunkArray = <T,>(items: T[], size: number) => {
-  if (!items.length || size <= 0) return [] as T[][]
-  const chunks: T[][] = []
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size))
-  }
-  return chunks
-}
-
 const loadCountsByRiding = async ({
   request,
   ridingNames,
@@ -63,32 +55,27 @@ const loadCountsByRiding = async ({
     return {} as Record<string, DistrictCounts>
   }
 
-  const byRiding: Record<string, DistrictCounts> = {}
-  for (const ridingChunk of chunkArray(ridingNames, ENRICHMENT_RIDING_BATCH_SIZE)) {
-    const url = new URL('/manage/federal-electoral-district/enrichment', request.url)
-    for (const ridingName of ridingChunk) {
-      url.searchParams.append('riding', ridingName)
-    }
+  const enrichmentRequest = new Request(new URL('/manage/federal-electoral-district/enrichment', request.url), {
+    method: 'POST',
+    headers: request.headers,
+    body: JSON.stringify({
+      ridings: ridingNames,
+      enrollmentStatuses: new URL(request.url).searchParams.getAll('enrollmentStatus'),
+    }),
+  })
+  const enrichmentResponse = await federalElectoralDistrictEnrichmentAction({
+    request: enrichmentRequest,
+  } as Parameters<typeof federalElectoralDistrictEnrichmentAction>[0])
 
-    const enrichmentRequest = new Request(url.toString(), {
-      method: 'GET',
-      headers: request.headers,
-    })
-    const enrichmentResponse = await federalElectoralDistrictEnrichmentLoader({
-      request: enrichmentRequest,
-    } as Parameters<typeof federalElectoralDistrictEnrichmentLoader>[0])
-
-    if (!(enrichmentResponse instanceof Response) || !enrichmentResponse.ok) {
-      return {} as Record<string, DistrictCounts>
-    }
-
-    const payload = (await enrichmentResponse.json()) as {
-      byRiding?: Record<string, DistrictCounts>
-    }
-    Object.assign(byRiding, payload.byRiding ?? {})
+  if (!(enrichmentResponse instanceof Response) || !enrichmentResponse.ok) {
+    const errorText = enrichmentResponse instanceof Response ? await enrichmentResponse.text() : 'Unknown enrichment failure.'
+    throw new Error(`Federal district enrichment failed: ${errorText}`)
   }
 
-  return byRiding
+  const payload = (await enrichmentResponse.json()) as {
+    byRiding?: Record<string, DistrictCounts>
+  }
+  return payload.byRiding ?? {}
 }
 
 export const buildFederalElectoralDistrictSnapshot = async ({ request }: { request: Request }) => {
@@ -129,6 +116,7 @@ export const buildFederalElectoralDistrictSnapshot = async ({ request }: { reque
     const name = typeof row.name === 'string' ? row.name : ''
     const counts = countsByRiding[name] ?? {
       total: 0,
+      families: 0,
       accepted: 0,
       pending: 0,
       waitlisted: 0,
@@ -145,6 +133,7 @@ export const buildFederalElectoralDistrictSnapshot = async ({ request }: { reque
       whitelist: row.whitelist,
       meal_kit: row.meal_kit,
       total: counts.total,
+      families: counts.families,
       accepted: counts.accepted,
       pending: counts.pending,
       waitlisted: counts.waitlisted,

--- a/web/app/routes/manage/federal-electoral-district.enrichment.ts
+++ b/web/app/routes/manage/federal-electoral-district.enrichment.ts
@@ -39,6 +39,14 @@ const HOUSEHOLD_TOTAL_PEOPLE_QUESTION_CODE = 'household_total_people'
 const HOUSEHOLD_TOTAL_CHILDREN_QUESTION_CODE = 'household_total_children'
 const MAX_REASONABLE_HOUSEHOLD_PEOPLE = 30
 const MAX_REASONABLE_HOUSEHOLD_CHILDREN = 30
+const ENROLLMENT_PAGE_SIZE = 1000
+const ENROLLMENT_STATUSES = new Set<Database['public']['Enums']['workshop_enrollment_status']>([
+  'pending',
+  'waitlisted',
+  'approved',
+  'rejected',
+  'revoked',
+])
 
 const statusBucketFor = (status: Database['public']['Enums']['workshop_enrollment_status']) => {
   if (status === 'approved') return 'accepted'
@@ -138,7 +146,7 @@ const firstRidingFromLinks = (
   return null
 }
 
-export async function loader({ request }: { request: Request }) {
+async function loadFederalElectoralDistrictEnrichment(request: Request) {
   const auth = await requireAuth(request)
   const { supabase } = createClient(request)
   if (!isRoleAtLeast(auth.claims.role, 'staff')) {
@@ -146,13 +154,22 @@ export async function loader({ request }: { request: Request }) {
   }
 
   const url = new URL(request.url)
+  let requestedRidings: unknown[] = url.searchParams.getAll('riding')
+  let requestedStatusValues: unknown[] = url.searchParams.getAll('enrollmentStatus')
+
+  if (request.method === 'POST') {
+    let payload: { ridings?: unknown; enrollmentStatuses?: unknown }
+    try {
+      payload = (await request.json()) as { ridings?: unknown; enrollmentStatuses?: unknown }
+    } catch {
+      return Response.json({ error: 'Invalid enrichment request body.' }, { status: 400, headers: auth.headers })
+    }
+    requestedRidings = Array.isArray(payload.ridings) ? payload.ridings : []
+    requestedStatusValues = Array.isArray(payload.enrollmentStatuses) ? payload.enrollmentStatuses : []
+  }
+
   const ridingNames = Array.from(
-    new Set(
-      url.searchParams
-        .getAll('riding')
-        .map(value => value.trim())
-        .filter(Boolean)
-    )
+    new Set(requestedRidings.filter((value): value is string => typeof value === 'string').map(value => value.trim()).filter(Boolean))
   )
 
   if (!ridingNames.length) {
@@ -161,6 +178,7 @@ export async function loader({ request }: { request: Request }) {
 
   const byRiding = ridingNames.reduce<Record<string, {
     total: number
+    families: number
     accepted: number
     pending: number
     waitlisted: number
@@ -174,6 +192,7 @@ export async function loader({ request }: { request: Request }) {
     (acc, riding) => {
       acc[riding] = {
         total: 0,
+        families: 0,
         accepted: 0,
         pending: 0,
         waitlisted: 0,
@@ -193,14 +212,21 @@ export async function loader({ request }: { request: Request }) {
     ridingNames.map(riding => [canonicalRiding(riding), riding])
   )
 
+  const invalidStatuses = requestedStatusValues.some(
+    value => typeof value !== 'string' || !ENROLLMENT_STATUSES.has(value as Database['public']['Enums']['workshop_enrollment_status'])
+  )
+  if (invalidStatuses) {
+    return Response.json({ error: 'Invalid enrollment status.' }, { status: 400, headers: auth.headers })
+  }
+  const requestedStatuses = Array.from(new Set(requestedStatusValues as Database['public']['Enums']['workshop_enrollment_status'][]))
+
   const { data: requestedDistrictRows, error: districtError } = await supabase
     .from('federal_electoral_district')
     .select('name, meal_kit')
-    .in('name', ridingNames)
 
   if (districtError) {
     console.error('[federal-electoral-district] failed to load requested district rows', districtError)
-    return Response.json({ byRiding }, { headers: auth.headers })
+    return Response.json({ error: 'Failed to load district rows.' }, { status: 500, headers: auth.headers })
   }
 
   const mealKitByRequestedRiding = new Map(
@@ -209,14 +235,32 @@ export async function loader({ request }: { request: Request }) {
       .filter((entry): entry is [string, boolean] => typeof entry[0] === 'string')
   )
 
-  const { data: enrollmentRows, error: enrollmentError } = await supabase
-    .from('workshop_enrollment')
-    .select('profile_id, status')
-    .not('profile_id', 'is', null)
+  const enrollmentRows: Array<{ profile_id: string | null; status: Database['public']['Enums']['workshop_enrollment_status'] }> = []
+  for (let page = 0; ; page += 1) {
+    let enrollmentQuery = supabase
+      .from('workshop_enrollment')
+      .select('profile_id, status, id')
+      .not('profile_id', 'is', null)
+      .order('id', { ascending: true })
+      .range(page * ENROLLMENT_PAGE_SIZE, (page + 1) * ENROLLMENT_PAGE_SIZE - 1)
 
-  if (enrollmentError) {
-    console.error('[federal-electoral-district] failed to load enrollment rows', enrollmentError)
-    return Response.json({ byRiding }, { headers: auth.headers })
+    if (requestedStatuses.length) {
+      enrollmentQuery = enrollmentQuery.in('status', requestedStatuses)
+    }
+
+    const { data, error: enrollmentError } = await enrollmentQuery
+    if (enrollmentError) {
+      console.error('[federal-electoral-district] failed to load enrollment rows', enrollmentError)
+      return Response.json({ error: 'Failed to load enrollment rows.' }, { status: 500, headers: auth.headers })
+    }
+
+    enrollmentRows.push(
+      ...((data ?? []) as Array<{
+        profile_id: string | null
+        status: Database['public']['Enums']['workshop_enrollment_status']
+      }>)
+    )
+    if (!data?.length || data.length < ENROLLMENT_PAGE_SIZE) break
   }
 
   const profileIds = Array.from(
@@ -240,7 +284,7 @@ export async function loader({ request }: { request: Request }) {
 
     if (error) {
       console.error('[federal-electoral-district] failed to load profile riding map', error)
-      return Response.json({ byRiding }, { headers: auth.headers })
+      return Response.json({ error: 'Failed to load profile data.' }, { status: 500, headers: auth.headers })
     }
 
     profileRows.push(...((data ?? []) as ProfileRidingRow[]))
@@ -285,14 +329,14 @@ export async function loader({ request }: { request: Request }) {
         chunkSize: profileChunk.length,
         error: guardianEdgesError.message,
       })
-      return Response.json({ byRiding }, { headers: auth.headers })
+      return Response.json({ error: 'Failed to load guardian family data.' }, { status: 500, headers: auth.headers })
     }
     if (childEdgesError) {
       console.error('[federal-electoral-district] failed to load child family edges', {
         chunkSize: profileChunk.length,
         error: childEdgesError.message,
       })
-      return Response.json({ byRiding }, { headers: auth.headers })
+      return Response.json({ error: 'Failed to load child family data.' }, { status: 500, headers: auth.headers })
     }
 
     for (const edge of [...(guardianEdges ?? []), ...(childEdges ?? [])] as FamilyEdgeRow[]) {
@@ -318,7 +362,7 @@ export async function loader({ request }: { request: Request }) {
 
     if (relatedProfilesError) {
       console.error('[federal-electoral-district] failed to load related profile ridings', relatedProfilesError)
-      return Response.json({ byRiding }, { headers: auth.headers })
+      return Response.json({ error: 'Failed to load related profile data.' }, { status: 500, headers: auth.headers })
     }
 
     for (const related of relatedProfiles ?? []) {
@@ -402,7 +446,7 @@ export async function loader({ request }: { request: Request }) {
 
     if (error) {
       console.error('[federal-electoral-district] failed to load form submissions by profile', error)
-      continue
+      return Response.json({ error: 'Failed to load form submissions.' }, { status: 500, headers: auth.headers })
     }
 
     for (const row of (submissions ?? []) as FormSubmissionRow[]) {
@@ -418,7 +462,7 @@ export async function loader({ request }: { request: Request }) {
 
     if (error) {
       console.error('[federal-electoral-district] failed to load form submissions by user', error)
-      continue
+      return Response.json({ error: 'Failed to load form submissions.' }, { status: 500, headers: auth.headers })
     }
 
     for (const row of (submissions ?? []) as FormSubmissionRow[]) {
@@ -443,7 +487,7 @@ export async function loader({ request }: { request: Request }) {
 
     if (error) {
       console.error('[federal-electoral-district] failed to load gift card answers', error)
-      continue
+      return Response.json({ error: 'Failed to load form answers.' }, { status: 500, headers: auth.headers })
     }
 
     for (const answer of (answers ?? []) as FormAnswerRow[]) {
@@ -587,6 +631,7 @@ export async function loader({ request }: { request: Request }) {
     if (seenHouseholds.has(householdId)) continue
     seenHouseholds.add(householdId)
     seenHouseholdsByRiding.set(requestedRiding, seenHouseholds)
+    byRiding[requestedRiding].families += 1
 
     const householdPeople = Number(householdPeopleByKey.get(householdId) ?? 0)
     if (Number.isFinite(householdPeople) && householdPeople >= 0) {
@@ -625,4 +670,12 @@ export async function loader({ request }: { request: Request }) {
   }
 
   return Response.json({ byRiding }, { headers: auth.headers })
+}
+
+export async function loader({ request }: { request: Request }) {
+  return loadFederalElectoralDistrictEnrichment(request)
+}
+
+export async function action({ request }: { request: Request }) {
+  return loadFederalElectoralDistrictEnrichment(request)
 }

--- a/web/app/routes/manage/federal-electoral-district.tsx
+++ b/web/app/routes/manage/federal-electoral-district.tsx
@@ -1,6 +1,7 @@
-import { Form, useLocation, useNavigation } from 'react-router'
+import { useEffect, useRef, useState } from 'react'
+import { Form, useLocation, useNavigation, useSearchParams } from 'react-router'
 
-import { Download, Loader2 } from 'lucide-react'
+import { Check, ChevronDown, Download, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { EXPORT_TYPE_FEDERAL_ELECTORAL_DISTRICT_CSV } from '@/lib/exports/types'
 import TableDisplay from './table-display'
@@ -23,7 +24,7 @@ export async function loader(args: Route.LoaderArgs) {
   const request = new Request(url.toString(), args.request)
   const base = await baseLoader({ ...args, request })
 
-  const columns = base.columns.includes('accepted')
+  const columns = base.columns.includes('accepted') && base.columns.includes('families')
     ? base.columns
     : [
         'code',
@@ -31,6 +32,7 @@ export async function loader(args: Route.LoaderArgs) {
         'whitelist',
         'meal_kit',
         'total',
+        'families',
         'accepted',
         'pending',
         'waitlisted',
@@ -47,6 +49,7 @@ export async function loader(args: Route.LoaderArgs) {
     return {
       ...row,
       total: null,
+      families: null,
       accepted: null,
       pending: null,
       waitlisted: null,
@@ -76,6 +79,7 @@ export async function loader(args: Route.LoaderArgs) {
         preferredWidth: 360,
       },
       total: { label: 'total', numeric: true },
+      families: { label: 'families', numeric: true, minWidth: 90, preferredWidth: 90 },
       accepted: { label: 'accepted', numeric: true, minWidth: 90, preferredWidth: 90 },
       pending: { label: 'pending', numeric: true, minWidth: 90, preferredWidth: 90 },
       waitlisted: { label: 'waitlisted', numeric: true, minWidth: 90, preferredWidth: 90 },
@@ -91,6 +95,116 @@ export async function loader(args: Route.LoaderArgs) {
 
 export const action = createTableAction('federal-electoral-district')
 
+const enrollmentStatusOptions = [
+  ['pending', 'Pending'],
+  ['waitlisted', 'Waitlisted'],
+  ['approved', 'Accepted'],
+  ['rejected', 'Rejected'],
+  ['revoked', 'Revoked'],
+] as const
+
+function EnrollmentStatusFilter() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const selected = searchParams.getAll('enrollmentStatus')
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState<string[]>(selected)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (open) setDraft(selected)
+  }, [open, searchParams])
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const apply = () => {
+    const next = new URLSearchParams(searchParams)
+    next.delete('enrollmentStatus')
+    enrollmentStatusOptions.forEach(([value]) => {
+      if (draft.includes(value)) next.append('enrollmentStatus', value)
+    })
+    next.delete('page')
+    setSearchParams(next, { replace: true })
+    setOpen(false)
+  }
+
+  const summary = selected.length ? `${selected.length} selected` : 'All statuses'
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls="federal-district-enrollment-status-filter"
+        onClick={() => setOpen(previous => !previous)}
+      >
+        Enrollment status: {summary}
+        <ChevronDown className="ml-1 size-4" />
+      </Button>
+      {open ? (
+        <div
+          id="federal-district-enrollment-status-filter"
+          role="dialog"
+          aria-label="Filter enrollment statuses"
+          className="absolute right-0 z-50 mt-2 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-lg"
+        >
+          <div className="mb-2 text-xs text-muted-foreground">Select one or more current enrollment statuses.</div>
+          <div className="space-y-1" role="group" aria-label="Enrollment statuses">
+            {enrollmentStatusOptions.map(([value, label]) => {
+              const checked = draft.includes(value)
+              return (
+                <label key={value} className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => setDraft(previous => (checked ? previous.filter(item => item !== value) : [...previous, value]))}
+                    className="sr-only"
+                  />
+                  <span className={`flex size-4 items-center justify-center rounded border ${checked ? 'border-primary bg-primary text-primary-foreground' : 'border-input'}`}>
+                    {checked ? <Check className="size-3" /> : null}
+                  </span>
+                  {label}
+                </label>
+              )
+            })}
+          </div>
+          <div className="mt-3 flex items-center justify-between border-t pt-3 text-xs">
+            <button type="button" className="text-muted-foreground hover:text-foreground" onClick={() => setDraft([])}>
+              Clear
+            </button>
+            <div className="flex gap-2">
+              <button type="button" className="rounded px-2 py-1 hover:bg-muted" onClick={() => setOpen(false)}>
+                Cancel
+              </button>
+              <button type="button" className="rounded bg-primary px-2 py-1 text-primary-foreground" onClick={apply}>
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
 export default function FederalElectoralDistrictTablePage() {
   const location = useLocation()
   const navigation = useNavigation()
@@ -100,6 +214,7 @@ export default function FederalElectoralDistrictTablePage() {
   return (
     <TableDisplay
       filterOptionsMode="client"
+      headerActions={<EnrollmentStatusFilter />}
       paginationActions={
         <Form method="post" action="/manage/exports" className="flex items-center gap-2">
           <input type="hidden" name="intent" value="create-export" />

--- a/web/app/routes/manage/federal-electoral-district.tsx
+++ b/web/app/routes/manage/federal-electoral-district.tsx
@@ -214,23 +214,25 @@ export default function FederalElectoralDistrictTablePage() {
   return (
     <TableDisplay
       filterOptionsMode="client"
-      headerActions={<EnrollmentStatusFilter />}
       paginationActions={
-        <Form method="post" action="/manage/exports" className="flex items-center gap-2">
-          <input type="hidden" name="intent" value="create-export" />
-          <input type="hidden" name="export_type" value={EXPORT_TYPE_FEDERAL_ELECTORAL_DISTRICT_CSV} />
-          <input type="hidden" name="source_path" value={sourcePath} />
-          <Button
-            type="submit"
-            variant="outline"
-            size="icon-sm"
-            disabled={isCreatingExport}
-            aria-label={isCreatingExport ? 'Exporting CSV' : 'Export CSV'}
-            title={isCreatingExport ? 'Exporting CSV...' : 'Export CSV'}
-          >
-            {isCreatingExport ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
-          </Button>
-        </Form>
+        <div className="flex items-center gap-2">
+          <EnrollmentStatusFilter />
+          <Form method="post" action="/manage/exports" className="flex items-center gap-2">
+            <input type="hidden" name="intent" value="create-export" />
+            <input type="hidden" name="export_type" value={EXPORT_TYPE_FEDERAL_ELECTORAL_DISTRICT_CSV} />
+            <input type="hidden" name="source_path" value={sourcePath} />
+            <Button
+              type="submit"
+              variant="outline"
+              size="icon-sm"
+              disabled={isCreatingExport}
+              aria-label={isCreatingExport ? 'Exporting CSV' : 'Export CSV'}
+              title={isCreatingExport ? 'Exporting CSV...' : 'Export CSV'}
+            >
+              {isCreatingExport ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+            </Button>
+          </Form>
+        </div>
       }
     />
   )

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -3832,7 +3832,8 @@ export default function TableDisplay({
                         column.includes('join_url') && typeof rawCellValue === 'string' && isHttpUrl(rawCellValue)
                       const shouldTruncate = columnMeta[column]?.truncate ?? tableVariant !== 'pivot'
                       const filterable = columnMeta[column]?.filterable ?? true
-                      const canClickFilter = enableCellClickFilter && filterable
+                      const isFederalDistrictNameColumn = isFederalDistrictTable && column === 'name'
+                      const canClickFilter = enableCellClickFilter && filterable && !isFederalDistrictNameColumn
                       const cellValue = getCellValue(column, row, tableName)
                       const rowCellClassByColumn =
                         row._cell_class_by_column && typeof row._cell_class_by_column === 'object' && !Array.isArray(row._cell_class_by_column)

--- a/web/app/routes/manage/table-display.tsx
+++ b/web/app/routes/manage/table-display.tsx
@@ -124,6 +124,7 @@ type ProfileEnrichment = Partial<WorkshopEnrollmentEnrichment & ClassAttendanceE
 
 type FederalDistrictCounts = {
   total: number
+  families: number
   accepted: number
   pending: number
   waitlisted: number
@@ -137,6 +138,7 @@ type FederalDistrictCounts = {
 
 type FederalDistrictEnrichmentResponse = {
   byRiding: Record<string, FederalDistrictCounts>
+  error?: string
 }
 
 export type LoaderData = {
@@ -939,6 +941,8 @@ export default function TableDisplay({
   const [editValues, setEditValues] = useState<Record<string, string>>({})
   const [enrichmentByProfileId, setEnrichmentByProfileId] = useState<Record<string, ProfileEnrichment>>({})
   const [districtCountsByRiding, setDistrictCountsByRiding] = useState<Record<string, FederalDistrictCounts>>({})
+  const [districtMetricsError, setDistrictMetricsError] = useState<string | null>(null)
+  const [districtMetricsRetry, setDistrictMetricsRetry] = useState(0)
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({})
   const [columnMinWidths, setColumnMinWidths] = useState<Record<string, number>>({})
   const [resizeState, setResizeState] = useState<ResizeState | null>(null)
@@ -951,7 +955,7 @@ export default function TableDisplay({
   const [hoverCardPosition, setHoverCardPosition] = useState<{ top: number; left: number } | null>(null)
   const loadingEnrichmentProfileIdsRef = useRef<Set<string>>(new Set())
   const loadedFamilyContextProfileIdsRef = useRef<Set<string>>(new Set())
-  const loadingDistrictRidingsRef = useRef<Set<string>>(new Set())
+  const districtMetricsRequestKeyRef = useRef('')
   const filterButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const filterPopoverRef = useRef<HTMLDivElement | null>(null)
   const hoverCardPopoverRef = useRef<HTMLDivElement | null>(null)
@@ -1042,6 +1046,7 @@ export default function TableDisplay({
           nextRow = {
             ...nextRow,
             total: '...',
+            families: '...',
             accepted: '...',
             pending: '...',
             waitlisted: '...',
@@ -1692,6 +1697,7 @@ export default function TableDisplay({
       const unresolvedCountColumns = districtRows.some(
         row =>
           typeof row.total !== 'number' ||
+          typeof row.families !== 'number' ||
           typeof row.accepted !== 'number' ||
           typeof row.pending !== 'number' ||
           typeof row.waitlisted !== 'number' ||
@@ -1706,6 +1712,7 @@ export default function TableDisplay({
       const totals = unresolvedCountColumns
         ? {
             total: '...',
+            families: '...',
             accepted: '...',
             pending: '...',
             waitlisted: '...',
@@ -1719,6 +1726,7 @@ export default function TableDisplay({
         : districtRows.reduce<FederalDistrictCounts>(
             (acc, row) => {
               acc.total += Number(row.total)
+              acc.families += Number(row.families)
               acc.accepted += Number(row.accepted)
               acc.pending += Number(row.pending)
               acc.waitlisted += Number(row.waitlisted)
@@ -1732,6 +1740,7 @@ export default function TableDisplay({
             },
             {
               total: 0,
+              families: 0,
               accepted: 0,
               pending: 0,
               waitlisted: 0,
@@ -2048,39 +2057,40 @@ export default function TableDisplay({
   useEffect(() => {
     if (!isFederalDistrictTable) return
 
-    const missingRidings = Array.from(
+    const ridingNames = Array.from(
       new Set(
-        paginatedRows
+        rows
           .map(row => (typeof row.name === 'string' ? row.name.trim() : ''))
-          .filter(
-            riding =>
-              Boolean(riding) &&
-              riding !== 'Total' &&
-              !districtCountsByRiding[riding] &&
-              !loadingDistrictRidingsRef.current.has(riding)
-          )
+          .filter(riding => Boolean(riding) && riding !== 'Total')
       )
     )
 
-    if (!missingRidings.length) return
+    if (!ridingNames.length) return
 
-    const requestRidings = missingRidings.slice(0, 30)
-    requestRidings.forEach(riding => loadingDistrictRidingsRef.current.add(riding))
-
+    const statuses = searchParams.getAll('enrollmentStatus')
+    const requestKey = JSON.stringify({ ridingNames, statuses })
+    districtMetricsRequestKeyRef.current = requestKey
+    setDistrictCountsByRiding({})
+    setDistrictMetricsError(null)
     const abortController = new AbortController()
     void (async () => {
       try {
-        const query = new URLSearchParams()
-        requestRidings.forEach(riding => query.append('riding', riding))
-        const response = await fetch(`/manage/federal-electoral-district/enrichment?${query.toString()}`, {
+        const response = await fetch('/manage/federal-electoral-district/enrichment', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ridings: ridingNames, enrollmentStatuses: statuses }),
           signal: abortController.signal,
         })
 
-        if (!response.ok) return
-        const payload = (await response.json()) as FederalDistrictEnrichmentResponse
-        const resolved = requestRidings.reduce<Record<string, FederalDistrictCounts>>((acc, riding) => {
+        const payload = (await response.json().catch(() => ({}))) as FederalDistrictEnrichmentResponse
+        if (!response.ok) {
+          throw new Error(payload.error ?? `District metrics request failed (${response.status}).`)
+        }
+        if (districtMetricsRequestKeyRef.current !== requestKey) return
+        const resolved = ridingNames.reduce<Record<string, FederalDistrictCounts>>((acc, riding) => {
           acc[riding] = payload?.byRiding?.[riding] ?? {
             total: 0,
+            families: 0,
             accepted: 0,
             pending: 0,
             waitlisted: 0,
@@ -2094,20 +2104,20 @@ export default function TableDisplay({
           return acc
         }, {})
 
-        setDistrictCountsByRiding(prev => ({ ...prev, ...resolved }))
+        setDistrictCountsByRiding(resolved)
+        setDistrictMetricsError(null)
       } catch (error) {
-        if ((error as Error).name !== 'AbortError') {
+        if ((error as Error).name !== 'AbortError' && districtMetricsRequestKeyRef.current === requestKey) {
+          setDistrictMetricsError(error instanceof Error ? error.message : 'Unable to load district metrics.')
           console.error('[table display] federal district enrichment fetch failed', error)
         }
-      } finally {
-        requestRidings.forEach(riding => loadingDistrictRidingsRef.current.delete(riding))
       }
     })()
 
     return () => {
       abortController.abort()
     }
-  }, [districtCountsByRiding, isFederalDistrictTable, paginatedRows])
+  }, [isFederalDistrictTable, rows, searchParams, districtMetricsRetry])
 
   const updateSort = (column: string) => {
     if (sortColumn !== column) {
@@ -3085,6 +3095,15 @@ export default function TableDisplay({
         {headerActions ? <div className="ml-auto">{headerActions}</div> : null}
       </div>
 
+      {isFederalDistrictTable && districtMetricsError ? (
+        <div className="mx-6 flex flex-wrap items-center justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <span>Unable to load district metrics: {districtMetricsError}</span>
+          <Button type="button" variant="outline" size="sm" onClick={() => setDistrictMetricsRetry(previous => previous + 1)}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+
       {canInlineInsert && showCreate ? (
         <section className="relative z-30 mx-6 overflow-visible rounded-lg border bg-card p-4">
           <div className="space-y-3">
@@ -3183,15 +3202,16 @@ export default function TableDisplay({
             ))}
             {canInlineUpdate ? <col key="col-actions" style={{ width: `${ACTIONS_COLUMN_WIDTH}px` }} /> : null}
           </colgroup>
-          <thead className="bg-muted/40 text-[11px] uppercase tracking-widest text-muted-foreground">
+          <thead className={`${hasStickyColumnHeaders ? 'sticky top-0 z-30' : ''} bg-muted/40 text-[11px] uppercase tracking-widest text-muted-foreground`}>
             <tr>
               {columns.map(column => {
                 const hasActiveFilter = hasOwn(filters, column)
+                const isStickyDistrictNameColumn = isFederalDistrictTable && column === 'name'
                 return (
                   <th
                     key={`head-${column}`}
                     title={columnMeta[column]?.headerTooltip}
-                    className={`${isNumericColumn(column) ? 'w-24' : ''} relative px-4 py-2 text-left ${hasStickyColumnHeaders ? 'sticky top-0 z-10 bg-muted/95 backdrop-blur supports-[backdrop-filter]:bg-muted/80' : ''}`}
+                    className={`${isNumericColumn(column) ? 'w-24' : ''} relative px-4 py-2 text-left ${hasStickyColumnHeaders ? 'sticky top-0 z-10 bg-muted/95 backdrop-blur supports-[backdrop-filter]:bg-muted/80' : ''} ${isStickyDistrictNameColumn ? 'left-0 z-40' : ''}`}
                   >
                     <div className="relative flex items-center gap-1">
                       <button
@@ -3903,14 +3923,14 @@ export default function TableDisplay({
                       )
 
                       return (
-                        <td
-                          key={`cell-${absoluteRowIndex}-${column}`}
-                          title={cellValue || '(empty)'}
-                          className={
-                            isNumericColumn(column)
-                              ? `w-24 whitespace-nowrap px-4 py-2 text-right font-mono tabular-nums select-text ${canClickFilter ? 'cursor-pointer hover:bg-muted/30' : ''} ${extraCellClass}`
-                              : `px-4 py-2 font-mono select-text ${canClickFilter ? 'cursor-pointer hover:bg-muted/30' : ''} ${extraCellClass}`
-                          }
+                    <td
+                      key={`cell-${absoluteRowIndex}-${column}`}
+                      title={cellValue || '(empty)'}
+                      className={
+                        isNumericColumn(column)
+                          ? `w-24 whitespace-nowrap px-4 py-2 text-right font-mono tabular-nums select-text ${canClickFilter ? 'cursor-pointer hover:bg-muted/30' : ''} ${extraCellClass}`
+                          : `px-4 py-2 font-mono select-text ${canClickFilter ? 'cursor-pointer hover:bg-muted/30' : ''} ${extraCellClass} ${isFederalDistrictTable && column === 'name' ? `sticky left-0 z-20 ${row.__is_total_row === true ? 'bg-muted' : absoluteRowIndex % 2 === 0 ? 'bg-card' : 'bg-background'}` : ''}`
+                      }
                           onClick={event => {
                             const interactiveTarget = (event.target as HTMLElement | null)?.closest(
                               'a,button,input,select,textarea,label'

--- a/web/tests/e2e/federal-electoral-district.spec.ts
+++ b/web/tests/e2e/federal-electoral-district.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from '@playwright/test'
+
+import { ensureReusableAdminAccount, getAdminSupabaseClient, hasAdminServiceEnv, loginAsAdmin } from './helpers/admin-account'
+import { uniqueSuffix } from './helpers/ids'
+
+type DistrictCounts = {
+  total: number
+  families: number
+  accepted: number
+  pending: number
+  waitlisted: number
+  declined: number
+  giftcard_pc: number
+  giftcard_sobeys: number
+  giftcard_meal_kit: number
+  household_count: number
+  household_child_count: number
+}
+
+test.describe.serial('federal electoral district metrics', () => {
+  test.skip(!hasAdminServiceEnv(), 'Requires SUPABASE_URL and SUPABASE_SECRET_KEY for admin setup')
+
+  test.beforeAll(async () => {
+    await ensureReusableAdminAccount()
+  })
+
+  test('uses one bounded POST enrichment request and applies status filters', async ({ page }) => {
+    const requests: Array<{ statuses: string[]; ridings: string[] }> = []
+
+    await page.route('**/manage/federal-electoral-district/enrichment', async route => {
+      const payload = route.request().postDataJSON() as { ridings?: string[]; enrollmentStatuses?: string[] }
+      const ridings = payload.ridings ?? []
+      const statuses = payload.enrollmentStatuses ?? []
+      requests.push({ ridings, statuses })
+
+      const byRiding = Object.fromEntries(
+        ridings.map(riding => [riding, {
+          total: statuses.length ? 1 : 2,
+          families: 1,
+          accepted: statuses.includes('approved') ? 1 : 0,
+          pending: statuses.includes('pending') ? 1 : 0,
+          waitlisted: 0,
+          declined: 0,
+          giftcard_pc: 0,
+          giftcard_sobeys: 0,
+          giftcard_meal_kit: 0,
+          household_count: 0,
+          household_child_count: 0,
+        }])
+      )
+
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ byRiding }) })
+    })
+
+    await loginAsAdmin(page)
+    await page.goto('/manage/federal-electoral-district')
+    await expect.poll(() => requests.length).toBe(1)
+    expect(requests[0]?.ridings.length).toBeGreaterThan(0)
+    expect(requests[0]?.ridings.length).toBeLessThan(1000)
+    expect(requests[0]?.statuses).toEqual([])
+
+    await expect(page.getByRole('cell', { name: '1' }).first()).toBeVisible()
+
+    await page.getByRole('button', { name: /Enrollment status: All statuses/ }).click()
+    await page.getByRole('dialog').getByText('Pending', { exact: true }).click()
+    await page.getByRole('button', { name: 'Apply' }).click()
+
+    await expect(page).toHaveURL(/enrollmentStatus=pending/)
+    await expect.poll(() => requests.length).toBe(2)
+    expect(requests[1]?.statuses).toEqual(['pending'])
+  })
+
+  test('live enrichment returns district metrics successfully', async ({ page }) => {
+    test.setTimeout(120_000)
+    await loginAsAdmin(page)
+    const responsePromise = page.waitForResponse(
+      response =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/manage/federal-electoral-district/enrichment')
+    )
+    await page.goto('/manage/federal-electoral-district')
+    const response = await responsePromise
+    expect(response.status()).toBe(200)
+
+    const payload = (await response.json()) as { byRiding?: Record<string, unknown> }
+    expect(Object.keys(payload.byRiding ?? {}).length).toBeGreaterThan(0)
+  })
+
+  test('cross-references an isolated database enrollment against endpoint deltas', async ({ page }) => {
+    test.setTimeout(120_000)
+    const adminSupabase = getAdminSupabaseClient()
+    await loginAsAdmin(page)
+
+    const { data: district, error: districtError } = await adminSupabase
+      .from('federal_electoral_district')
+      .select('name')
+      .order('name')
+      .limit(1)
+      .single()
+    if (districtError || !district?.name) throw new Error(districtError?.message ?? 'No district fixture available')
+
+    const readMetrics = async () => {
+      const response = await page.request.post('/manage/federal-electoral-district/enrichment', {
+        data: { ridings: [district.name] },
+      })
+      expect(response.status()).toBe(200)
+      const payload = (await response.json()) as { byRiding?: Record<string, DistrictCounts> }
+      const metrics = payload.byRiding?.[district.name]
+      if (!metrics) throw new Error(`No metrics returned for ${district.name}`)
+      return metrics
+    }
+
+    const baseline = await readMetrics()
+    const suffix = uniqueSuffix()
+    const email = `federal-district-cross-check-${suffix}@example.test`
+    let profileId: string | null = null
+    let semesterId: string | null = null
+    let workshopId: string | null = null
+
+    try {
+      const { data: profile, error: profileError } = await adminSupabase
+        .from('profile')
+        .insert({
+          role: 'guardian',
+          email,
+          firstname: 'Federal District Cross Check',
+          surname: suffix,
+          federal_electoral_district_name: district.name,
+        })
+        .select('id')
+        .single()
+      if (profileError || !profile?.id) throw new Error(profileError?.message ?? 'Unable to create profile fixture')
+      profileId = profile.id
+
+      const { data: semester, error: semesterError } = await adminSupabase
+        .from('semester')
+        .insert({
+          name: `Federal district cross-check ${suffix}`,
+          starts_at: '2026-01-01T00:00:00Z',
+          ends_at: '2026-12-31T00:00:00Z',
+        })
+        .select('id')
+        .single()
+      if (semesterError || !semester?.id) throw new Error(semesterError?.message ?? 'Unable to create semester fixture')
+      semesterId = semester.id
+
+      const { data: workshop, error: workshopError } = await adminSupabase
+        .from('workshop')
+        .insert({ semester_id: semester.id, description: `Federal district cross-check ${suffix}` })
+        .select('id')
+        .single()
+      if (workshopError || !workshop?.id) throw new Error(workshopError?.message ?? 'Unable to create workshop fixture')
+      workshopId = workshop.id
+
+      const { data: enrollment, error: enrollmentError } = await adminSupabase
+        .from('workshop_enrollment')
+        .insert({ profile_id: profile.id, semester_id: semester.id, workshop_id: workshop.id, status: 'approved' })
+        .select('id, profile_id, status')
+        .single()
+      if (enrollmentError || !enrollment?.id) throw new Error(enrollmentError?.message ?? 'Unable to create enrollment fixture')
+      expect(enrollment.profile_id).toBe(profile.id)
+      expect(enrollment.status).toBe('approved')
+
+      const after = await readMetrics()
+      expect(after.total - baseline.total).toBe(1)
+      expect(after.accepted - baseline.accepted).toBe(1)
+      expect(after.families - baseline.families).toBe(1)
+    } finally {
+      if (profileId) await adminSupabase.from('workshop_enrollment').delete().eq('profile_id', profileId)
+      if (workshopId) await adminSupabase.from('workshop').delete().eq('id', workshopId)
+      if (semesterId) await adminSupabase.from('semester').delete().eq('id', semesterId)
+      if (profileId) await adminSupabase.from('profile').delete().eq('id', profileId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Fix federal electoral district metric enrichment and status filtering.
- Add database cross-reference and request regression coverage.
- Make the district name column and table header sticky.
- Move enrollment status controls into the pagination toolbar.

## Verification
- npm run typecheck
- npm run test -- tests/e2e/federal-electoral-district.spec.ts
- 3 federal district E2E tests passed.