### PR TITLE
Unify gift card fulfillment math

### DIFF
--- a/web/app/lib/gift-cards/forecast.server.ts
+++ b/web/app/lib/gift-cards/forecast.server.ts
@@ -1,30 +1,19 @@
+import { resolveGiftCardFulfillmentByProfileId, type GiftCardProvider } from '@/lib/gift-cards/provider.server'
 import { adminClient } from '@/lib/supabase/adminClient'
 
 const TORONTO_TIME_ZONE = 'America/Toronto'
-const QUERY_BATCH_SIZE = 100
+const BATCH_SIZE = 100
 
-export type GiftCardProvider = 'PC' | 'Sobeys'
-
-type ClassScopeRow = { id: string; workshop_id: string | null; starts_at: string }
+type ClassRow = { id: string; workshop_id: string | null; starts_at: string }
 type EnrollmentRow = { workshop_id: string | null; profile_id: string | null }
-type AttendanceRow = {
-  class_id: string
-  profile_id: string | null
-  state: 'active' | 'inactive' | null
-  camera_on: boolean | null
-  photo_status: 'uploaded' | 'accepted' | 'rejected' | 'expired' | null
-  gift_card_blocked: boolean | null
-}
 type AllocationRow = {
   class_id: string
   profile_id: string | null
   asset: { provider: GiftCardProvider } | Array<{ provider: GiftCardProvider }> | null
 }
-type FamilyEdgeRow = { guardian_profile_id: string; child_profile_id: string }
-type ProfileRow = { id: string; user_id: string | null }
-type FormSubmissionRow = { id: string; profile_id: string | null; user_id: string | null; submitted_at: string | null }
-type FormAnswerRow = { submission_id: string; value: unknown }
+type AttendanceRow = { class_id: string; profile_id: string | null; gift_card_blocked: boolean | null }
 
