### PR TITLE
Add riding and participant status to form answers

### DIFF
--- a/web/app/lib/participant-status.ts
+++ b/web/app/lib/participant-status.ts
@@ -1,0 +1,8 @@
+export const participantStatusFromAnswer = (value: unknown) => {
+  if (typeof value !== 'string') return 'N/A'
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return 'N/A'
+  if (normalized === 'no' || normalized.startsWith('no -')) return 'New'
+  if (normalized === 'yes' || normalized.startsWith('yes -')) return 'Returning'
+  return 'N/A'
+}

--- a/web/app/routes/manage/form.$id.answers.tsx
+++ b/web/app/routes/manage/form.$id.answers.tsx
@@ -9,6 +9,7 @@ import { requireAuth } from '@/lib/auth.server'
 import type { Json } from '@/lib/database.types'
 import { EXPORT_TYPE_FORM_ID_ANSWERS_CSV } from '@/lib/exports/types'
 import { resolveConnectedProfileIds } from '@/lib/family.server'
+import { participantStatusFromAnswer } from '@/lib/participant-status'
 import { isRoleAtLeast } from '@/lib/roles'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { createClient } from '@/lib/supabase/server'
@@ -31,6 +32,7 @@ type LoaderData = {
 const ANSWER_BATCH_SIZE = 200
 const ANSWER_PAGE_SIZE = 1000
 const PROFILE_FILTER_BATCH_SIZE = 100
+const PRIOR_PARTICIPATION_QUESTION_CODES = ['onboarding_prior_participation', 'child_prior_participation'] as const
 
 type SubmissionRow = {
   id: string
@@ -52,6 +54,11 @@ type SubmissionRow = {
     | null
 }
 
+type DerivedProfileValues = {
+  riding_display: string
+  participant_status_display: string
+}
+
 const chunkArray = <T,>(items: T[], size: number): T[][] => {
   if (size <= 0 || !items.length) return []
   const chunks: T[][] = []
@@ -70,6 +77,77 @@ const toAnswerDisplayValue = (value: unknown) => {
   }
   if (value === null || typeof value === 'undefined') return ''
   return JSON.stringify(value as Json)
+}
+
+const loadDerivedProfileValues = async (profileIds: string[]) => {
+  const valuesByProfileId: Record<string, DerivedProfileValues> = {}
+  const normalizedProfileIds = Array.from(new Set(profileIds.filter(Boolean)))
+  if (!normalizedProfileIds.length) return valuesByProfileId
+
+  for (const profileIdChunk of chunkArray(normalizedProfileIds, PROFILE_FILTER_BATCH_SIZE)) {
+    const { data, error } = await adminClient
+      .from('profile')
+      .select('id, federal_electoral_district_name')
+      .in('id', profileIdChunk)
+
+    if (error) throw new Error(error.message)
+    for (const profile of data ?? []) {
+      valuesByProfileId[profile.id] = {
+        riding_display: profile.federal_electoral_district_name?.trim() || 'Not looked up',
+        participant_status_display: 'N/A',
+      }
+    }
+  }
+
+  const submissionsById = new Map<string, { profileId: string; submittedAt: number }>()
+  for (const profileIdChunk of chunkArray(normalizedProfileIds, PROFILE_FILTER_BATCH_SIZE)) {
+    for (let from = 0; ; from += ANSWER_PAGE_SIZE) {
+      const { data, error } = await adminClient
+        .from('form_submission')
+        .select('id, profile_id, submitted_at')
+        .in('profile_id', profileIdChunk)
+        .order('submitted_at', { ascending: false })
+        .range(from, from + ANSWER_PAGE_SIZE - 1)
+
+      if (error) throw new Error(error.message)
+      const pageRows = data ?? []
+      for (const submission of pageRows) {
+        if (!submission.profile_id) continue
+        submissionsById.set(submission.id, {
+          profileId: submission.profile_id,
+          submittedAt: Date.parse(submission.submitted_at) || 0,
+        })
+      }
+      if (pageRows.length < ANSWER_PAGE_SIZE) break
+    }
+  }
+
+  const latestStatusByProfileId = new Map<string, { status: string; submittedAt: number }>()
+  for (const submissionIdChunk of chunkArray(Array.from(submissionsById.keys()), ANSWER_BATCH_SIZE)) {
+    const { data, error } = await adminClient
+      .from('form_answer')
+      .select('submission_id, value')
+      .in('submission_id', submissionIdChunk)
+      .in('question_code', PRIOR_PARTICIPATION_QUESTION_CODES)
+
+    if (error) throw new Error(error.message)
+    for (const answer of data ?? []) {
+      const submission = submissionsById.get(answer.submission_id)
+      const status = participantStatusFromAnswer(answer.value)
+      if (!submission || status === 'N/A') continue
+      const existing = latestStatusByProfileId.get(submission.profileId)
+      if (!existing || submission.submittedAt > existing.submittedAt) {
+        latestStatusByProfileId.set(submission.profileId, { status, submittedAt: submission.submittedAt })
+      }
+    }
+  }
+
+  for (const [profileId, status] of latestStatusByProfileId) {
+    const values = valuesByProfileId[profileId]
+    if (values) values.participant_status_display = status.status
+  }
+
+  return valuesByProfileId
 }
 
 const safeReturnTo = (input: string | null) => {
@@ -136,13 +214,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const returnTo = safeReturnTo(url.searchParams.get('returnTo'))
   if (!deferTable) {
     return {
-      columns: ['profile_display', 'submitted_at'],
+      columns: ['profile_display', 'riding_display', 'participant_status_display', 'submitted_at'],
       rows: [],
       label,
       tableName: 'form-answers',
       tableVariant: 'pivot',
       columnMeta: {
         profile_display: { label: 'Profile', truncate: true },
+        riding_display: { label: 'Riding', filterable: true },
+        participant_status_display: { label: 'Participant status', filterable: true },
         submitted_at: { label: 'Timestamp', truncate: false },
       },
       form: {
@@ -247,6 +327,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return acc
   }, {})
 
+  const derivedValuesByProfileId = await loadDerivedProfileValues(submissionRows.map(row => row.profile_id))
+
   const rows = submissionRows.map(row => {
     const profile = Array.isArray(row.profile) ? row.profile[0] : row.profile
     const profileLabel =
@@ -258,14 +340,20 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return {
       profile_display: profileLabel,
       profile_id: row.profile_id,
+      ...(derivedValuesByProfileId[row.profile_id] ?? {
+        riding_display: 'Not looked up',
+        participant_status_display: 'N/A',
+      }),
       submitted_at: row.submitted_at,
       ...Object.fromEntries(answerColumns.map(code => [code, values[code] ?? ''])),
     }
   })
 
-  const columns = ['profile_display', 'submitted_at', ...answerColumns]
+  const columns = ['profile_display', 'riding_display', 'participant_status_display', 'submitted_at', ...answerColumns]
   const columnMeta: LoaderData['columnMeta'] = {
     profile_display: { label: 'Profile', truncate: true },
+    riding_display: { label: 'Riding', filterable: true },
+    participant_status_display: { label: 'Participant status', filterable: true },
     submitted_at: { label: 'Timestamp', truncate: false },
   }
   for (const code of answerColumns) {
@@ -309,13 +397,15 @@ export default function ManageFormAnswersPage() {
     <DeferredTableDisplay
       dataPath={`/manage/form/${form.id}/answers/table-data`}
       fallbackData={{
-        columns: ['profile_display', 'submitted_at'],
+        columns: ['profile_display', 'riding_display', 'participant_status_display', 'submitted_at'],
         rows: [],
         label: `${form.name} answers${audience === 'approved-families' ? ' - accepted families' : ''}`,
         tableName: 'form-answers',
         tableVariant: 'pivot',
         columnMeta: {
           profile_display: { label: 'Profile', truncate: true },
+          riding_display: { label: 'Riding', filterable: true },
+          participant_status_display: { label: 'Participant status', filterable: true },
           submitted_at: { label: 'Timestamp', truncate: false },
         },
       }}

--- a/web/tests/unit/participant-status.spec.ts
+++ b/web/tests/unit/participant-status.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test'
+
+import { participantStatusFromAnswer } from '../../app/lib/participant-status'
+
+test('classifies prior participation answers', () => {
+  expect(participantStatusFromAnswer('No')).toBe('New')
+  expect(participantStatusFromAnswer('No - this is their 1st summer')).toBe('New')
+  expect(participantStatusFromAnswer('Yes')).toBe('Returning')
+  expect(participantStatusFromAnswer('Yes - this is their 3rd summer')).toBe('Returning')
+  expect(participantStatusFromAnswer('Unknown')).toBe('N/A')
+})


### PR DESCRIPTION
## Summary
- add riding and participant status columns to managed form answers
- include the derived fields in CSV exports through the shared snapshot loader
- classify existing prior-participation answers as New or Returning

## Verification
- npm run typecheck
- npm run test -- tests/unit/participant-status.spec.ts