+export type { GiftCardProvider }
 export type GiftCardWeekRange = { startsAt: string; endsAt: string }
 export type GiftCardWeekSnapshot = GiftCardWeekRange & {
   allocated: Record<GiftCardProvider, number>
@@ -49,17 +38,16 @@ const torontoDateFormatter = new Intl.DateTimeFormat('en-CA', {
   day: '2-digit',
 })
 
-const unique = <T,>(items: T[]) => Array.from(new Set(items))
-const emptyProviderCounts = (): Record<GiftCardProvider, number> => ({ PC: 0, Sobeys: 0 })
+const emptyCounts = (): Record<GiftCardProvider, number> => ({ PC: 0, Sobeys: 0 })
+const unique = <T,>(values: T[]) => Array.from(new Set(values))
 const allocationKey = (classId: string, profileId: string) => `${classId}::${profileId}`
-
 const chunkArray = <T,>(items: T[]) => {
   const chunks: T[][] = []
-  for (let index = 0; index < items.length; index += QUERY_BATCH_SIZE) chunks.push(items.slice(index, index + QUERY_BATCH_SIZE))
+  for (let index = 0; index < items.length; index += BATCH_SIZE) chunks.push(items.slice(index, index + BATCH_SIZE))
   return chunks
 }
 
-const torontoPartsForDate = (date: Date) => {
+const torontoParts = (date: Date) => {
   const parts = torontoDateFormatter.formatToParts(date)
   const get = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? ''
   return { weekday: get('weekday'), year: Number(get('year')), month: Number(get('month')), day: Number(get('day')) }
@@ -73,27 +61,20 @@ const addDays = (year: number, month: number, day: number, days: number) => {
 const torontoMidnightIso = (year: number, month: number, day: number) => {
   for (let hour = 0; hour < 24; hour += 1) {
     const candidate = new Date(Date.UTC(year, month - 1, day, hour))
-    const local = torontoPartsForDate(candidate)
+    const local = torontoParts(candidate)
     if (local.year === year && local.month === month && local.day === day) return candidate.toISOString()
   }
   throw new Error(`Unable to resolve Toronto midnight for ${year}-${month}-${day}`)
 }
 
 export const buildGiftCardWeekRanges = (now = new Date()): [GiftCardWeekRange, GiftCardWeekRange, GiftCardWeekRange] => {
-  const local = torontoPartsForDate(now)
-  const thisSunday = addDays(local.year, local.month, local.day, -weekdayIndexByLabel[local.weekday])
-  return [0, 7, 14].map(days => {
-    const start = addDays(thisSunday.year, thisSunday.month, thisSunday.day, days)
+  const local = torontoParts(now)
+  const sunday = addDays(local.year, local.month, local.day, -weekdayIndexByLabel[local.weekday])
+  return [0, 7, 14].map(offset => {
+    const start = addDays(sunday.year, sunday.month, sunday.day, offset)
     const end = addDays(start.year, start.month, start.day, 7)
     return { startsAt: torontoMidnightIso(start.year, start.month, start.day), endsAt: torontoMidnightIso(end.year, end.month, end.day) }
   }) as [GiftCardWeekRange, GiftCardWeekRange, GiftCardWeekRange]
-}
-
-const providerFromDisplay = (value: string | null | undefined): GiftCardProvider | null => {
-  const normalized = (value ?? '').trim().toLowerCase()
-  const compact = normalized.replace(/[^a-z0-9]+/g, '')
-  if (compact.includes('mealkit') || normalized.includes('meal kit')) return null
-  return compact.includes('sobeys') || normalized.includes('sobeys') || normalized.includes("sobey's") ? 'Sobeys' : 'PC'
 }
 
 const loadClasses = async (range: GiftCardWeekRange) => {
@@ -103,10 +84,20 @@ const loadClasses = async (range: GiftCardWeekRange) => {
     .gte('starts_at', range.startsAt)
     .lt('starts_at', range.endsAt)
   if (error) throw new Error(`Failed to load gift-card classes: ${error.message}`)
-  return (data ?? []) as ClassScopeRow[]
+  return (data ?? []) as ClassRow[]
 }
 
-const loadEnrollments = async (workshopIds: string[]) => {
+const loadRowsByClass = async <T>(table: 'class_attendance' | 'gift_card_allocation', select: string, classIds: string[]) => {
+  const rows: T[] = []
+  for (const chunk of chunkArray(classIds)) {
+    const { data, error } = await adminClient.from(table).select(select).in('class_id', chunk)
+    if (error) throw new Error(`Failed to load ${table}: ${error.message}`)
+    rows.push(...((data ?? []) as T[]))
+  }
+  return rows
+}
+
+const loadApprovedEnrollments = async (workshopIds: string[]) => {
   const rows: EnrollmentRow[] = []
   for (const chunk of chunkArray(workshopIds)) {
     const { data, error } = await adminClient
@@ -120,138 +111,8 @@ const loadEnrollments = async (workshopIds: string[]) => {
   return rows
 }
 
-const loadAttendance = async (classIds: string[]) => {
-  const rows: AttendanceRow[] = []
-  for (const chunk of chunkArray(classIds)) {
-    const { data, error } = await adminClient
-      .from('class_attendance')
-      .select('class_id, profile_id, state, camera_on, photo_status, gift_card_blocked')
-      .in('class_id', chunk)
-    if (error) throw new Error(`Failed to load attendance rows: ${error.message}`)
-    rows.push(...((data ?? []) as AttendanceRow[]))
-  }
-  return rows
-}
-
-const loadAllocations = async (classIds: string[]) => {
-  const rows: AllocationRow[] = []
-  for (const chunk of chunkArray(classIds)) {
-    const { data, error } = await adminClient
-      .from('gift_card_allocation')
-      .select('class_id, profile_id, asset:gift_card_asset_id(provider)')
-      .in('class_id', chunk)
-    if (error) throw new Error(`Failed to load gift-card allocations: ${error.message}`)
-    rows.push(...((data ?? []) as AllocationRow[]))
-  }
-  return rows
-}
-
-const loadProviderByProfileId = async (profileIds: string[]) => {
-  const normalizedProfileIds = unique(profileIds.filter(Boolean))
-  const providerByProfileId = new Map<string, GiftCardProvider | null>()
-  if (!normalizedProfileIds.length) return providerByProfileId
-
-  const profiles: ProfileRow[] = []
-  for (const chunk of chunkArray(normalizedProfileIds)) {
-    const { data, error } = await adminClient.from('profile').select('id, user_id').in('id', chunk)
-    if (error) throw new Error(`Failed to load gift-card profiles: ${error.message}`)
-    profiles.push(...((data ?? []) as ProfileRow[]))
-  }
-
-  const profilesByUserId = new Map<string, string[]>()
-  for (const profile of profiles) {
-    if (!profile.user_id) continue
-    const ids = profilesByUserId.get(profile.user_id) ?? []
-    ids.push(profile.id)
-    profilesByUserId.set(profile.user_id, ids)
-  }
-
-  const submissionsById = new Map<string, FormSubmissionRow>()
-  const loadSubmissions = async (column: 'profile_id' | 'user_id', ids: string[]) => {
-    for (const chunk of chunkArray(ids)) {
-      const { data, error } = await adminClient.from('form_submission').select('id, profile_id, user_id, submitted_at').in(column, chunk)
-      if (error) throw new Error(`Failed to load gift-card form submissions: ${error.message}`)
-      for (const row of (data ?? []) as FormSubmissionRow[]) submissionsById.set(row.id, row)
-    }
-  }
-  await loadSubmissions('profile_id', normalizedProfileIds)
-  await loadSubmissions('user_id', Array.from(profilesByUserId.keys()))
-
-  const latestValueByProfileId = new Map<string, { value: string; submittedAt: number }>()
-  for (const chunk of chunkArray(Array.from(submissionsById.keys()))) {
-    const { data, error } = await adminClient
-      .from('form_answer')
-      .select('submission_id, value')
-      .eq('question_code', 'gift_card_store_preference')
-      .in('submission_id', chunk)
-    if (error) throw new Error(`Failed to load gift-card preference answers: ${error.message}`)
-    for (const answer of (data ?? []) as FormAnswerRow[]) {
-      const submission = submissionsById.get(answer.submission_id)
-      const value = typeof answer.value === 'string' ? answer.value.trim() : ''
-      if (!submission || !value) continue
-      const associated = new Set<string>()
-      if (submission.profile_id && normalizedProfileIds.includes(submission.profile_id)) associated.add(submission.profile_id)
-      if (submission.user_id) for (const id of profilesByUserId.get(submission.user_id) ?? []) associated.add(id)
-      const submittedAt = Date.parse(submission.submitted_at ?? '') || 0
-      for (const profileId of associated) {
-        const prior = latestValueByProfileId.get(profileId)
-        if (!prior || submittedAt > prior.submittedAt) latestValueByProfileId.set(profileId, { value, submittedAt })
-      }
-    }
-  }
-
-  for (const profileId of normalizedProfileIds) {
-    providerByProfileId.set(profileId, providerFromDisplay(latestValueByProfileId.get(profileId)?.value))
-  }
-  return providerByProfileId
-}
-
-const loadFamilyIdByProfileId = async (profileIds: string[]) => {
-  const seen = new Set(profileIds)
-  const queue = [...seen]
-  const edges: FamilyEdgeRow[] = []
-  while (queue.length) {
-    const batch = queue.splice(0, QUERY_BATCH_SIZE)
-    const [guardians, children] = await Promise.all([
-      adminClient.from('person_guardian_child').select('guardian_profile_id, child_profile_id').in('guardian_profile_id', batch),
-      adminClient.from('person_guardian_child').select('guardian_profile_id, child_profile_id').in('child_profile_id', batch),
-    ])
-    if (guardians.error) throw new Error(`Failed to load family guardians: ${guardians.error.message}`)
-    if (children.error) throw new Error(`Failed to load family children: ${children.error.message}`)
-    for (const edge of [...(guardians.data ?? []), ...(children.data ?? [])] as FamilyEdgeRow[]) {
-      edges.push(edge)
-      for (const id of [edge.guardian_profile_id, edge.child_profile_id]) if (!seen.has(id)) {
-        seen.add(id)
-        queue.push(id)
-      }
-    }
-  }
-  const adjacent = new Map<string, Set<string>>()
-  for (const id of seen) adjacent.set(id, new Set())
-  for (const edge of edges) {
-    adjacent.get(edge.guardian_profile_id)?.add(edge.child_profile_id)
-    adjacent.get(edge.child_profile_id)?.add(edge.guardian_profile_id)
-  }
-  const familyByProfileId = new Map<string, string>()
-  for (const id of seen) {
-    if (familyByProfileId.has(id)) continue
-    const stack = [id]
-    const members: string[] = []
-    while (stack.length) {
-      const current = stack.pop() as string
-      if (familyByProfileId.has(current)) continue
-      familyByProfileId.set(current, id)
-      members.push(current)
-      for (const next of adjacent.get(current) ?? []) stack.push(next)
-    }
-    const familyId = members.sort((left, right) => left.localeCompare(right))[0]
-    for (const member of members) familyByProfileId.set(member, familyId)
-  }
-  return familyByProfileId
-}
-
 const loadAssetCounts = async (status: 'available' | 'used') => {
-  const counts = emptyProviderCounts()
+  const counts = emptyCounts()
   await Promise.all(providers.map(async provider => {
     const { count, error } = await adminClient
       .from('gift_card_asset')
@@ -266,59 +127,59 @@ const loadAssetCounts = async (status: 'available' | 'used') => {
 
 export const loadGiftCardAllocationForecastSnapshot = async (): Promise<GiftCardAllocationForecastSnapshot> => {
   const weeks = buildGiftCardWeekRanges()
-  const fullRange = { startsAt: weeks[0].startsAt, endsAt: weeks[2].endsAt }
-  const classes = await loadClasses(fullRange)
+  const classes = await loadClasses({ startsAt: weeks[0].startsAt, endsAt: weeks[2].endsAt })
   const classIds = classes.map(row => row.id)
   const workshopIds = unique(classes.map(row => row.workshop_id).filter((id): id is string => Boolean(id)))
   const [enrollments, attendanceRows, allocations, available, used] = await Promise.all([
-    loadEnrollments(workshopIds),
-    loadAttendance(classIds),
-    loadAllocations(classIds),
+    loadApprovedEnrollments(workshopIds),
+    loadRowsByClass<AttendanceRow>('class_attendance', 'class_id, profile_id, gift_card_blocked', classIds),
+    loadRowsByClass<AllocationRow>('gift_card_allocation', 'class_id, profile_id, asset:gift_card_asset_id(provider)', classIds),
     loadAssetCounts('available'),
     loadAssetCounts('used'),
   ])
-
   const approvedProfileIds = unique(enrollments.map(row => row.profile_id).filter((id): id is string => Boolean(id)))
-  const attendanceProfileIds = attendanceRows.map(row => row.profile_id).filter((id): id is string => Boolean(id))
-  const [providerByProfileId, familyByProfileId] = await Promise.all([
-    loadProviderByProfileId([...approvedProfileIds, ...attendanceProfileIds]),
-    loadFamilyIdByProfileId(approvedProfileIds),
-  ])
+  const { fulfillmentByProfileId, familyIdByProfileId } = await resolveGiftCardFulfillmentByProfileId(approvedProfileIds)
+  const profilesByWorkshop = new Map<string, string[]>()
+  for (const enrollment of enrollments) {
+    if (!enrollment.workshop_id || !enrollment.profile_id) continue
+    const profileIds = profilesByWorkshop.get(enrollment.workshop_id) ?? []
+    if (!profileIds.includes(enrollment.profile_id)) profileIds.push(enrollment.profile_id)
+    profilesByWorkshop.set(enrollment.workshop_id, profileIds)
+  }
 
-  const acceptedFamilies = emptyProviderCounts()
+  const acceptedFamilies = emptyCounts()
   for (const provider of providers) {
     const familyIds = new Set<string>()
     for (const profileId of approvedProfileIds) {
-      if (providerByProfileId.get(profileId) === provider) familyIds.add(familyByProfileId.get(profileId) ?? profileId)
+      if (fulfillmentByProfileId.get(profileId) === provider) familyIds.add(familyIdByProfileId.get(profileId) ?? profileId)
     }
     acceptedFamilies[provider] = familyIds.size
   }
 
+  const attendanceByPair = new Map<string, AttendanceRow>()
+  for (const attendance of attendanceRows) if (attendance.profile_id) attendanceByPair.set(allocationKey(attendance.class_id, attendance.profile_id), attendance)
+  const allocationByPair = new Map<string, AllocationRow>()
+  for (const allocation of allocations) if (allocation.profile_id) allocationByPair.set(allocationKey(allocation.class_id, allocation.profile_id), allocation)
+
   const snapshots = weeks.map(range => {
-    const classIdSet = new Set(
-      classes
-        .filter(row => row.starts_at >= range.startsAt && row.starts_at < range.endsAt)
-        .map(row => row.id)
-    )
-    const allocated = emptyProviderCounts()
-    const allocatedPairs = new Set<string>()
-    for (const allocation of allocations) {
-      if (!allocation.profile_id || !classIdSet.has(allocation.class_id)) continue
-      allocatedPairs.add(allocationKey(allocation.class_id, allocation.profile_id))
-      const asset = Array.isArray(allocation.asset) ? allocation.asset[0] : allocation.asset
-      if (asset?.provider === 'PC' || asset?.provider === 'Sobeys') allocated[asset.provider] += 1
+    const allocated = emptyCounts()
+    const stillNeeded = emptyCounts()
+    for (const classRow of classes) {
+      if (classRow.starts_at < range.startsAt || classRow.starts_at >= range.endsAt || !classRow.workshop_id) continue
+      for (const profileId of profilesByWorkshop.get(classRow.workshop_id) ?? []) {
+        const fulfillment = fulfillmentByProfileId.get(profileId)
+        if (fulfillment === 'meal_kit') continue
+        const provider = fulfillment === 'Sobeys' ? 'Sobeys' : 'PC'
+        const key = allocationKey(classRow.id, profileId)
+        if (allocationByPair.has(key)) {
+          allocated[provider] += 1
+          continue
+        }
+        if (attendanceByPair.get(key)?.gift_card_blocked) continue
+        stillNeeded[provider] += 1
+      }
     }
-    const stillNeeded: Record<GiftCardProvider, Set<string>> = { PC: new Set(), Sobeys: new Set() }
-    for (const attendance of attendanceRows) {
-      if (!attendance.profile_id || !classIdSet.has(attendance.class_id)) continue
-      if (attendance.state !== 'active' || attendance.gift_card_blocked) continue
-      if (attendance.camera_on !== true && attendance.photo_status !== 'accepted') continue
-      const key = allocationKey(attendance.class_id, attendance.profile_id)
-      if (allocatedPairs.has(key)) continue
-      const provider = providerByProfileId.get(attendance.profile_id)
-      if (provider) stillNeeded[provider].add(key)
-    }
-    return { ...range, allocated, stillNeeded: { PC: stillNeeded.PC.size, Sobeys: stillNeeded.Sobeys.size } }
+    return { ...range, allocated, stillNeeded }
   }) as [GiftCardWeekSnapshot, GiftCardWeekSnapshot, GiftCardWeekSnapshot]
 
   return { generatedAt: new Date().toISOString(), timezone: TORONTO_TIME_ZONE, available, acceptedFamilies, used, weeks: snapshots }

--- a/web/app/lib/gift-cards/provider.server.ts
+++ b/web/app/lib/gift-cards/provider.server.ts
@@ -1,0 +1,206 @@
+import { adminClient } from '@/lib/supabase/adminClient'
+
+const BATCH_SIZE = 100
+
+export type GiftCardProvider = 'PC' | 'Sobeys'
+export type GiftCardFulfillmentType = GiftCardProvider | 'meal_kit'
+
+type ProfileRow = {
+  id: string
+  user_id: string | null
+  role: string | null
+  federal_electoral_district_name: string | null
+}
+
+type FamilyEdgeRow = {
+  guardian_profile_id: string
+  child_profile_id: string
+  primary_child: boolean
+}
+
+type FormSubmissionRow = {
+  id: string
+  profile_id: string | null
+  user_id: string | null
+  submitted_at: string | null
+}
+
+type FormAnswerRow = {
+  submission_id: string
+  value: unknown
+}
+
+const chunkArray = <T,>(items: T[]) => {
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += BATCH_SIZE) chunks.push(items.slice(index, index + BATCH_SIZE))
+  return chunks
+}
+
+const addCandidate = (candidates: string[], profileId: string | null | undefined) => {
+  if (profileId && !candidates.includes(profileId)) candidates.push(profileId)
+}
+
+const fulfillmentFromAnswer = (value: string | undefined): GiftCardFulfillmentType => {
+  const normalized = (value ?? '').trim().toLowerCase()
+  const compact = normalized.replace(/[^a-z0-9]+/g, '')
+  if (compact.includes('mealkit') || normalized.includes('meal kit')) return 'meal_kit'
+  return compact.includes('sobeys') || normalized.includes('sobeys') || normalized.includes("sobey's") ? 'Sobeys' : 'PC'
+}
+
+export const resolveGiftCardFulfillmentByProfileId = async (profileIds: string[]) => {
+  const requestedProfileIds = Array.from(new Set(profileIds.filter(Boolean)))
+  const fulfillmentByProfileId = new Map<string, GiftCardFulfillmentType>()
+  const familyIdByProfileId = new Map<string, string>()
+  if (!requestedProfileIds.length) return { fulfillmentByProfileId, familyIdByProfileId }
+
+  const seen = new Set(requestedProfileIds)
+  const queue = [...seen]
+  const edges: FamilyEdgeRow[] = []
+  while (queue.length) {
+    const batch = queue.splice(0, BATCH_SIZE)
+    const { data, error } = await adminClient
+      .from('person_guardian_child')
+      .select('guardian_profile_id, child_profile_id, primary_child')
+      .or(`guardian_profile_id.in.(${batch.join(',')}),child_profile_id.in.(${batch.join(',')})`)
+    if (error) throw new Error(`Failed to load gift-card family relationships: ${error.message}`)
+    for (const edge of (data ?? []) as FamilyEdgeRow[]) {
+      edges.push(edge)
+      for (const profileId of [edge.guardian_profile_id, edge.child_profile_id]) {
+        if (!seen.has(profileId)) {
+          seen.add(profileId)
+          queue.push(profileId)
+        }
+      }
+    }
+  }
+
+  const profiles: ProfileRow[] = []
+  for (const chunk of chunkArray(Array.from(seen))) {
+    const { data, error } = await adminClient
+      .from('profile')
+      .select('id, user_id, role, federal_electoral_district_name')
+      .in('id', chunk)
+    if (error) throw new Error(`Failed to load gift-card profiles: ${error.message}`)
+    profiles.push(...((data ?? []) as ProfileRow[]))
+  }
+  const profileById = new Map(profiles.map(profile => [profile.id, profile]))
+
+  const childrenByGuardianId = new Map<string, Array<{ id: string; primary: boolean }>>()
+  const guardiansByChildId = new Map<string, Array<{ id: string; primary: boolean }>>()
+  const adjacent = new Map<string, Set<string>>()
+  for (const profileId of seen) adjacent.set(profileId, new Set())
+  for (const edge of edges) {
+    const childEntries = childrenByGuardianId.get(edge.guardian_profile_id) ?? []
+    childEntries.push({ id: edge.child_profile_id, primary: edge.primary_child })
+    childrenByGuardianId.set(edge.guardian_profile_id, childEntries)
+    const guardianEntries = guardiansByChildId.get(edge.child_profile_id) ?? []
+    guardianEntries.push({ id: edge.guardian_profile_id, primary: edge.primary_child })
+    guardiansByChildId.set(edge.child_profile_id, guardianEntries)
+    adjacent.get(edge.guardian_profile_id)?.add(edge.child_profile_id)
+    adjacent.get(edge.child_profile_id)?.add(edge.guardian_profile_id)
+  }
+  const preferredRelatedId = (entries: Array<{ id: string; primary: boolean }> | undefined) =>
+    [...(entries ?? [])].sort((left, right) => Number(right.primary) - Number(left.primary) || left.id.localeCompare(right.id))[0]?.id ?? null
+
+  const familyProfileIdsByProfileId = new Map<string, string[]>()
+  const visited = new Set<string>()
+  for (const profileId of seen) {
+    if (visited.has(profileId)) continue
+    const members: string[] = []
+    const stack = [profileId]
+    visited.add(profileId)
+    while (stack.length) {
+      const current = stack.pop() as string
+      members.push(current)
+      for (const next of adjacent.get(current) ?? []) {
+        if (!visited.has(next)) {
+          visited.add(next)
+          stack.push(next)
+        }
+      }
+    }
+    members.sort((left, right) => left.localeCompare(right))
+    for (const member of members) {
+      familyProfileIdsByProfileId.set(member, members)
+      familyIdByProfileId.set(member, members[0])
+    }
+  }
+
+  const profilesByUserId = new Map<string, string[]>()
+  for (const profile of profiles) {
+    if (!profile.user_id) continue
+    const ids = profilesByUserId.get(profile.user_id) ?? []
+    ids.push(profile.id)
+    profilesByUserId.set(profile.user_id, ids)
+  }
+
+  const submissionsById = new Map<string, FormSubmissionRow>()
+  const loadSubmissions = async (column: 'profile_id' | 'user_id', ids: string[]) => {
+    for (const chunk of chunkArray(ids)) {
+      const { data, error } = await adminClient
+        .from('form_submission')
+        .select('id, profile_id, user_id, submitted_at')
+        .in(column, chunk)
+      if (error) throw new Error(`Failed to load gift-card form submissions: ${error.message}`)
+      for (const row of (data ?? []) as FormSubmissionRow[]) submissionsById.set(row.id, row)
+    }
+  }
+  await loadSubmissions('profile_id', Array.from(seen))
+  await loadSubmissions('user_id', Array.from(profilesByUserId.keys()))
+
+  const latestPreferenceByProfileId = new Map<string, { value: string; submittedAt: number }>()
+  for (const chunk of chunkArray(Array.from(submissionsById.keys()))) {
+    const { data, error } = await adminClient
+      .from('form_answer')
+      .select('submission_id, value')
+      .eq('question_code', 'gift_card_store_preference')
+      .in('submission_id', chunk)
+    if (error) throw new Error(`Failed to load gift-card preference answers: ${error.message}`)
+    for (const answer of (data ?? []) as FormAnswerRow[]) {
+      const submission = submissionsById.get(answer.submission_id)
+      const value = typeof answer.value === 'string' ? answer.value.trim() : ''
+      if (!submission || !value) continue
+      const associatedProfileIds = new Set<string>()
+      if (submission.profile_id) associatedProfileIds.add(submission.profile_id)
+      if (submission.user_id) for (const profileId of profilesByUserId.get(submission.user_id) ?? []) associatedProfileIds.add(profileId)
+      const submittedAt = Date.parse(submission.submitted_at ?? '') || 0
+      for (const profileId of associatedProfileIds) {
+        const previous = latestPreferenceByProfileId.get(profileId)
+        if (!previous || submittedAt > previous.submittedAt) latestPreferenceByProfileId.set(profileId, { value, submittedAt })
+      }
+    }
+  }
+
+  const ridingNames = Array.from(new Set(profiles.map(profile => profile.federal_electoral_district_name?.trim()).filter(Boolean))) as string[]
+  const mealKitRidings = new Set<string>()
+  for (const chunk of chunkArray(ridingNames)) {
+    const { data, error } = await adminClient.from('federal_electoral_district').select('name, meal_kit').in('name', chunk)
+    if (error) throw new Error(`Failed to load meal-kit ridings: ${error.message}`)
+    for (const riding of data ?? []) if (riding.meal_kit) mealKitRidings.add(riding.name)
+  }
+
+  for (const profileId of requestedProfileIds) {
+    const profile = profileById.get(profileId)
+    const studentId = profile?.role === 'student' ? profileId : preferredRelatedId(childrenByGuardianId.get(profileId)) ?? profileId
+    const parentId = preferredRelatedId(guardiansByChildId.get(studentId)) ?? (profile?.role === 'guardian' ? profileId : null)
+    const candidates: string[] = []
+    addCandidate(candidates, studentId)
+    addCandidate(candidates, parentId)
+    for (const familyProfileId of familyProfileIdsByProfileId.get(profileId) ?? []) addCandidate(candidates, familyProfileId)
+    for (const candidateId of [...candidates]) {
+      for (const sameUserProfileId of profilesByUserId.get(profileById.get(candidateId)?.user_id ?? '') ?? []) {
+        addCandidate(candidates, sameUserProfileId)
+      }
+    }
+    addCandidate(candidates, profileId)
+
+    if (candidates.some(candidateId => mealKitRidings.has(profileById.get(candidateId)?.federal_electoral_district_name?.trim() ?? ''))) {
+      fulfillmentByProfileId.set(profileId, 'meal_kit')
+      continue
+    }
+    const preference = candidates.map(candidateId => latestPreferenceByProfileId.get(candidateId)?.value).find(Boolean)
+    fulfillmentByProfileId.set(profileId, fulfillmentFromAnswer(preference))
+  }
+
+  return { fulfillmentByProfileId, familyIdByProfileId }
+}

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -5,6 +5,7 @@ import {
   resolveGiftCardShortfallForProvider,
 } from '@/lib/gift-cards/inventory-alerts'
 import { loadGiftCardAllocationForecastSnapshot, type GiftCardProvider } from '@/lib/gift-cards/forecast.server'
+import { resolveGiftCardFulfillmentByProfileId } from '@/lib/gift-cards/provider.server'
 import {
   eligibleAfterIso,
   isEligibilityTimingEnabled,
@@ -15,7 +16,6 @@ import {
 } from '@/lib/gift-cards/release.server'
 import { scanByIdKeyset } from '@/lib/supabase/keyset-pagination.server'
 import { adminClient } from '@/lib/supabase/adminClient'
-import { loadWorkshopEnrollmentEnrichment } from '@/routes/manage/workshop-enrollment-enrichment.server'
 
 import { hashGlrToken, newGlrToken } from './token.server'
 
@@ -376,11 +376,8 @@ const sendMealKitPickupReminders = async () => {
     }
   }
 
-  const enrichment = await loadWorkshopEnrollmentEnrichment(profileIds)
-  const mealKitProfileIds = profileIds.filter(profileId => {
-    const value = (enrichment[profileId]?.giftcard_display ?? '').trim().toLowerCase()
-    return value === 'meal kit'
-  })
+  const { fulfillmentByProfileId } = await resolveGiftCardFulfillmentByProfileId(profileIds)
+  const mealKitProfileIds = profileIds.filter(profileId => fulfillmentByProfileId.get(profileId) === 'meal_kit')
 
   if (!mealKitProfileIds.length) {
     return {
@@ -577,21 +574,6 @@ const resolveRecipientEmail = async (profileId: string, fallbackEmail: string | 
   return ''
 }
 
-const requestedProviderFromDisplay = (value: string | null | undefined) => {
-  const normalized = (value ?? '').trim().toLowerCase()
-  if (!normalized) return null
-
-  const compact = normalized.replace(/[^a-z0-9]+/g, '')
-  if (compact.includes('mealkit')) return 'meal_kit'
-  if (compact.includes('sobeys')) return 'Sobeys'
-  if (compact.includes('pc') || compact.includes('presidentschoice')) return 'PC'
-
-  if (normalized.includes('meal kit')) return 'meal_kit'
-  if (normalized.includes('sobeys') || normalized.includes("sobey's")) return 'Sobeys'
-  if (normalized.includes('pc') || normalized.includes('president')) return 'PC'
-  return null
-}
-
 const emptyScanCounters = (): GiftCardScanCounters => ({
   pagesRead: 0,
   rowsScanned: 0,
@@ -676,10 +658,9 @@ const allocateGiftCards = async (): Promise<AllocationSummary> => {
     const uncachedProfileIds = profileIds.filter(profileId => !requestedProviderByProfileId.has(profileId))
     if (uncachedProfileIds.length) {
       try {
-        const enrichment = await loadWorkshopEnrollmentEnrichment(uncachedProfileIds)
+        const { fulfillmentByProfileId } = await resolveGiftCardFulfillmentByProfileId(uncachedProfileIds)
         for (const profileId of uncachedProfileIds) {
-          const display = enrichment[profileId]?.giftcard_display
-          requestedProviderByProfileId.set(profileId, requestedProviderFromDisplay(display))
+          requestedProviderByProfileId.set(profileId, fulfillmentByProfileId.get(profileId) ?? 'PC')
         }
       } catch (error) {
         console.warn('[gift-cards] provider preference enrichment failed', {


### PR DESCRIPTION
## Summary
- calculate weekly card demand from approved enrollment/class pairs instead of only qualified attendance
- share family-aware provider and Meal Kit resolution between forecasts, allocation, and reminders
- make weekly allocations and still-needed counts reconcile against the same demand set

## Verification
- npm run typecheck
- npm run test -- tests/unit
- verified local aggregate demand against approved enrollment and allocation records