### PR TITLE
Add post-program survey campaigns

### DIFF
--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -2,7 +2,7 @@ IMAGE_NAME ?= summerlunchplus-scheduler-local
 CONTAINER_NAME ?= summerlunchplus-scheduler-cron
 ENV_FILE ?= .env.local
 
-.PHONY: check-env build cron cron-bg down logs status smoke-zoom smoke-gift-card smoke-export smoke-cleanup smoke-all
+.PHONY: check-env build cron cron-bg down logs status smoke-zoom smoke-gift-card smoke-post-program-survey smoke-export smoke-cleanup smoke-all
 
 check-env:
 	@test -f "$(ENV_FILE)" || (echo "Missing $(ENV_FILE). Create it from .env.template." && exit 1)
@@ -32,10 +32,13 @@ smoke-zoom: build
 smoke-gift-card: build
 	docker run --rm --env-file $(ENV_FILE) $(IMAGE_NAME) /bin/bash /app/scripts/gift-card-jobs.sh
 
+smoke-post-program-survey: build
+	docker run --rm --env-file $(ENV_FILE) $(IMAGE_NAME) /bin/bash /app/scripts/post-program-survey-jobs.sh
+
 smoke-export: build
 	docker run --rm --env-file $(ENV_FILE) $(IMAGE_NAME) /bin/bash /app/scripts/export-jobs.sh
 
 smoke-cleanup: build
 	docker run --rm --env-file $(ENV_FILE) $(IMAGE_NAME) /bin/bash /app/scripts/export-cleanup.sh
 
-smoke-all: smoke-zoom smoke-gift-card smoke-export smoke-cleanup
+smoke-all: smoke-zoom smoke-gift-card smoke-post-program-survey smoke-export smoke-cleanup

--- a/scheduler/crontab
+++ b/scheduler/crontab
@@ -1,5 +1,6 @@
 */5 * * * * /bin/bash /app/scripts/zoom-jobs.sh
 */5 * * * * /bin/bash /app/scripts/gift-card-jobs.sh
+*/5 * * * * /bin/bash /app/scripts/post-program-survey-jobs.sh
 0 9,21 * * * /bin/bash /app/scripts/gift-card-inventory-alerts.sh
 */5 * * * * /bin/bash /app/scripts/export-jobs.sh
 5 * * * * /bin/bash /app/scripts/export-cleanup.sh

--- a/scheduler/scripts/post-program-survey-jobs.sh
+++ b/scheduler/scripts/post-program-survey-jobs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+require_env APP_BASE_URL
+require_env INTERNAL_RUNNER_SECRET
+
+RID="$(run_id)-post-program-survey"
+TARGET_URL="${APP_BASE_URL%/}/internal/post-program-survey-jobs/run"
+
+printf '[scheduler] starting post-program survey jobs run_id=%s target=%s\n' "$RID" "$TARGET_URL"
+RESPONSE="$(post_json "$TARGET_URL" "x-internal-runner-secret" "$INTERNAL_RUNNER_SECRET" "$RID")"
+printf '[scheduler] post-program survey jobs completed run_id=%s response=%s\n' "$RID" "$RESPONSE"

--- a/supabase/migrations/20260813165744_add_post_program_survey_permission.sql
+++ b/supabase/migrations/20260813165744_add_post_program_survey_permission.sql
@@ -1,0 +1,1 @@
+alter type public.app_permissions add value if not exists 'post_program_survey.manage';

--- a/supabase/migrations/20260813165745_post_program_survey_campaigns.sql
+++ b/supabase/migrations/20260813165745_post_program_survey_campaigns.sql
@@ -1,0 +1,770 @@
+/*
+create type "public"."app_permissions" as enum ('site.read', 'form.create', 'form.read', 'form.update', 'form.delete', 'form_question.create', 'form_question.read', 'form_question.update', 'form_question.delete', 'form_question_map.create', 'form_question_map.read', 'form_question_map.update', 'form_question_map.delete', 'form_assignment.create', 'form_assignment.read', 'form_assignment.update', 'form_assignment.delete', 'form_submission.create', 'form_submission.read', 'form_submission.update', 'form_submission.delete', 'form_answer.create', 'form_answer.read', 'form_answer.update', 'form_answer.delete', 'semester.create', 'semester.read', 'semester.update', 'semester.delete', 'workshop.create', 'workshop.read', 'workshop.update', 'workshop.delete', 'workshop_enrollment.create', 'workshop_enrollment.read', 'workshop_enrollment.update', 'workshop_enrollment.update_status', 'class_attendance.create', 'class_attendance.read', 'class_attendance.update', 'class_attendance.delete', 'user_roles.manage', 'role_permission.manage', 'profiles.read', 'profiles.update', 'zoom_host.create', 'zoom_host.read', 'zoom_host.update', 'zoom_host.delete', 'class_zoom_meeting.create', 'class_zoom_meeting.read', 'class_zoom_meeting.update', 'class_zoom_meeting.delete', 'class_zoom_registrant.create', 'class_zoom_registrant.read', 'class_zoom_registrant.update', 'class_zoom_registrant.delete', 'class_zoom_participant_sync.create', 'class_zoom_participant_sync.read', 'class_zoom_participant_sync.update', 'class_zoom_participant_sync.delete', 'class_zoom_participant.create', 'class_zoom_participant.read', 'class_zoom_participant.update', 'class_zoom_participant.delete', 'zlr_click_event.create', 'zlr_click_event.read', 'zlr_click_event.update', 'zlr_click_event.delete', 'class_attendance_photo.create', 'class_attendance_photo.read', 'class_attendance_photo.update', 'class_attendance_photo.delete', 'class_attendance_photo_upload_attempt.create', 'class_attendance_photo_upload_attempt.read', 'class_attendance_photo_upload_attempt.update', 'class_attendance_photo_upload_attempt.delete', 'post_program_survey.manage');
+
+
+*/
+  create table "public"."post_program_survey_campaign" (
+    "id" uuid not null default gen_random_uuid(),
+    "semester_id" uuid not null,
+    "form_id" uuid not null,
+    "family_anchor_profile_id" uuid not null,
+    "survey_profile_id" uuid not null,
+    "available_at" timestamp with time zone not null,
+    "initial_sent_at" timestamp with time zone,
+    "last_normal_reminder_on" date,
+    "completed_at" timestamp with time zone,
+    "completed_submission_id" uuid,
+    "manually_completed_at" timestamp with time zone,
+    "manually_completed_by_user_id" uuid,
+    "manual_completion_reason" text,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."post_program_survey_campaign" enable row level security;
+
+
+  create table "public"."post_program_survey_campaign_audit" (
+    "id" uuid not null default gen_random_uuid(),
+    "campaign_id" uuid not null,
+    "event_type" text not null,
+    "actor_user_id" uuid,
+    "actor_role" text,
+    "source" text not null,
+    "details" jsonb not null default '{}'::jsonb,
+    "created_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."post_program_survey_campaign_audit" enable row level security;
+
+
+  create table "public"."post_program_survey_campaign_enrollment" (
+    "campaign_id" uuid not null,
+    "workshop_enrollment_id" uuid not null,
+    "gift_card_notice_sent_at" timestamp with time zone,
+    "created_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."post_program_survey_campaign_enrollment" enable row level security;
+
+
+  create table "public"."post_program_survey_campaign_member" (
+    "campaign_id" uuid not null,
+    "profile_id" uuid not null,
+    "created_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."post_program_survey_campaign_member" enable row level security;
+
+CREATE INDEX post_program_survey_campaign_audit_campaign_created_idx ON public.post_program_survey_campaign_audit USING btree (campaign_id, created_at DESC);
+
+CREATE UNIQUE INDEX post_program_survey_campaign_audit_pkey ON public.post_program_survey_campaign_audit USING btree (id);
+
+CREATE UNIQUE INDEX post_program_survey_campaign_completed_submission_id_key ON public.post_program_survey_campaign USING btree (completed_submission_id);
+
+CREATE UNIQUE INDEX post_program_survey_campaign_enrollm_workshop_enrollment_id_key ON public.post_program_survey_campaign_enrollment USING btree (workshop_enrollment_id);
+
+CREATE INDEX post_program_survey_campaign_enrollment_campaign_idx ON public.post_program_survey_campaign_enrollment USING btree (campaign_id);
+
+CREATE UNIQUE INDEX post_program_survey_campaign_enrollment_pkey ON public.post_program_survey_campaign_enrollment USING btree (campaign_id, workshop_enrollment_id);
+
+CREATE UNIQUE INDEX post_program_survey_campaign_member_pkey ON public.post_program_survey_campaign_member USING btree (campaign_id, profile_id);
+
+CREATE INDEX post_program_survey_campaign_member_profile_idx ON public.post_program_survey_campaign_member USING btree (profile_id, campaign_id);
+
+CREATE INDEX post_program_survey_campaign_open_idx ON public.post_program_survey_campaign USING btree (available_at, id) WHERE (completed_at IS NULL);
+
+CREATE UNIQUE INDEX post_program_survey_campaign_pkey ON public.post_program_survey_campaign USING btree (id);
+
+CREATE UNIQUE INDEX post_program_survey_campaign_semester_id_family_anchor_prof_key ON public.post_program_survey_campaign USING btree (semester_id, family_anchor_profile_id);
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_pkey" PRIMARY KEY using index "post_program_survey_campaign_pkey";
+
+alter table "public"."post_program_survey_campaign_audit" add constraint "post_program_survey_campaign_audit_pkey" PRIMARY KEY using index "post_program_survey_campaign_audit_pkey";
+
+alter table "public"."post_program_survey_campaign_enrollment" add constraint "post_program_survey_campaign_enrollment_pkey" PRIMARY KEY using index "post_program_survey_campaign_enrollment_pkey";
+
+alter table "public"."post_program_survey_campaign_member" add constraint "post_program_survey_campaign_member_pkey" PRIMARY KEY using index "post_program_survey_campaign_member_pkey";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_check" CHECK ((((completed_submission_id IS NULL) AND (manually_completed_at IS NULL)) OR ((completed_submission_id IS NOT NULL) AND (manually_completed_at IS NULL)) OR ((completed_submission_id IS NULL) AND (manually_completed_at IS NOT NULL) AND (manually_completed_by_user_id IS NOT NULL) AND (NULLIF(btrim(manual_completion_reason), ''::text) IS NOT NULL)))) not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_check";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_check1" CHECK (((completed_at IS NULL) OR (completed_submission_id IS NOT NULL) OR (manually_completed_at IS NOT NULL))) not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_check1";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_completed_submission_id_fkey" FOREIGN KEY (completed_submission_id) REFERENCES public.form_submission(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_completed_submission_id_fkey";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_completed_submission_id_key" UNIQUE using index "post_program_survey_campaign_completed_submission_id_key";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_family_anchor_profile_id_fkey" FOREIGN KEY (family_anchor_profile_id) REFERENCES public.profile(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_family_anchor_profile_id_fkey";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_form_id_fkey" FOREIGN KEY (form_id) REFERENCES public.form(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_form_id_fkey";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_manually_completed_by_user_id_fkey" FOREIGN KEY (manually_completed_by_user_id) REFERENCES auth.users(id) ON DELETE SET NULL not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_manually_completed_by_user_id_fkey";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_semester_id_family_anchor_prof_key" UNIQUE using index "post_program_survey_campaign_semester_id_family_anchor_prof_key";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_semester_id_fkey" FOREIGN KEY (semester_id) REFERENCES public.semester(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_semester_id_fkey";
+
+alter table "public"."post_program_survey_campaign" add constraint "post_program_survey_campaign_survey_profile_id_fkey" FOREIGN KEY (survey_profile_id) REFERENCES public.profile(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign" validate constraint "post_program_survey_campaign_survey_profile_id_fkey";
+
+alter table "public"."post_program_survey_campaign_audit" add constraint "post_program_survey_campaign_audit_actor_user_id_fkey" FOREIGN KEY (actor_user_id) REFERENCES auth.users(id) ON DELETE SET NULL not valid;
+
+alter table "public"."post_program_survey_campaign_audit" validate constraint "post_program_survey_campaign_audit_actor_user_id_fkey";
+
+alter table "public"."post_program_survey_campaign_audit" add constraint "post_program_survey_campaign_audit_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES public.post_program_survey_campaign(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign_audit" validate constraint "post_program_survey_campaign_audit_campaign_id_fkey";
+
+alter table "public"."post_program_survey_campaign_audit" add constraint "post_program_survey_campaign_audit_event_type_check" CHECK ((event_type = ANY (ARRAY['created'::text, 'completed_submission'::text, 'completed_manual'::text]))) not valid;
+
+alter table "public"."post_program_survey_campaign_audit" validate constraint "post_program_survey_campaign_audit_event_type_check";
+
+alter table "public"."post_program_survey_campaign_audit" add constraint "post_program_survey_campaign_audit_source_check" CHECK ((source = ANY (ARRAY['user'::text, 'staff'::text, 'automation'::text]))) not valid;
+
+alter table "public"."post_program_survey_campaign_audit" validate constraint "post_program_survey_campaign_audit_source_check";
+
+alter table "public"."post_program_survey_campaign_enrollment" add constraint "post_program_survey_campaign_enroll_workshop_enrollment_id_fkey" FOREIGN KEY (workshop_enrollment_id) REFERENCES public.workshop_enrollment(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign_enrollment" validate constraint "post_program_survey_campaign_enroll_workshop_enrollment_id_fkey";
+
+alter table "public"."post_program_survey_campaign_enrollment" add constraint "post_program_survey_campaign_enrollm_workshop_enrollment_id_key" UNIQUE using index "post_program_survey_campaign_enrollm_workshop_enrollment_id_key";
+
+alter table "public"."post_program_survey_campaign_enrollment" add constraint "post_program_survey_campaign_enrollment_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES public.post_program_survey_campaign(id) ON DELETE CASCADE not valid;
+
+alter table "public"."post_program_survey_campaign_enrollment" validate constraint "post_program_survey_campaign_enrollment_campaign_id_fkey";
+
+alter table "public"."post_program_survey_campaign_member" add constraint "post_program_survey_campaign_member_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES public.post_program_survey_campaign(id) ON DELETE CASCADE not valid;
+
+alter table "public"."post_program_survey_campaign_member" validate constraint "post_program_survey_campaign_member_campaign_id_fkey";
+
+alter table "public"."post_program_survey_campaign_member" add constraint "post_program_survey_campaign_member_profile_id_fkey" FOREIGN KEY (profile_id) REFERENCES public.profile(id) ON DELETE RESTRICT not valid;
+
+alter table "public"."post_program_survey_campaign_member" validate constraint "post_program_survey_campaign_member_profile_id_fkey";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.complete_post_program_survey_campaign(p_campaign_id uuid, p_answers jsonb, p_request_metadata jsonb DEFAULT '{}'::jsonb)
+ RETURNS TABLE(campaign_id uuid, completed boolean, submission_id uuid, completed_at timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_campaign public.post_program_survey_campaign%rowtype;
+  v_actor_profile_id uuid;
+  v_submission_id uuid;
+  v_question record;
+  v_value jsonb;
+  v_option text;
+begin
+  if jsonb_typeof(p_answers) <> 'object' then
+    raise exception 'Answers must be an object';
+  end if;
+
+  select *
+    into v_campaign
+  from public.post_program_survey_campaign
+  where id = p_campaign_id
+  for update;
+
+  if not found then
+    raise exception 'Campaign not found';
+  end if;
+
+  v_actor_profile_id := public.current_profile_id();
+  if v_actor_profile_id is null
+     or not exists (
+       select 1
+       from public.post_program_survey_campaign_member as member
+       where member.campaign_id = v_campaign.id
+         and member.profile_id = v_actor_profile_id
+     ) then
+    raise exception 'Campaign access denied';
+  end if;
+
+  if v_campaign.completed_at is not null then
+    return query select v_campaign.id, true, v_campaign.completed_submission_id, v_campaign.completed_at;
+    return;
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_object_keys(p_answers) as answer(question_code)
+    where not exists (
+      select 1
+      from public.form_question_map as map
+      where map.form_id = v_campaign.form_id
+        and map.question_code = answer.question_code
+    )
+  ) then
+    raise exception 'Answers contain an unknown question';
+  end if;
+
+  for v_question in
+    select
+      map.question_code,
+      coalesce(map.options_override, question.options) as options,
+      question.type,
+      coalesce((map.metadata ->> 'optional')::boolean, false) as optional
+    from public.form_question_map as map
+    join public.form_question as question on question.question_code = map.question_code
+    where map.form_id = v_campaign.form_id
+    order by map.position
+  loop
+    v_value := p_answers -> v_question.question_code;
+
+    if not v_question.optional
+       and v_question.type <> 'no-input-text'
+       and (
+         v_value is null
+         or v_value = 'null'::jsonb
+         or (jsonb_typeof(v_value) = 'string' and btrim(v_value #>> '{}') = '')
+         or (jsonb_typeof(v_value) = 'array' and jsonb_array_length(v_value) = 0)
+       ) then
+      raise exception 'Question % is required', v_question.question_code;
+    end if;
+
+    if v_value is null or v_value = 'null'::jsonb then
+      continue;
+    end if;
+
+    if v_question.type in ('text', 'date', 'address', 'agreement') and jsonb_typeof(v_value) <> 'string' then
+      raise exception 'Question % requires a string answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'number' and jsonb_typeof(v_value) <> 'number' then
+      raise exception 'Question % requires a numeric answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'checkbox' and jsonb_typeof(v_value) <> 'boolean' then
+      raise exception 'Question % requires a boolean answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'single_choice' then
+      if jsonb_typeof(v_value) <> 'string'
+         or not (v_question.options @> jsonb_build_array(v_value)) then
+        raise exception 'Question % has an invalid option', v_question.question_code;
+      end if;
+    end if;
+
+    if v_question.type = 'multi_choice' then
+      if jsonb_typeof(v_value) <> 'array' then
+        raise exception 'Question % requires an array answer', v_question.question_code;
+      end if;
+
+      for v_option in select jsonb_array_elements_text(v_value)
+      loop
+        if not (v_question.options @> jsonb_build_array(to_jsonb(v_option))) then
+          raise exception 'Question % has an invalid option', v_question.question_code;
+        end if;
+      end loop;
+    end if;
+  end loop;
+
+  insert into public.form_submission (
+    form_id,
+    profile_id,
+    user_id,
+    metadata
+  )
+  values (
+    v_campaign.form_id,
+    v_campaign.survey_profile_id,
+    auth.uid(),
+    jsonb_build_object(
+      'source', 'semester_post_program_survey',
+      'campaign_id', v_campaign.id,
+      'respondent_profile_id', v_actor_profile_id,
+      'request', p_request_metadata
+    )
+  )
+  returning id into v_submission_id;
+
+  insert into public.form_answer (submission_id, question_code, value)
+  select v_submission_id, answer.question_code, answer.value
+  from jsonb_each(p_answers) as answer(question_code, value)
+  join public.form_question_map as map
+    on map.form_id = v_campaign.form_id
+   and map.question_code = answer.question_code
+  where answer.value <> 'null'::jsonb;
+
+  update public.post_program_survey_campaign
+  set completed_submission_id = v_submission_id,
+      completed_at = now()
+  where id = v_campaign.id
+  returning completed_at into completed_at;
+
+  insert into public.post_program_survey_campaign_audit (
+    campaign_id,
+    event_type,
+    actor_user_id,
+    source,
+    details
+  )
+  values (
+    v_campaign.id,
+    'completed_submission',
+    auth.uid(),
+    'user',
+    jsonb_build_object('submission_id', v_submission_id, 'respondent_profile_id', v_actor_profile_id)
+  );
+
+  return query select v_campaign.id, true, v_submission_id, completed_at;
+end;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.ensure_post_program_survey_campaign(p_semester_id uuid, p_form_id uuid, p_family_anchor_profile_id uuid, p_survey_profile_id uuid, p_member_profile_ids uuid[], p_workshop_enrollment_ids uuid[], p_available_at timestamp with time zone)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_campaign_id uuid;
+  v_active_form_id uuid;
+  v_member_count integer;
+  v_enrollment_count integer;
+begin
+  if coalesce(array_length(p_member_profile_ids, 1), 0) = 0 then
+    raise exception 'Campaign members are required';
+  end if;
+
+  if coalesce(array_length(p_workshop_enrollment_ids, 1), 0) = 0 then
+    raise exception 'Campaign enrollments are required';
+  end if;
+
+  select requirement.form_id
+    into v_active_form_id
+  from public.semester_form_requirement as requirement
+  where requirement.semester_id = p_semester_id
+    and requirement.form_id = p_form_id
+    and requirement.is_active = true
+    and requirement.kind::text in ('post_survey', 'post_program_survey')
+  limit 1;
+
+  if v_active_form_id is null then
+    raise exception 'Form % is not the active post-program survey for semester %', p_form_id, p_semester_id;
+  end if;
+
+  select count(*)
+    into v_member_count
+  from (
+    select distinct member_id
+    from unnest(p_member_profile_ids) as member_id
+  ) as members
+  join public.profile as profile on profile.id = members.member_id;
+
+  if v_member_count <> cardinality(array(select distinct member_id from unnest(p_member_profile_ids) as member_id))
+     or not (p_family_anchor_profile_id = any(p_member_profile_ids))
+     or not (p_survey_profile_id = any(p_member_profile_ids)) then
+    raise exception 'Campaign members must include valid anchor and survey profiles';
+  end if;
+
+  select count(*)
+    into v_enrollment_count
+  from public.workshop_enrollment as enrollment
+  where enrollment.id = any(p_workshop_enrollment_ids)
+    and enrollment.semester_id = p_semester_id
+    and enrollment.status = 'approved'
+    and enrollment.profile_id = any(p_member_profile_ids);
+
+  if v_enrollment_count <> cardinality(array(select distinct enrollment_id from unnest(p_workshop_enrollment_ids) as enrollment_id)) then
+    raise exception 'Campaign enrollments must be approved members of the selected semester';
+  end if;
+
+  insert into public.post_program_survey_campaign (
+    semester_id,
+    form_id,
+    family_anchor_profile_id,
+    survey_profile_id,
+    available_at
+  )
+  values (
+    p_semester_id,
+    p_form_id,
+    p_family_anchor_profile_id,
+    p_survey_profile_id,
+    p_available_at
+  )
+  on conflict (semester_id, family_anchor_profile_id) do nothing
+  returning id into v_campaign_id;
+
+  if v_campaign_id is null then
+    select id
+      into v_campaign_id
+    from public.post_program_survey_campaign
+    where semester_id = p_semester_id
+      and family_anchor_profile_id = p_family_anchor_profile_id
+    for update;
+  else
+    insert into public.post_program_survey_campaign_audit (
+      campaign_id,
+      event_type,
+      source,
+      details
+    )
+    values (
+      v_campaign_id,
+      'created',
+      'automation',
+      jsonb_build_object('available_at', p_available_at)
+    );
+  end if;
+
+  insert into public.post_program_survey_campaign_member (campaign_id, profile_id)
+  select v_campaign_id, member_id
+  from (
+    select distinct member_id
+    from unnest(p_member_profile_ids) as member_id
+  ) as members
+  on conflict do nothing;
+
+  insert into public.post_program_survey_campaign_enrollment (
+    campaign_id,
+    workshop_enrollment_id
+  )
+  select v_campaign_id, enrollment_id
+  from (
+    select distinct enrollment_id
+    from unnest(p_workshop_enrollment_ids) as enrollment_id
+  ) as enrollments
+  on conflict do nothing;
+
+  return v_campaign_id;
+end;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.manually_complete_post_program_survey_campaign(p_campaign_id uuid, p_reason text)
+ RETURNS TABLE(campaign_id uuid, completed_at timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_campaign public.post_program_survey_campaign%rowtype;
+begin
+  if not public.authorize('post_program_survey.manage') then
+    raise exception 'Campaign management access denied';
+  end if;
+
+  if nullif(btrim(p_reason), '') is null then
+    raise exception 'A completion reason is required';
+  end if;
+
+  select *
+    into v_campaign
+  from public.post_program_survey_campaign
+  where id = p_campaign_id
+  for update;
+
+  if not found then
+    raise exception 'Campaign not found';
+  end if;
+
+  if v_campaign.completed_at is not null then
+    return query select v_campaign.id, v_campaign.completed_at;
+    return;
+  end if;
+
+  update public.post_program_survey_campaign
+  set completed_at = now(),
+      manually_completed_at = now(),
+      manually_completed_by_user_id = auth.uid(),
+      manual_completion_reason = btrim(p_reason)
+  where id = v_campaign.id
+  returning completed_at into completed_at;
+
+  insert into public.post_program_survey_campaign_audit (
+    campaign_id,
+    event_type,
+    actor_user_id,
+    actor_role,
+    source,
+    details
+  )
+  values (
+    v_campaign.id,
+    'completed_manual',
+    auth.uid(),
+    public.current_user_role()::text,
+    'staff',
+    jsonb_build_object('reason', btrim(p_reason))
+  );
+
+  return query select v_campaign.id, completed_at;
+end;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.touch_post_program_survey_campaign_updated_at()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$function$
+;
+
+grant select on table "public"."post_program_survey_campaign" to "authenticated";
+
+grant delete on table "public"."post_program_survey_campaign" to "service_role";
+
+grant insert on table "public"."post_program_survey_campaign" to "service_role";
+
+grant references on table "public"."post_program_survey_campaign" to "service_role";
+
+grant select on table "public"."post_program_survey_campaign" to "service_role";
+
+grant trigger on table "public"."post_program_survey_campaign" to "service_role";
+
+grant truncate on table "public"."post_program_survey_campaign" to "service_role";
+
+grant update on table "public"."post_program_survey_campaign" to "service_role";
+
+grant delete on table "public"."post_program_survey_campaign" to "supabase_auth_admin";
+
+grant insert on table "public"."post_program_survey_campaign" to "supabase_auth_admin";
+
+grant references on table "public"."post_program_survey_campaign" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_campaign" to "supabase_auth_admin";
+
+grant trigger on table "public"."post_program_survey_campaign" to "supabase_auth_admin";
+
+grant truncate on table "public"."post_program_survey_campaign" to "supabase_auth_admin";
+
+grant update on table "public"."post_program_survey_campaign" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_campaign_audit" to "authenticated";
+
+grant delete on table "public"."post_program_survey_campaign_audit" to "service_role";
+
+grant insert on table "public"."post_program_survey_campaign_audit" to "service_role";
+
+grant references on table "public"."post_program_survey_campaign_audit" to "service_role";
+
+grant select on table "public"."post_program_survey_campaign_audit" to "service_role";
+
+grant trigger on table "public"."post_program_survey_campaign_audit" to "service_role";
+
+grant truncate on table "public"."post_program_survey_campaign_audit" to "service_role";
+
+grant update on table "public"."post_program_survey_campaign_audit" to "service_role";
+
+grant delete on table "public"."post_program_survey_campaign_audit" to "supabase_auth_admin";
+
+grant insert on table "public"."post_program_survey_campaign_audit" to "supabase_auth_admin";
+
+grant references on table "public"."post_program_survey_campaign_audit" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_campaign_audit" to "supabase_auth_admin";
+
+grant trigger on table "public"."post_program_survey_campaign_audit" to "supabase_auth_admin";
+
+grant truncate on table "public"."post_program_survey_campaign_audit" to "supabase_auth_admin";
+
+grant update on table "public"."post_program_survey_campaign_audit" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_campaign_enrollment" to "authenticated";
+
+grant delete on table "public"."post_program_survey_campaign_enrollment" to "service_role";
+
+grant insert on table "public"."post_program_survey_campaign_enrollment" to "service_role";
+
+grant references on table "public"."post_program_survey_campaign_enrollment" to "service_role";
+
+grant select on table "public"."post_program_survey_campaign_enrollment" to "service_role";
+
+grant trigger on table "public"."post_program_survey_campaign_enrollment" to "service_role";
+
+grant truncate on table "public"."post_program_survey_campaign_enrollment" to "service_role";
+
+grant update on table "public"."post_program_survey_campaign_enrollment" to "service_role";
+
+grant delete on table "public"."post_program_survey_campaign_enrollment" to "supabase_auth_admin";
+
+grant insert on table "public"."post_program_survey_campaign_enrollment" to "supabase_auth_admin";
+
+grant references on table "public"."post_program_survey_campaign_enrollment" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_campaign_enrollment" to "supabase_auth_admin";
+
+grant trigger on table "public"."post_program_survey_campaign_enrollment" to "supabase_auth_admin";
+
+grant truncate on table "public"."post_program_survey_campaign_enrollment" to "supabase_auth_admin";
+
+grant update on table "public"."post_program_survey_campaign_enrollment" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_campaign_member" to "authenticated";
+
+grant delete on table "public"."post_program_survey_campaign_member" to "service_role";
+
+grant insert on table "public"."post_program_survey_campaign_member" to "service_role";
+
+grant references on table "public"."post_program_survey_campaign_member" to "service_role";
+
+grant select on table "public"."post_program_survey_campaign_member" to "service_role";
+
+grant trigger on table "public"."post_program_survey_campaign_member" to "service_role";
+
+grant truncate on table "public"."post_program_survey_campaign_member" to "service_role";
+
+grant update on table "public"."post_program_survey_campaign_member" to "service_role";
+
+grant delete on table "public"."post_program_survey_campaign_member" to "supabase_auth_admin";
+
+grant insert on table "public"."post_program_survey_campaign_member" to "supabase_auth_admin";
+
+grant references on table "public"."post_program_survey_campaign_member" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_campaign_member" to "supabase_auth_admin";
+
+grant trigger on table "public"."post_program_survey_campaign_member" to "supabase_auth_admin";
+
+grant truncate on table "public"."post_program_survey_campaign_member" to "supabase_auth_admin";
+
+grant update on table "public"."post_program_survey_campaign_member" to "supabase_auth_admin";
+
+
+  create policy "post_program_survey_campaign_read_auth_admin"
+  on "public"."post_program_survey_campaign"
+  as permissive
+  for select
+  to supabase_auth_admin
+using (true);
+
+
+
+  create policy "post_program_survey_campaign_read_manager"
+  on "public"."post_program_survey_campaign"
+  as permissive
+  for select
+  to public
+using (public.authorize('post_program_survey.manage'::public.app_permissions));
+
+
+
+  create policy "post_program_survey_campaign_read_member"
+  on "public"."post_program_survey_campaign"
+  as permissive
+  for select
+  to public
+using ((EXISTS ( SELECT 1
+   FROM public.post_program_survey_campaign_member member
+  WHERE ((member.campaign_id = post_program_survey_campaign.id) AND (member.profile_id = public.current_profile_id())))));
+
+
+
+  create policy "post_program_survey_campaign_audit_read_auth_admin"
+  on "public"."post_program_survey_campaign_audit"
+  as permissive
+  for select
+  to supabase_auth_admin
+using (true);
+
+
+
+  create policy "post_program_survey_campaign_audit_read_manager"
+  on "public"."post_program_survey_campaign_audit"
+  as permissive
+  for select
+  to public
+using (public.authorize('post_program_survey.manage'::public.app_permissions));
+
+
+
+  create policy "post_program_survey_campaign_enrollment_read_auth_admin"
+  on "public"."post_program_survey_campaign_enrollment"
+  as permissive
+  for select
+  to supabase_auth_admin
+using (true);
+
+
+
+  create policy "post_program_survey_campaign_enrollment_read_manager"
+  on "public"."post_program_survey_campaign_enrollment"
+  as permissive
+  for select
+  to public
+using (public.authorize('post_program_survey.manage'::public.app_permissions));
+
+
+
+  create policy "post_program_survey_campaign_enrollment_read_member"
+  on "public"."post_program_survey_campaign_enrollment"
+  as permissive
+  for select
+  to public
+using ((EXISTS ( SELECT 1
+   FROM public.post_program_survey_campaign_member member
+  WHERE ((member.campaign_id = post_program_survey_campaign_enrollment.campaign_id) AND (member.profile_id = public.current_profile_id())))));
+
+
+
+  create policy "post_program_survey_campaign_member_read_auth_admin"
+  on "public"."post_program_survey_campaign_member"
+  as permissive
+  for select
+  to supabase_auth_admin
+using (true);
+
+
+
+  create policy "post_program_survey_campaign_member_read_manager"
+  on "public"."post_program_survey_campaign_member"
+  as permissive
+  for select
+  to public
+using (public.authorize('post_program_survey.manage'::public.app_permissions));
+
+
+
+  create policy "post_program_survey_campaign_member_read_member"
+  on "public"."post_program_survey_campaign_member"
+  as permissive
+  for select
+  to public
+using ((profile_id = public.current_profile_id()));
+
+
+CREATE TRIGGER on_post_program_survey_campaign_updated_set_timestamp BEFORE UPDATE ON public.post_program_survey_campaign FOR EACH ROW EXECUTE FUNCTION public.touch_post_program_survey_campaign_updated_at();
+
+insert into public.role_permission (role, permission)
+values
+  ('admin'::public.app_role, 'post_program_survey.manage'::public.app_permissions),
+  ('manager'::public.app_role, 'post_program_survey.manage'::public.app_permissions)
+on conflict do nothing;
+
+revoke all on function public.ensure_post_program_survey_campaign(uuid, uuid, uuid, uuid, uuid[], uuid[], timestamptz) from public, anon, authenticated;
+revoke all on function public.complete_post_program_survey_campaign(uuid, jsonb, jsonb) from public, anon;
+revoke all on function public.manually_complete_post_program_survey_campaign(uuid, text) from public, anon;
+
+grant execute on function public.ensure_post_program_survey_campaign(uuid, uuid, uuid, uuid, uuid[], uuid[], timestamptz) to service_role;
+grant execute on function public.complete_post_program_survey_campaign(uuid, jsonb, jsonb) to authenticated;
+grant execute on function public.manually_complete_post_program_survey_campaign(uuid, text) to authenticated;

--- a/supabase/migrations/20260813173606_post_program_survey_email_events.sql
+++ b/supabase/migrations/20260813173606_post_program_survey_email_events.sql
@@ -1,0 +1,472 @@
+revoke delete on table "public"."post_program_survey_campaign" from "anon";
+
+revoke insert on table "public"."post_program_survey_campaign" from "anon";
+
+revoke references on table "public"."post_program_survey_campaign" from "anon";
+
+revoke select on table "public"."post_program_survey_campaign" from "anon";
+
+revoke trigger on table "public"."post_program_survey_campaign" from "anon";
+
+revoke truncate on table "public"."post_program_survey_campaign" from "anon";
+
+revoke update on table "public"."post_program_survey_campaign" from "anon";
+
+revoke delete on table "public"."post_program_survey_campaign" from "authenticated";
+
+revoke insert on table "public"."post_program_survey_campaign" from "authenticated";
+
+revoke references on table "public"."post_program_survey_campaign" from "authenticated";
+
+revoke trigger on table "public"."post_program_survey_campaign" from "authenticated";
+
+revoke truncate on table "public"."post_program_survey_campaign" from "authenticated";
+
+revoke update on table "public"."post_program_survey_campaign" from "authenticated";
+
+revoke delete on table "public"."post_program_survey_campaign_audit" from "anon";
+
+revoke insert on table "public"."post_program_survey_campaign_audit" from "anon";
+
+revoke references on table "public"."post_program_survey_campaign_audit" from "anon";
+
+revoke select on table "public"."post_program_survey_campaign_audit" from "anon";
+
+revoke trigger on table "public"."post_program_survey_campaign_audit" from "anon";
+
+revoke truncate on table "public"."post_program_survey_campaign_audit" from "anon";
+
+revoke update on table "public"."post_program_survey_campaign_audit" from "anon";
+
+revoke delete on table "public"."post_program_survey_campaign_audit" from "authenticated";
+
+revoke insert on table "public"."post_program_survey_campaign_audit" from "authenticated";
+
+revoke references on table "public"."post_program_survey_campaign_audit" from "authenticated";
+
+revoke trigger on table "public"."post_program_survey_campaign_audit" from "authenticated";
+
+revoke truncate on table "public"."post_program_survey_campaign_audit" from "authenticated";
+
+revoke update on table "public"."post_program_survey_campaign_audit" from "authenticated";
+
+revoke delete on table "public"."post_program_survey_campaign_enrollment" from "anon";
+
+revoke insert on table "public"."post_program_survey_campaign_enrollment" from "anon";
+
+revoke references on table "public"."post_program_survey_campaign_enrollment" from "anon";
+
+revoke select on table "public"."post_program_survey_campaign_enrollment" from "anon";
+
+revoke trigger on table "public"."post_program_survey_campaign_enrollment" from "anon";
+
+revoke truncate on table "public"."post_program_survey_campaign_enrollment" from "anon";
+
+revoke update on table "public"."post_program_survey_campaign_enrollment" from "anon";
+
+revoke delete on table "public"."post_program_survey_campaign_enrollment" from "authenticated";
+
+revoke insert on table "public"."post_program_survey_campaign_enrollment" from "authenticated";
+
+revoke references on table "public"."post_program_survey_campaign_enrollment" from "authenticated";
+
+revoke trigger on table "public"."post_program_survey_campaign_enrollment" from "authenticated";
+
+revoke truncate on table "public"."post_program_survey_campaign_enrollment" from "authenticated";
+
+revoke update on table "public"."post_program_survey_campaign_enrollment" from "authenticated";
+
+revoke delete on table "public"."post_program_survey_campaign_member" from "anon";
+
+revoke insert on table "public"."post_program_survey_campaign_member" from "anon";
+
+revoke references on table "public"."post_program_survey_campaign_member" from "anon";
+
+revoke select on table "public"."post_program_survey_campaign_member" from "anon";
+
+revoke trigger on table "public"."post_program_survey_campaign_member" from "anon";
+
+revoke truncate on table "public"."post_program_survey_campaign_member" from "anon";
+
+revoke update on table "public"."post_program_survey_campaign_member" from "anon";
+
+revoke delete on table "public"."post_program_survey_campaign_member" from "authenticated";
+
+revoke insert on table "public"."post_program_survey_campaign_member" from "authenticated";
+
+revoke references on table "public"."post_program_survey_campaign_member" from "authenticated";
+
+revoke trigger on table "public"."post_program_survey_campaign_member" from "authenticated";
+
+revoke truncate on table "public"."post_program_survey_campaign_member" from "authenticated";
+
+revoke update on table "public"."post_program_survey_campaign_member" from "authenticated";
+
+
+  create table "public"."post_program_survey_email_event" (
+    "id" uuid not null default gen_random_uuid(),
+    "campaign_id" uuid not null,
+    "template_key" text not null,
+    "slot_at" timestamp with time zone not null,
+    "recipient_email" text not null,
+    "due_at" timestamp with time zone not null,
+    "claimed_at" timestamp with time zone,
+    "claim_expires_at" timestamp with time zone,
+    "sent_at" timestamp with time zone,
+    "email_message_id" uuid,
+    "attempt_count" integer not null default 0,
+    "next_attempt_at" timestamp with time zone,
+    "last_error" text,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."post_program_survey_email_event" enable row level security;
+
+CREATE UNIQUE INDEX post_program_survey_email_eve_campaign_id_template_key_slot_key ON public.post_program_survey_email_event USING btree (campaign_id, template_key, slot_at, recipient_email);
+
+CREATE INDEX post_program_survey_email_event_due_idx ON public.post_program_survey_email_event USING btree (due_at, id) WHERE (sent_at IS NULL);
+
+CREATE UNIQUE INDEX post_program_survey_email_event_pkey ON public.post_program_survey_email_event USING btree (id);
+
+alter table "public"."post_program_survey_email_event" add constraint "post_program_survey_email_event_pkey" PRIMARY KEY using index "post_program_survey_email_event_pkey";
+
+alter table "public"."post_program_survey_email_event" add constraint "post_program_survey_email_eve_campaign_id_template_key_slot_key" UNIQUE using index "post_program_survey_email_eve_campaign_id_template_key_slot_key";
+
+alter table "public"."post_program_survey_email_event" add constraint "post_program_survey_email_event_attempt_count_check" CHECK ((attempt_count >= 0)) not valid;
+
+alter table "public"."post_program_survey_email_event" validate constraint "post_program_survey_email_event_attempt_count_check";
+
+alter table "public"."post_program_survey_email_event" add constraint "post_program_survey_email_event_campaign_id_fkey" FOREIGN KEY (campaign_id) REFERENCES public.post_program_survey_campaign(id) ON DELETE CASCADE not valid;
+
+alter table "public"."post_program_survey_email_event" validate constraint "post_program_survey_email_event_campaign_id_fkey";
+
+alter table "public"."post_program_survey_email_event" add constraint "post_program_survey_email_event_check" CHECK ((((claimed_at IS NULL) AND (claim_expires_at IS NULL)) OR ((claimed_at IS NOT NULL) AND (claim_expires_at IS NOT NULL)))) not valid;
+
+alter table "public"."post_program_survey_email_event" validate constraint "post_program_survey_email_event_check";
+
+alter table "public"."post_program_survey_email_event" add constraint "post_program_survey_email_event_email_message_id_fkey" FOREIGN KEY (email_message_id) REFERENCES public.email_message(id) ON DELETE SET NULL not valid;
+
+alter table "public"."post_program_survey_email_event" validate constraint "post_program_survey_email_event_email_message_id_fkey";
+
+alter table "public"."post_program_survey_email_event" add constraint "post_program_survey_email_event_template_key_check" CHECK ((template_key = ANY (ARRAY['post_program_survey_initial_v1'::text, 'post_program_survey_reminder_v1'::text, 'post_program_survey_gift_card_v1'::text]))) not valid;
+
+alter table "public"."post_program_survey_email_event" validate constraint "post_program_survey_email_event_template_key_check";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.claim_post_program_survey_email_events(p_now timestamp with time zone, p_limit integer DEFAULT 100)
+ RETURNS TABLE(id uuid, campaign_id uuid, template_key text, recipient_email text, slot_at timestamp with time zone, attempt_count integer)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  with candidates as (
+    select event.id
+    from public.post_program_survey_email_event as event
+    join public.post_program_survey_campaign as campaign on campaign.id = event.campaign_id
+    where event.sent_at is null
+      and campaign.completed_at is null
+      and event.due_at <= p_now
+      and coalesce(event.next_attempt_at, event.due_at) <= p_now
+      and (event.claim_expires_at is null or event.claim_expires_at <= p_now)
+    order by event.due_at, event.id
+    limit greatest(1, least(p_limit, 500))
+    for update of event skip locked
+  ), claimed as (
+    update public.post_program_survey_email_event as event
+    set
+      claimed_at = p_now,
+      claim_expires_at = p_now + interval '15 minutes',
+      attempt_count = event.attempt_count + 1,
+      last_error = null
+    from candidates
+    where event.id = candidates.id
+    returning event.id, event.campaign_id, event.template_key, event.recipient_email, event.slot_at, event.attempt_count
+  )
+  select * from claimed;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.complete_post_program_survey_email_event(p_event_id uuid, p_email_message_id uuid)
+ RETURNS boolean
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  with updated as (
+    update public.post_program_survey_email_event
+    set
+      sent_at = now(),
+      email_message_id = p_email_message_id,
+      claimed_at = null,
+      claim_expires_at = null,
+      next_attempt_at = null,
+      last_error = null
+    where id = p_event_id
+      and sent_at is null
+      and claimed_at is not null
+    returning id
+  )
+  select exists (select 1 from updated);
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.ensure_post_program_survey_email_draft(p_draft_key text, p_title text, p_description text, p_trigger_summary text, p_subject text, p_body text)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_draft_id uuid;
+  v_version_id uuid;
+begin
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    p_draft_key,
+    p_title,
+    p_description,
+    p_trigger_summary,
+    'post_program_survey.email',
+    'web/app/lib/post-program-survey/runner.server.ts',
+    'transactional',
+    'draft',
+    true,
+    '{"required": ["recipientName", "surveyUrl"]}'::jsonb,
+    p_subject,
+    p_body
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      is_system = true,
+      variables_schema = case
+        when public.email_draft.variables_schema = '{}'::jsonb then excluded.variables_schema
+        else public.email_draft.variables_schema
+      end,
+      current_subject_markdown = case
+        when char_length(btrim(public.email_draft.current_subject_markdown)) = 0 then excluded.current_subject_markdown
+        else public.email_draft.current_subject_markdown
+      end,
+      current_body_markdown = case
+        when char_length(btrim(public.email_draft.current_body_markdown)) = 0 then excluded.current_body_markdown
+        else public.email_draft.current_body_markdown
+      end
+  returning id into v_draft_id;
+
+  insert into public.email_draft_version (
+    email_draft_id,
+    version_number,
+    subject_markdown,
+    body_markdown,
+    subject_rendered,
+    html_rendered,
+    text_rendered,
+    variables_schema,
+    change_note,
+    published_at
+  )
+  values (
+    v_draft_id,
+    1,
+    p_subject,
+    p_body,
+    p_subject,
+    replace(replace(p_body, E'\n', '<br />'), '{{surveyUrl}}', '<a href="{{surveyUrl}}">Complete the post-program survey</a>'),
+    p_body,
+    '{"required": ["recipientName", "surveyUrl"]}'::jsonb,
+    'Seeded post-program survey email draft.',
+    now()
+  )
+  on conflict (email_draft_id, version_number) do nothing;
+
+  if exists (
+    select 1
+    from public.email_draft
+    where id = v_draft_id
+      and published_version_id is null
+  ) then
+    select version.id
+      into v_version_id
+    from public.email_draft_version as version
+    where version.email_draft_id = v_draft_id
+    order by version.version_number desc
+    limit 1;
+
+    update public.email_draft
+    set
+      published_version_id = v_version_id,
+      status = 'published'
+    where id = v_draft_id;
+  end if;
+end;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.ensure_post_program_survey_gift_card_email_draft()
+ RETURNS void
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  select public.ensure_post_program_survey_email_draft(
+    'post_program_survey_gift_card_v1',
+    'Post-program survey gift-card reminder',
+    'Gift-card reminder for a family that has not completed its post-program survey.',
+    'Sent August 25, August 27, September 1, and September 3, 2026 at 9 PM Toronto time to incomplete campaign guardians.',
+    'Complete your survey to receive your final grocery gift card',
+    E'Hi {{recipientName}},\n\nIt looks like you have still not completed your summerlunch+ post-program evaluation.\n\nPlease complete the survey as soon as possible. To receive your final Week 8 grocery gift card, you must complete the post-program evaluation.\n\nComplete the survey: {{surveyUrl}}\n\nThe summerlunch+ Team'
+  );
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.ensure_post_program_survey_initial_email_draft()
+ RETURNS void
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  select public.ensure_post_program_survey_email_draft(
+    'post_program_survey_initial_v1',
+    'Post-program survey initial request',
+    'Initial request for a family to complete its post-program survey.',
+    'Sent August 14, 2026 at 9 AM Toronto time to incomplete campaign guardians.',
+    'Please complete your summerlunch+ post-program evaluation',
+    E'Hi {{recipientName}},\n\nThank you for participating in the summerlunch+ program!\n\nJust as you completed the pre-program questions when you registered, we now have our post-program evaluation for you to complete.\n\nPlease complete the survey: {{surveyUrl}}\n\nThe summerlunch+ Team'
+  );
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.ensure_post_program_survey_reminder_email_draft()
+ RETURNS void
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  select public.ensure_post_program_survey_email_draft(
+    'post_program_survey_reminder_v1',
+    'Post-program survey reminder',
+    'Regular reminder for a family to complete its post-program survey.',
+    'Sent August 18 and August 20, 2026 at 9 PM Toronto time to incomplete campaign guardians.',
+    'Reminder: complete your summerlunch+ post-program evaluation',
+    E'Hi {{recipientName}},\n\nThis is a quick reminder to complete your summerlunch+ post-program evaluation if you have not already done so.\n\nIt only takes a few minutes, and your feedback is very important to us.\n\nComplete the survey: {{surveyUrl}}\n\nThe summerlunch+ Team'
+  );
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.fail_post_program_survey_email_event(p_event_id uuid, p_error text)
+ RETURNS boolean
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  with updated as (
+    update public.post_program_survey_email_event
+    set
+      claimed_at = null,
+      claim_expires_at = null,
+      next_attempt_at = now() + make_interval(mins => least(240, 15 * greatest(1, attempt_count))),
+      last_error = left(coalesce(p_error, 'Unknown email failure'), 1000)
+    where id = p_event_id
+      and sent_at is null
+    returning id
+  )
+  select exists (select 1 from updated);
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.touch_post_program_survey_email_event_updated_at()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$function$
+;
+
+grant select on table "public"."post_program_survey_email_event" to "authenticated";
+
+grant delete on table "public"."post_program_survey_email_event" to "service_role";
+
+grant insert on table "public"."post_program_survey_email_event" to "service_role";
+
+grant references on table "public"."post_program_survey_email_event" to "service_role";
+
+grant select on table "public"."post_program_survey_email_event" to "service_role";
+
+grant trigger on table "public"."post_program_survey_email_event" to "service_role";
+
+grant truncate on table "public"."post_program_survey_email_event" to "service_role";
+
+grant update on table "public"."post_program_survey_email_event" to "service_role";
+
+grant delete on table "public"."post_program_survey_email_event" to "supabase_auth_admin";
+
+grant insert on table "public"."post_program_survey_email_event" to "supabase_auth_admin";
+
+grant references on table "public"."post_program_survey_email_event" to "supabase_auth_admin";
+
+grant select on table "public"."post_program_survey_email_event" to "supabase_auth_admin";
+
+grant trigger on table "public"."post_program_survey_email_event" to "supabase_auth_admin";
+
+grant truncate on table "public"."post_program_survey_email_event" to "supabase_auth_admin";
+
+grant update on table "public"."post_program_survey_email_event" to "supabase_auth_admin";
+
+
+  create policy "post_program_survey_email_event_read_auth_admin"
+  on "public"."post_program_survey_email_event"
+  as permissive
+  for select
+  to supabase_auth_admin
+using (true);
+
+
+
+  create policy "post_program_survey_email_event_read_manager"
+  on "public"."post_program_survey_email_event"
+  as permissive
+  for select
+  to public
+using (public.authorize('post_program_survey.manage'::public.app_permissions));
+
+
+CREATE TRIGGER on_post_program_survey_email_event_updated_set_timestamp BEFORE UPDATE ON public.post_program_survey_email_event FOR EACH ROW EXECUTE FUNCTION public.touch_post_program_survey_email_event_updated_at();
+
+revoke all on function public.claim_post_program_survey_email_events(timestamptz, integer) from public, anon, authenticated;
+revoke all on function public.complete_post_program_survey_email_event(uuid, uuid) from public, anon, authenticated;
+revoke all on function public.fail_post_program_survey_email_event(uuid, text) from public, anon, authenticated;
+
+grant execute on function public.claim_post_program_survey_email_events(timestamptz, integer) to service_role;
+grant execute on function public.complete_post_program_survey_email_event(uuid, uuid) to service_role;
+grant execute on function public.fail_post_program_survey_email_event(uuid, text) to service_role;
+
+select public.ensure_post_program_survey_initial_email_draft();
+select public.ensure_post_program_survey_reminder_email_draft();
+select public.ensure_post_program_survey_gift_card_email_draft();

--- a/supabase/migrations/20260813183714_fix_post_program_survey_completion_timestamp.sql
+++ b/supabase/migrations/20260813183714_fix_post_program_survey_completion_timestamp.sql
@@ -1,0 +1,261 @@
+revoke delete on table "public"."post_program_survey_email_event" from "anon";
+
+revoke insert on table "public"."post_program_survey_email_event" from "anon";
+
+revoke references on table "public"."post_program_survey_email_event" from "anon";
+
+revoke select on table "public"."post_program_survey_email_event" from "anon";
+
+revoke trigger on table "public"."post_program_survey_email_event" from "anon";
+
+revoke truncate on table "public"."post_program_survey_email_event" from "anon";
+
+revoke update on table "public"."post_program_survey_email_event" from "anon";
+
+revoke delete on table "public"."post_program_survey_email_event" from "authenticated";
+
+revoke insert on table "public"."post_program_survey_email_event" from "authenticated";
+
+revoke references on table "public"."post_program_survey_email_event" from "authenticated";
+
+revoke trigger on table "public"."post_program_survey_email_event" from "authenticated";
+
+revoke truncate on table "public"."post_program_survey_email_event" from "authenticated";
+
+revoke update on table "public"."post_program_survey_email_event" from "authenticated";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.complete_post_program_survey_campaign(p_campaign_id uuid, p_answers jsonb, p_request_metadata jsonb DEFAULT '{}'::jsonb)
+ RETURNS TABLE(campaign_id uuid, completed boolean, submission_id uuid, completed_at timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_campaign public.post_program_survey_campaign%rowtype;
+  v_actor_profile_id uuid;
+  v_submission_id uuid;
+  v_completed_at timestamptz;
+  v_question record;
+  v_value jsonb;
+  v_option text;
+begin
+  if jsonb_typeof(p_answers) <> 'object' then
+    raise exception 'Answers must be an object';
+  end if;
+
+  select *
+    into v_campaign
+  from public.post_program_survey_campaign
+  where id = p_campaign_id
+  for update;
+
+  if not found then
+    raise exception 'Campaign not found';
+  end if;
+
+  v_actor_profile_id := public.current_profile_id();
+  if v_actor_profile_id is null
+     or not exists (
+       select 1
+       from public.post_program_survey_campaign_member as member
+       where member.campaign_id = v_campaign.id
+         and member.profile_id = v_actor_profile_id
+     ) then
+    raise exception 'Campaign access denied';
+  end if;
+
+  if v_campaign.completed_at is not null then
+    return query select v_campaign.id, true, v_campaign.completed_submission_id, v_campaign.completed_at;
+    return;
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_object_keys(p_answers) as answer(question_code)
+    where not exists (
+      select 1
+      from public.form_question_map as map
+      where map.form_id = v_campaign.form_id
+        and map.question_code = answer.question_code
+    )
+  ) then
+    raise exception 'Answers contain an unknown question';
+  end if;
+
+  for v_question in
+    select
+      map.question_code,
+      coalesce(map.options_override, question.options) as options,
+      question.type,
+      coalesce((map.metadata ->> 'optional')::boolean, false) as optional
+    from public.form_question_map as map
+    join public.form_question as question on question.question_code = map.question_code
+    where map.form_id = v_campaign.form_id
+    order by map.position
+  loop
+    v_value := p_answers -> v_question.question_code;
+
+    if not v_question.optional
+       and v_question.type <> 'no-input-text'
+       and (
+         v_value is null
+         or v_value = 'null'::jsonb
+         or (jsonb_typeof(v_value) = 'string' and btrim(v_value #>> '{}') = '')
+         or (jsonb_typeof(v_value) = 'array' and jsonb_array_length(v_value) = 0)
+       ) then
+      raise exception 'Question % is required', v_question.question_code;
+    end if;
+
+    if v_value is null or v_value = 'null'::jsonb then
+      continue;
+    end if;
+
+    if v_question.type in ('text', 'date', 'address', 'agreement') and jsonb_typeof(v_value) <> 'string' then
+      raise exception 'Question % requires a string answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'number' and jsonb_typeof(v_value) <> 'number' then
+      raise exception 'Question % requires a numeric answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'checkbox' and jsonb_typeof(v_value) <> 'boolean' then
+      raise exception 'Question % requires a boolean answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'single_choice' then
+      if jsonb_typeof(v_value) <> 'string'
+         or not (v_question.options @> jsonb_build_array(v_value)) then
+        raise exception 'Question % has an invalid option', v_question.question_code;
+      end if;
+    end if;
+
+    if v_question.type = 'multi_choice' then
+      if jsonb_typeof(v_value) <> 'array' then
+        raise exception 'Question % requires an array answer', v_question.question_code;
+      end if;
+
+      for v_option in select jsonb_array_elements_text(v_value)
+      loop
+        if not (v_question.options @> jsonb_build_array(to_jsonb(v_option))) then
+          raise exception 'Question % has an invalid option', v_question.question_code;
+        end if;
+      end loop;
+    end if;
+  end loop;
+
+  insert into public.form_submission (
+    form_id,
+    profile_id,
+    user_id,
+    metadata
+  )
+  values (
+    v_campaign.form_id,
+    v_campaign.survey_profile_id,
+    auth.uid(),
+    jsonb_build_object(
+      'source', 'semester_post_program_survey',
+      'campaign_id', v_campaign.id,
+      'respondent_profile_id', v_actor_profile_id,
+      'request', p_request_metadata
+    )
+  )
+  returning id into v_submission_id;
+
+  insert into public.form_answer (submission_id, question_code, value)
+  select v_submission_id, answer.question_code, answer.value
+  from jsonb_each(p_answers) as answer(question_code, value)
+  join public.form_question_map as map
+    on map.form_id = v_campaign.form_id
+   and map.question_code = answer.question_code
+  where answer.value <> 'null'::jsonb;
+
+  update public.post_program_survey_campaign
+  set completed_submission_id = v_submission_id,
+      completed_at = now()
+  where id = v_campaign.id
+  returning public.post_program_survey_campaign.completed_at into v_completed_at;
+
+  insert into public.post_program_survey_campaign_audit (
+    campaign_id,
+    event_type,
+    actor_user_id,
+    source,
+    details
+  )
+  values (
+    v_campaign.id,
+    'completed_submission',
+    auth.uid(),
+    'user',
+    jsonb_build_object('submission_id', v_submission_id, 'respondent_profile_id', v_actor_profile_id)
+  );
+
+  return query select v_campaign.id, true, v_submission_id, v_completed_at;
+end;
+$function$
+;
+CREATE OR REPLACE FUNCTION public.manually_complete_post_program_survey_campaign(p_campaign_id uuid, p_reason text)
+ RETURNS TABLE(campaign_id uuid, completed_at timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_campaign public.post_program_survey_campaign%rowtype;
+  v_completed_at timestamptz;
+begin
+  if not public.authorize('post_program_survey.manage') then
+    raise exception 'Campaign management access denied';
+  end if;
+
+  if nullif(btrim(p_reason), '') is null then
+    raise exception 'A completion reason is required';
+  end if;
+
+  select *
+    into v_campaign
+  from public.post_program_survey_campaign
+  where id = p_campaign_id
+  for update;
+
+  if not found then
+    raise exception 'Campaign not found';
+  end if;
+
+  if v_campaign.completed_at is not null then
+    return query select v_campaign.id, v_campaign.completed_at;
+    return;
+  end if;
+
+  update public.post_program_survey_campaign
+  set completed_at = now(),
+      manually_completed_at = now(),
+      manually_completed_by_user_id = auth.uid(),
+      manual_completion_reason = btrim(p_reason)
+  where id = v_campaign.id
+  returning public.post_program_survey_campaign.completed_at into v_completed_at;
+
+  insert into public.post_program_survey_campaign_audit (
+    campaign_id,
+    event_type,
+    actor_user_id,
+    actor_role,
+    source,
+    details
+  )
+  values (
+    v_campaign.id,
+    'completed_manual',
+    auth.uid(),
+    public.current_user_role()::text,
+    'staff',
+    jsonb_build_object('reason', btrim(p_reason))
+  );
+
+  return query select v_campaign.id, v_completed_at;
+end;
+$function$
+;

--- a/supabase/schemas/00_roles.sql
+++ b/supabase/schemas/00_roles.sql
@@ -32,7 +32,8 @@ create type app_permissions as enum (
   'class_zoom_participant.create', 'class_zoom_participant.read', 'class_zoom_participant.update', 'class_zoom_participant.delete',
   'zlr_click_event.create', 'zlr_click_event.read', 'zlr_click_event.update', 'zlr_click_event.delete',
   'class_attendance_photo.create', 'class_attendance_photo.read', 'class_attendance_photo.update', 'class_attendance_photo.delete',
-  'class_attendance_photo_upload_attempt.create', 'class_attendance_photo_upload_attempt.read', 'class_attendance_photo_upload_attempt.update', 'class_attendance_photo_upload_attempt.delete'
+  'class_attendance_photo_upload_attempt.create', 'class_attendance_photo_upload_attempt.read', 'class_attendance_photo_upload_attempt.update', 'class_attendance_photo_upload_attempt.delete',
+  'post_program_survey.manage'
 );
 
 create table if not exists public.user_roles (

--- a/supabase/schemas/12_email_drafts.sql
+++ b/supabase/schemas/12_email_drafts.sql
@@ -761,6 +761,175 @@ begin
 end;
 $$;
 
+create or replace function public.ensure_post_program_survey_email_draft(
+  p_draft_key text,
+  p_title text,
+  p_description text,
+  p_trigger_summary text,
+  p_subject text,
+  p_body text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_draft_id uuid;
+  v_version_id uuid;
+begin
+  insert into public.email_draft (
+    draft_key,
+    title,
+    description,
+    trigger_summary,
+    trigger_event_key,
+    trigger_owner,
+    channel,
+    status,
+    is_system,
+    variables_schema,
+    current_subject_markdown,
+    current_body_markdown
+  )
+  values (
+    p_draft_key,
+    p_title,
+    p_description,
+    p_trigger_summary,
+    'post_program_survey.email',
+    'web/app/lib/post-program-survey/runner.server.ts',
+    'transactional',
+    'draft',
+    true,
+    '{"required": ["recipientName", "surveyUrl"]}'::jsonb,
+    p_subject,
+    p_body
+  )
+  on conflict (draft_key)
+  do update
+    set
+      title = excluded.title,
+      description = excluded.description,
+      trigger_summary = excluded.trigger_summary,
+      trigger_event_key = excluded.trigger_event_key,
+      trigger_owner = excluded.trigger_owner,
+      channel = excluded.channel,
+      is_system = true,
+      variables_schema = case
+        when public.email_draft.variables_schema = '{}'::jsonb then excluded.variables_schema
+        else public.email_draft.variables_schema
+      end,
+      current_subject_markdown = case
+        when char_length(btrim(public.email_draft.current_subject_markdown)) = 0 then excluded.current_subject_markdown
+        else public.email_draft.current_subject_markdown
+      end,
+      current_body_markdown = case
+        when char_length(btrim(public.email_draft.current_body_markdown)) = 0 then excluded.current_body_markdown
+        else public.email_draft.current_body_markdown
+      end
+  returning id into v_draft_id;
+
+  insert into public.email_draft_version (
+    email_draft_id,
+    version_number,
+    subject_markdown,
+    body_markdown,
+    subject_rendered,
+    html_rendered,
+    text_rendered,
+    variables_schema,
+    change_note,
+    published_at
+  )
+  values (
+    v_draft_id,
+    1,
+    p_subject,
+    p_body,
+    p_subject,
+    replace(replace(p_body, E'\n', '<br />'), '{{surveyUrl}}', '<a href="{{surveyUrl}}">Complete the post-program survey</a>'),
+    p_body,
+    '{"required": ["recipientName", "surveyUrl"]}'::jsonb,
+    'Seeded post-program survey email draft.',
+    now()
+  )
+  on conflict (email_draft_id, version_number) do nothing;
+
+  if exists (
+    select 1
+    from public.email_draft
+    where id = v_draft_id
+      and published_version_id is null
+  ) then
+    select version.id
+      into v_version_id
+    from public.email_draft_version as version
+    where version.email_draft_id = v_draft_id
+    order by version.version_number desc
+    limit 1;
+
+    update public.email_draft
+    set
+      published_version_id = v_version_id,
+      status = 'published'
+    where id = v_draft_id;
+  end if;
+end;
+$$;
+
+create or replace function public.ensure_post_program_survey_initial_email_draft()
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  select public.ensure_post_program_survey_email_draft(
+    'post_program_survey_initial_v1',
+    'Post-program survey initial request',
+    'Initial request for a family to complete its post-program survey.',
+    'Sent August 14, 2026 at 9 AM Toronto time to incomplete campaign guardians.',
+    'Please complete your summerlunch+ post-program evaluation',
+    E'Hi {{recipientName}},\n\nThank you for participating in the summerlunch+ program!\n\nJust as you completed the pre-program questions when you registered, we now have our post-program evaluation for you to complete.\n\nPlease complete the survey: {{surveyUrl}}\n\nThe summerlunch+ Team'
+  );
+$$;
+
+create or replace function public.ensure_post_program_survey_reminder_email_draft()
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  select public.ensure_post_program_survey_email_draft(
+    'post_program_survey_reminder_v1',
+    'Post-program survey reminder',
+    'Regular reminder for a family to complete its post-program survey.',
+    'Sent August 18 and August 20, 2026 at 9 PM Toronto time to incomplete campaign guardians.',
+    'Reminder: complete your summerlunch+ post-program evaluation',
+    E'Hi {{recipientName}},\n\nThis is a quick reminder to complete your summerlunch+ post-program evaluation if you have not already done so.\n\nIt only takes a few minutes, and your feedback is very important to us.\n\nComplete the survey: {{surveyUrl}}\n\nThe summerlunch+ Team'
+  );
+$$;
+
+create or replace function public.ensure_post_program_survey_gift_card_email_draft()
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  select public.ensure_post_program_survey_email_draft(
+    'post_program_survey_gift_card_v1',
+    'Post-program survey gift-card reminder',
+    'Gift-card reminder for a family that has not completed its post-program survey.',
+    'Sent August 25, August 27, September 1, and September 3, 2026 at 9 PM Toronto time to incomplete campaign guardians.',
+    'Complete your survey to receive your final grocery gift card',
+    E'Hi {{recipientName}},\n\nIt looks like you have still not completed your summerlunch+ post-program evaluation.\n\nPlease complete the survey as soon as possible. To receive your final Week 8 grocery gift card, you must complete the post-program evaluation.\n\nComplete the survey: {{surveyUrl}}\n\nThe summerlunch+ Team'
+  );
+$$;
+
+select public.ensure_post_program_survey_initial_email_draft();
+select public.ensure_post_program_survey_reminder_email_draft();
+select public.ensure_post_program_survey_gift_card_email_draft();
+
 grant usage on type public.email_draft_channel to authenticated, supabase_auth_admin;
 grant usage on type public.email_draft_status to authenticated, supabase_auth_admin;
 

--- a/supabase/schemas/18_post_program_survey_campaigns.sql
+++ b/supabase/schemas/18_post_program_survey_campaigns.sql
@@ -331,6 +331,7 @@ declare
   v_campaign public.post_program_survey_campaign%rowtype;
   v_actor_profile_id uuid;
   v_submission_id uuid;
+  v_completed_at timestamptz;
   v_question record;
   v_value jsonb;
   v_option text;
@@ -470,7 +471,7 @@ begin
   set completed_submission_id = v_submission_id,
       completed_at = now()
   where id = v_campaign.id
-  returning completed_at into completed_at;
+  returning public.post_program_survey_campaign.completed_at into v_completed_at;
 
   insert into public.post_program_survey_campaign_audit (
     campaign_id,
@@ -487,7 +488,7 @@ begin
     jsonb_build_object('submission_id', v_submission_id, 'respondent_profile_id', v_actor_profile_id)
   );
 
-  return query select v_campaign.id, true, v_submission_id, completed_at;
+  return query select v_campaign.id, true, v_submission_id, v_completed_at;
 end;
 $$;
 
@@ -505,6 +506,7 @@ set search_path = public
 as $$
 declare
   v_campaign public.post_program_survey_campaign%rowtype;
+  v_completed_at timestamptz;
 begin
   if not public.authorize('post_program_survey.manage') then
     raise exception 'Campaign management access denied';
@@ -535,7 +537,7 @@ begin
       manually_completed_by_user_id = auth.uid(),
       manual_completion_reason = btrim(p_reason)
   where id = v_campaign.id
-  returning completed_at into completed_at;
+  returning public.post_program_survey_campaign.completed_at into v_completed_at;
 
   insert into public.post_program_survey_campaign_audit (
     campaign_id,
@@ -554,7 +556,7 @@ begin
     jsonb_build_object('reason', btrim(p_reason))
   );
 
-  return query select v_campaign.id, completed_at;
+  return query select v_campaign.id, v_completed_at;
 end;
 $$;
 

--- a/supabase/schemas/18_post_program_survey_campaigns.sql
+++ b/supabase/schemas/18_post_program_survey_campaigns.sql
@@ -1,0 +1,567 @@
+create table public.post_program_survey_campaign (
+  id uuid primary key default gen_random_uuid(),
+  semester_id uuid not null references public.semester (id) on delete restrict,
+  form_id uuid not null references public.form (id) on delete restrict,
+  family_anchor_profile_id uuid not null references public.profile (id) on delete restrict,
+  survey_profile_id uuid not null references public.profile (id) on delete restrict,
+  available_at timestamptz not null,
+  initial_sent_at timestamptz,
+  last_normal_reminder_on date,
+  completed_at timestamptz,
+  completed_submission_id uuid unique references public.form_submission (id) on delete restrict,
+  manually_completed_at timestamptz,
+  manually_completed_by_user_id uuid references auth.users (id) on delete set null,
+  manual_completion_reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (semester_id, family_anchor_profile_id),
+  check (
+    (completed_submission_id is null and manually_completed_at is null)
+    or (completed_submission_id is not null and manually_completed_at is null)
+    or (
+      completed_submission_id is null
+      and manually_completed_at is not null
+      and manually_completed_by_user_id is not null
+      and nullif(btrim(manual_completion_reason), '') is not null
+    )
+  ),
+  check (
+    completed_at is null
+    or completed_submission_id is not null
+    or manually_completed_at is not null
+  )
+);
+
+create table public.post_program_survey_campaign_member (
+  campaign_id uuid not null references public.post_program_survey_campaign (id) on delete cascade,
+  profile_id uuid not null references public.profile (id) on delete restrict,
+  created_at timestamptz not null default now(),
+  primary key (campaign_id, profile_id)
+);
+
+create table public.post_program_survey_campaign_enrollment (
+  campaign_id uuid not null references public.post_program_survey_campaign (id) on delete cascade,
+  workshop_enrollment_id uuid not null references public.workshop_enrollment (id) on delete restrict,
+  gift_card_notice_sent_at timestamptz,
+  created_at timestamptz not null default now(),
+  primary key (campaign_id, workshop_enrollment_id),
+  unique (workshop_enrollment_id)
+);
+
+create table public.post_program_survey_campaign_audit (
+  id uuid primary key default gen_random_uuid(),
+  campaign_id uuid not null references public.post_program_survey_campaign (id) on delete restrict,
+  event_type text not null,
+  actor_user_id uuid references auth.users (id) on delete set null,
+  actor_role text,
+  source text not null,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  check (event_type in ('created', 'completed_submission', 'completed_manual')),
+  check (source in ('user', 'staff', 'automation'))
+);
+
+create index post_program_survey_campaign_open_idx
+  on public.post_program_survey_campaign (available_at, id)
+  where completed_at is null;
+
+create index post_program_survey_campaign_member_profile_idx
+  on public.post_program_survey_campaign_member (profile_id, campaign_id);
+
+create index post_program_survey_campaign_enrollment_campaign_idx
+  on public.post_program_survey_campaign_enrollment (campaign_id);
+
+create index post_program_survey_campaign_audit_campaign_created_idx
+  on public.post_program_survey_campaign_audit (campaign_id, created_at desc);
+
+create or replace function public.touch_post_program_survey_campaign_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger on_post_program_survey_campaign_updated_set_timestamp
+before update on public.post_program_survey_campaign
+for each row execute function public.touch_post_program_survey_campaign_updated_at();
+
+alter table public.post_program_survey_campaign enable row level security;
+alter table public.post_program_survey_campaign_member enable row level security;
+alter table public.post_program_survey_campaign_enrollment enable row level security;
+alter table public.post_program_survey_campaign_audit enable row level security;
+
+create policy post_program_survey_campaign_read_member
+  on public.post_program_survey_campaign
+  for select
+  using (
+    exists (
+      select 1
+      from public.post_program_survey_campaign_member as member
+      where member.campaign_id = post_program_survey_campaign.id
+        and member.profile_id = public.current_profile_id()
+    )
+  );
+
+create policy post_program_survey_campaign_read_manager
+  on public.post_program_survey_campaign
+  for select
+  using (public.authorize('post_program_survey.manage'));
+
+create policy post_program_survey_campaign_member_read_member
+  on public.post_program_survey_campaign_member
+  for select
+  using (profile_id = public.current_profile_id());
+
+create policy post_program_survey_campaign_member_read_manager
+  on public.post_program_survey_campaign_member
+  for select
+  using (public.authorize('post_program_survey.manage'));
+
+create policy post_program_survey_campaign_enrollment_read_member
+  on public.post_program_survey_campaign_enrollment
+  for select
+  using (
+    exists (
+      select 1
+      from public.post_program_survey_campaign_member as member
+      where member.campaign_id = post_program_survey_campaign_enrollment.campaign_id
+        and member.profile_id = public.current_profile_id()
+    )
+  );
+
+create policy post_program_survey_campaign_enrollment_read_manager
+  on public.post_program_survey_campaign_enrollment
+  for select
+  using (public.authorize('post_program_survey.manage'));
+
+create policy post_program_survey_campaign_audit_read_manager
+  on public.post_program_survey_campaign_audit
+  for select
+  using (public.authorize('post_program_survey.manage'));
+
+create policy post_program_survey_campaign_read_auth_admin
+  on public.post_program_survey_campaign
+  for select
+  to supabase_auth_admin
+  using (true);
+
+create policy post_program_survey_campaign_member_read_auth_admin
+  on public.post_program_survey_campaign_member
+  for select
+  to supabase_auth_admin
+  using (true);
+
+create policy post_program_survey_campaign_enrollment_read_auth_admin
+  on public.post_program_survey_campaign_enrollment
+  for select
+  to supabase_auth_admin
+  using (true);
+
+create policy post_program_survey_campaign_audit_read_auth_admin
+  on public.post_program_survey_campaign_audit
+  for select
+  to supabase_auth_admin
+  using (true);
+
+grant all on table public.post_program_survey_campaign to supabase_auth_admin;
+grant all on table public.post_program_survey_campaign_member to supabase_auth_admin;
+grant all on table public.post_program_survey_campaign_enrollment to supabase_auth_admin;
+grant all on table public.post_program_survey_campaign_audit to supabase_auth_admin;
+
+revoke all on table public.post_program_survey_campaign from authenticated, anon, public;
+revoke all on table public.post_program_survey_campaign_member from authenticated, anon, public;
+revoke all on table public.post_program_survey_campaign_enrollment from authenticated, anon, public;
+revoke all on table public.post_program_survey_campaign_audit from authenticated, anon, public;
+
+grant select on table public.post_program_survey_campaign to authenticated;
+grant select on table public.post_program_survey_campaign_member to authenticated;
+grant select on table public.post_program_survey_campaign_enrollment to authenticated;
+grant select on table public.post_program_survey_campaign_audit to authenticated;
+
+create or replace function public.ensure_post_program_survey_campaign(
+  p_semester_id uuid,
+  p_form_id uuid,
+  p_family_anchor_profile_id uuid,
+  p_survey_profile_id uuid,
+  p_member_profile_ids uuid[],
+  p_workshop_enrollment_ids uuid[],
+  p_available_at timestamptz
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_campaign_id uuid;
+  v_active_form_id uuid;
+  v_member_count integer;
+  v_enrollment_count integer;
+begin
+  if coalesce(array_length(p_member_profile_ids, 1), 0) = 0 then
+    raise exception 'Campaign members are required';
+  end if;
+
+  if coalesce(array_length(p_workshop_enrollment_ids, 1), 0) = 0 then
+    raise exception 'Campaign enrollments are required';
+  end if;
+
+  select requirement.form_id
+    into v_active_form_id
+  from public.semester_form_requirement as requirement
+  where requirement.semester_id = p_semester_id
+    and requirement.form_id = p_form_id
+    and requirement.is_active = true
+    and requirement.kind::text in ('post_survey', 'post_program_survey')
+  limit 1;
+
+  if v_active_form_id is null then
+    raise exception 'Form % is not the active post-program survey for semester %', p_form_id, p_semester_id;
+  end if;
+
+  select count(*)
+    into v_member_count
+  from (
+    select distinct member_id
+    from unnest(p_member_profile_ids) as member_id
+  ) as members
+  join public.profile as profile on profile.id = members.member_id;
+
+  if v_member_count <> cardinality(array(select distinct member_id from unnest(p_member_profile_ids) as member_id))
+     or not (p_family_anchor_profile_id = any(p_member_profile_ids))
+     or not (p_survey_profile_id = any(p_member_profile_ids)) then
+    raise exception 'Campaign members must include valid anchor and survey profiles';
+  end if;
+
+  select count(*)
+    into v_enrollment_count
+  from public.workshop_enrollment as enrollment
+  where enrollment.id = any(p_workshop_enrollment_ids)
+    and enrollment.semester_id = p_semester_id
+    and enrollment.status = 'approved'
+    and enrollment.profile_id = any(p_member_profile_ids);
+
+  if v_enrollment_count <> cardinality(array(select distinct enrollment_id from unnest(p_workshop_enrollment_ids) as enrollment_id)) then
+    raise exception 'Campaign enrollments must be approved members of the selected semester';
+  end if;
+
+  insert into public.post_program_survey_campaign (
+    semester_id,
+    form_id,
+    family_anchor_profile_id,
+    survey_profile_id,
+    available_at
+  )
+  values (
+    p_semester_id,
+    p_form_id,
+    p_family_anchor_profile_id,
+    p_survey_profile_id,
+    p_available_at
+  )
+  on conflict (semester_id, family_anchor_profile_id) do nothing
+  returning id into v_campaign_id;
+
+  if v_campaign_id is null then
+    select id
+      into v_campaign_id
+    from public.post_program_survey_campaign
+    where semester_id = p_semester_id
+      and family_anchor_profile_id = p_family_anchor_profile_id
+    for update;
+  else
+    insert into public.post_program_survey_campaign_audit (
+      campaign_id,
+      event_type,
+      source,
+      details
+    )
+    values (
+      v_campaign_id,
+      'created',
+      'automation',
+      jsonb_build_object('available_at', p_available_at)
+    );
+  end if;
+
+  insert into public.post_program_survey_campaign_member (campaign_id, profile_id)
+  select v_campaign_id, member_id
+  from (
+    select distinct member_id
+    from unnest(p_member_profile_ids) as member_id
+  ) as members
+  on conflict do nothing;
+
+  insert into public.post_program_survey_campaign_enrollment (
+    campaign_id,
+    workshop_enrollment_id
+  )
+  select v_campaign_id, enrollment_id
+  from (
+    select distinct enrollment_id
+    from unnest(p_workshop_enrollment_ids) as enrollment_id
+  ) as enrollments
+  on conflict do nothing;
+
+  return v_campaign_id;
+end;
+$$;
+
+create or replace function public.complete_post_program_survey_campaign(
+  p_campaign_id uuid,
+  p_answers jsonb,
+  p_request_metadata jsonb default '{}'::jsonb
+)
+returns table (
+  campaign_id uuid,
+  completed boolean,
+  submission_id uuid,
+  completed_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_campaign public.post_program_survey_campaign%rowtype;
+  v_actor_profile_id uuid;
+  v_submission_id uuid;
+  v_question record;
+  v_value jsonb;
+  v_option text;
+begin
+  if jsonb_typeof(p_answers) <> 'object' then
+    raise exception 'Answers must be an object';
+  end if;
+
+  select *
+    into v_campaign
+  from public.post_program_survey_campaign
+  where id = p_campaign_id
+  for update;
+
+  if not found then
+    raise exception 'Campaign not found';
+  end if;
+
+  v_actor_profile_id := public.current_profile_id();
+  if v_actor_profile_id is null
+     or not exists (
+       select 1
+       from public.post_program_survey_campaign_member as member
+       where member.campaign_id = v_campaign.id
+         and member.profile_id = v_actor_profile_id
+     ) then
+    raise exception 'Campaign access denied';
+  end if;
+
+  if v_campaign.completed_at is not null then
+    return query select v_campaign.id, true, v_campaign.completed_submission_id, v_campaign.completed_at;
+    return;
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_object_keys(p_answers) as answer(question_code)
+    where not exists (
+      select 1
+      from public.form_question_map as map
+      where map.form_id = v_campaign.form_id
+        and map.question_code = answer.question_code
+    )
+  ) then
+    raise exception 'Answers contain an unknown question';
+  end if;
+
+  for v_question in
+    select
+      map.question_code,
+      coalesce(map.options_override, question.options) as options,
+      question.type,
+      coalesce((map.metadata ->> 'optional')::boolean, false) as optional
+    from public.form_question_map as map
+    join public.form_question as question on question.question_code = map.question_code
+    where map.form_id = v_campaign.form_id
+    order by map.position
+  loop
+    v_value := p_answers -> v_question.question_code;
+
+    if not v_question.optional
+       and v_question.type <> 'no-input-text'
+       and (
+         v_value is null
+         or v_value = 'null'::jsonb
+         or (jsonb_typeof(v_value) = 'string' and btrim(v_value #>> '{}') = '')
+         or (jsonb_typeof(v_value) = 'array' and jsonb_array_length(v_value) = 0)
+       ) then
+      raise exception 'Question % is required', v_question.question_code;
+    end if;
+
+    if v_value is null or v_value = 'null'::jsonb then
+      continue;
+    end if;
+
+    if v_question.type in ('text', 'date', 'address', 'agreement') and jsonb_typeof(v_value) <> 'string' then
+      raise exception 'Question % requires a string answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'number' and jsonb_typeof(v_value) <> 'number' then
+      raise exception 'Question % requires a numeric answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'checkbox' and jsonb_typeof(v_value) <> 'boolean' then
+      raise exception 'Question % requires a boolean answer', v_question.question_code;
+    end if;
+
+    if v_question.type = 'single_choice' then
+      if jsonb_typeof(v_value) <> 'string'
+         or not (v_question.options @> jsonb_build_array(v_value)) then
+        raise exception 'Question % has an invalid option', v_question.question_code;
+      end if;
+    end if;
+
+    if v_question.type = 'multi_choice' then
+      if jsonb_typeof(v_value) <> 'array' then
+        raise exception 'Question % requires an array answer', v_question.question_code;
+      end if;
+
+      for v_option in select jsonb_array_elements_text(v_value)
+      loop
+        if not (v_question.options @> jsonb_build_array(to_jsonb(v_option))) then
+          raise exception 'Question % has an invalid option', v_question.question_code;
+        end if;
+      end loop;
+    end if;
+  end loop;
+
+  insert into public.form_submission (
+    form_id,
+    profile_id,
+    user_id,
+    metadata
+  )
+  values (
+    v_campaign.form_id,
+    v_campaign.survey_profile_id,
+    auth.uid(),
+    jsonb_build_object(
+      'source', 'semester_post_program_survey',
+      'campaign_id', v_campaign.id,
+      'respondent_profile_id', v_actor_profile_id,
+      'request', p_request_metadata
+    )
+  )
+  returning id into v_submission_id;
+
+  insert into public.form_answer (submission_id, question_code, value)
+  select v_submission_id, answer.question_code, answer.value
+  from jsonb_each(p_answers) as answer(question_code, value)
+  join public.form_question_map as map
+    on map.form_id = v_campaign.form_id
+   and map.question_code = answer.question_code
+  where answer.value <> 'null'::jsonb;
+
+  update public.post_program_survey_campaign
+  set completed_submission_id = v_submission_id,
+      completed_at = now()
+  where id = v_campaign.id
+  returning completed_at into completed_at;
+
+  insert into public.post_program_survey_campaign_audit (
+    campaign_id,
+    event_type,
+    actor_user_id,
+    source,
+    details
+  )
+  values (
+    v_campaign.id,
+    'completed_submission',
+    auth.uid(),
+    'user',
+    jsonb_build_object('submission_id', v_submission_id, 'respondent_profile_id', v_actor_profile_id)
+  );
+
+  return query select v_campaign.id, true, v_submission_id, completed_at;
+end;
+$$;
+
+create or replace function public.manually_complete_post_program_survey_campaign(
+  p_campaign_id uuid,
+  p_reason text
+)
+returns table (
+  campaign_id uuid,
+  completed_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_campaign public.post_program_survey_campaign%rowtype;
+begin
+  if not public.authorize('post_program_survey.manage') then
+    raise exception 'Campaign management access denied';
+  end if;
+
+  if nullif(btrim(p_reason), '') is null then
+    raise exception 'A completion reason is required';
+  end if;
+
+  select *
+    into v_campaign
+  from public.post_program_survey_campaign
+  where id = p_campaign_id
+  for update;
+
+  if not found then
+    raise exception 'Campaign not found';
+  end if;
+
+  if v_campaign.completed_at is not null then
+    return query select v_campaign.id, v_campaign.completed_at;
+    return;
+  end if;
+
+  update public.post_program_survey_campaign
+  set completed_at = now(),
+      manually_completed_at = now(),
+      manually_completed_by_user_id = auth.uid(),
+      manual_completion_reason = btrim(p_reason)
+  where id = v_campaign.id
+  returning completed_at into completed_at;
+
+  insert into public.post_program_survey_campaign_audit (
+    campaign_id,
+    event_type,
+    actor_user_id,
+    actor_role,
+    source,
+    details
+  )
+  values (
+    v_campaign.id,
+    'completed_manual',
+    auth.uid(),
+    public.current_user_role()::text,
+    'staff',
+    jsonb_build_object('reason', btrim(p_reason))
+  );
+
+  return query select v_campaign.id, completed_at;
+end;
+$$;
+
+revoke all on function public.ensure_post_program_survey_campaign(uuid, uuid, uuid, uuid, uuid[], uuid[], timestamptz) from public, anon, authenticated;
+revoke all on function public.complete_post_program_survey_campaign(uuid, jsonb, jsonb) from public, anon;
+revoke all on function public.manually_complete_post_program_survey_campaign(uuid, text) from public, anon;
+
+grant execute on function public.ensure_post_program_survey_campaign(uuid, uuid, uuid, uuid, uuid[], uuid[], timestamptz) to service_role;
+grant execute on function public.complete_post_program_survey_campaign(uuid, jsonb, jsonb) to authenticated;
+grant execute on function public.manually_complete_post_program_survey_campaign(uuid, text) to authenticated;

--- a/supabase/schemas/19_post_program_survey_email_events.sql
+++ b/supabase/schemas/19_post_program_survey_email_events.sql
@@ -1,0 +1,164 @@
+create table public.post_program_survey_email_event (
+  id uuid primary key default gen_random_uuid(),
+  campaign_id uuid not null references public.post_program_survey_campaign (id) on delete cascade,
+  template_key text not null check (
+    template_key in (
+      'post_program_survey_initial_v1',
+      'post_program_survey_reminder_v1',
+      'post_program_survey_gift_card_v1'
+    )
+  ),
+  slot_at timestamptz not null,
+  recipient_email text not null,
+  due_at timestamptz not null,
+  claimed_at timestamptz,
+  claim_expires_at timestamptz,
+  sent_at timestamptz,
+  email_message_id uuid references public.email_message (id) on delete set null,
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  next_attempt_at timestamptz,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (campaign_id, template_key, slot_at, recipient_email),
+  check (
+    (claimed_at is null and claim_expires_at is null)
+    or (claimed_at is not null and claim_expires_at is not null)
+  )
+);
+
+create index post_program_survey_email_event_due_idx
+  on public.post_program_survey_email_event (due_at, id)
+  where sent_at is null;
+
+create or replace function public.touch_post_program_survey_email_event_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger on_post_program_survey_email_event_updated_set_timestamp
+before update on public.post_program_survey_email_event
+for each row execute function public.touch_post_program_survey_email_event_updated_at();
+
+alter table public.post_program_survey_email_event enable row level security;
+
+create policy post_program_survey_email_event_read_manager
+  on public.post_program_survey_email_event
+  for select
+  using (public.authorize('post_program_survey.manage'));
+
+create policy post_program_survey_email_event_read_auth_admin
+  on public.post_program_survey_email_event
+  for select
+  to supabase_auth_admin
+  using (true);
+
+grant all on table public.post_program_survey_email_event to supabase_auth_admin;
+revoke all on table public.post_program_survey_email_event from authenticated, anon, public;
+grant select on table public.post_program_survey_email_event to authenticated;
+
+create or replace function public.claim_post_program_survey_email_events(
+  p_now timestamptz,
+  p_limit integer default 100
+)
+returns table (
+  id uuid,
+  campaign_id uuid,
+  template_key text,
+  recipient_email text,
+  slot_at timestamptz,
+  attempt_count integer
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with candidates as (
+    select event.id
+    from public.post_program_survey_email_event as event
+    join public.post_program_survey_campaign as campaign on campaign.id = event.campaign_id
+    where event.sent_at is null
+      and campaign.completed_at is null
+      and event.due_at <= p_now
+      and coalesce(event.next_attempt_at, event.due_at) <= p_now
+      and (event.claim_expires_at is null or event.claim_expires_at <= p_now)
+    order by event.due_at, event.id
+    limit greatest(1, least(p_limit, 500))
+    for update of event skip locked
+  ), claimed as (
+    update public.post_program_survey_email_event as event
+    set
+      claimed_at = p_now,
+      claim_expires_at = p_now + interval '15 minutes',
+      attempt_count = event.attempt_count + 1,
+      last_error = null
+    from candidates
+    where event.id = candidates.id
+    returning event.id, event.campaign_id, event.template_key, event.recipient_email, event.slot_at, event.attempt_count
+  )
+  select * from claimed;
+$$;
+
+create or replace function public.complete_post_program_survey_email_event(
+  p_event_id uuid,
+  p_email_message_id uuid
+)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  with updated as (
+    update public.post_program_survey_email_event
+    set
+      sent_at = now(),
+      email_message_id = p_email_message_id,
+      claimed_at = null,
+      claim_expires_at = null,
+      next_attempt_at = null,
+      last_error = null
+    where id = p_event_id
+      and sent_at is null
+      and claimed_at is not null
+    returning id
+  )
+  select exists (select 1 from updated);
+$$;
+
+create or replace function public.fail_post_program_survey_email_event(
+  p_event_id uuid,
+  p_error text
+)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  with updated as (
+    update public.post_program_survey_email_event
+    set
+      claimed_at = null,
+      claim_expires_at = null,
+      next_attempt_at = now() + make_interval(mins => least(240, 15 * greatest(1, attempt_count))),
+      last_error = left(coalesce(p_error, 'Unknown email failure'), 1000)
+    where id = p_event_id
+      and sent_at is null
+    returning id
+  )
+  select exists (select 1 from updated);
+$$;
+
+revoke all on function public.claim_post_program_survey_email_events(timestamptz, integer) from public, anon, authenticated;
+revoke all on function public.complete_post_program_survey_email_event(uuid, uuid) from public, anon, authenticated;
+revoke all on function public.fail_post_program_survey_email_event(uuid, text) from public, anon, authenticated;
+
+grant execute on function public.claim_post_program_survey_email_events(timestamptz, integer) to service_role;
+grant execute on function public.complete_post_program_survey_email_event(uuid, uuid) to service_role;
+grant execute on function public.fail_post_program_survey_email_event(uuid, text) to service_role;

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.1"
-  }
   public: {
     Tables: {
       class: {
@@ -1863,6 +1858,206 @@ export type Database = {
           },
         ]
       }
+      post_program_survey_campaign: {
+        Row: {
+          available_at: string
+          completed_at: string | null
+          completed_submission_id: string | null
+          created_at: string
+          family_anchor_profile_id: string
+          form_id: string
+          id: string
+          initial_sent_at: string | null
+          last_normal_reminder_on: string | null
+          manual_completion_reason: string | null
+          manually_completed_at: string | null
+          manually_completed_by_user_id: string | null
+          semester_id: string
+          survey_profile_id: string
+          updated_at: string
+        }
+        Insert: {
+          available_at: string
+          completed_at?: string | null
+          completed_submission_id?: string | null
+          created_at?: string
+          family_anchor_profile_id: string
+          form_id: string
+          id?: string
+          initial_sent_at?: string | null
+          last_normal_reminder_on?: string | null
+          manual_completion_reason?: string | null
+          manually_completed_at?: string | null
+          manually_completed_by_user_id?: string | null
+          semester_id: string
+          survey_profile_id: string
+          updated_at?: string
+        }
+        Update: {
+          available_at?: string
+          completed_at?: string | null
+          completed_submission_id?: string | null
+          created_at?: string
+          family_anchor_profile_id?: string
+          form_id?: string
+          id?: string
+          initial_sent_at?: string | null
+          last_normal_reminder_on?: string | null
+          manual_completion_reason?: string | null
+          manually_completed_at?: string | null
+          manually_completed_by_user_id?: string | null
+          semester_id?: string
+          survey_profile_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "post_program_survey_campaign_completed_submission_id_fkey"
+            columns: ["completed_submission_id"]
+            isOneToOne: true
+            referencedRelation: "form_submission"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "post_program_survey_campaign_family_anchor_profile_id_fkey"
+            columns: ["family_anchor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profile"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "post_program_survey_campaign_form_id_fkey"
+            columns: ["form_id"]
+            isOneToOne: false
+            referencedRelation: "form"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "post_program_survey_campaign_semester_id_fkey"
+            columns: ["semester_id"]
+            isOneToOne: false
+            referencedRelation: "semester"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "post_program_survey_campaign_survey_profile_id_fkey"
+            columns: ["survey_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profile"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      post_program_survey_campaign_audit: {
+        Row: {
+          actor_role: string | null
+          actor_user_id: string | null
+          campaign_id: string
+          created_at: string
+          details: Json
+          event_type: string
+          id: string
+          source: string
+        }
+        Insert: {
+          actor_role?: string | null
+          actor_user_id?: string | null
+          campaign_id: string
+          created_at?: string
+          details?: Json
+          event_type: string
+          id?: string
+          source: string
+        }
+        Update: {
+          actor_role?: string | null
+          actor_user_id?: string | null
+          campaign_id?: string
+          created_at?: string
+          details?: Json
+          event_type?: string
+          id?: string
+          source?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "post_program_survey_campaign_audit_campaign_id_fkey"
+            columns: ["campaign_id"]
+            isOneToOne: false
+            referencedRelation: "post_program_survey_campaign"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      post_program_survey_campaign_enrollment: {
+        Row: {
+          campaign_id: string
+          created_at: string
+          gift_card_notice_sent_at: string | null
+          workshop_enrollment_id: string
+        }
+        Insert: {
+          campaign_id: string
+          created_at?: string
+          gift_card_notice_sent_at?: string | null
+          workshop_enrollment_id: string
+        }
+        Update: {
+          campaign_id?: string
+          created_at?: string
+          gift_card_notice_sent_at?: string | null
+          workshop_enrollment_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "post_program_survey_campaign_enroll_workshop_enrollment_id_fkey"
+            columns: ["workshop_enrollment_id"]
+            isOneToOne: true
+            referencedRelation: "workshop_enrollment"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "post_program_survey_campaign_enrollment_campaign_id_fkey"
+            columns: ["campaign_id"]
+            isOneToOne: false
+            referencedRelation: "post_program_survey_campaign"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      post_program_survey_campaign_member: {
+        Row: {
+          campaign_id: string
+          created_at: string
+          profile_id: string
+        }
+        Insert: {
+          campaign_id: string
+          created_at?: string
+          profile_id: string
+        }
+        Update: {
+          campaign_id?: string
+          created_at?: string
+          profile_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "post_program_survey_campaign_member_campaign_id_fkey"
+            columns: ["campaign_id"]
+            isOneToOne: false
+            referencedRelation: "post_program_survey_campaign"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "post_program_survey_campaign_member_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profile"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profile: {
         Row: {
           address_fingerprint: string | null
@@ -2721,6 +2916,19 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      complete_post_program_survey_campaign: {
+        Args: {
+          p_answers: Json
+          p_campaign_id: string
+          p_request_metadata?: Json
+        }
+        Returns: {
+          campaign_id: string
+          completed: boolean
+          completed_at: string
+          submission_id: string
+        }[]
+      }
       current_profile_id: { Args: never; Returns: string }
       current_user_role: {
         Args: never
@@ -2744,9 +2952,28 @@ export type Database = {
         Args: never
         Returns: undefined
       }
+      ensure_post_program_survey_campaign: {
+        Args: {
+          p_available_at: string
+          p_family_anchor_profile_id: string
+          p_form_id: string
+          p_member_profile_ids: string[]
+          p_semester_id: string
+          p_survey_profile_id: string
+          p_workshop_enrollment_ids: string[]
+        }
+        Returns: string
+      }
       has_completed_required_forms: {
         Args: { p_user_id: string }
         Returns: boolean
+      }
+      manually_complete_post_program_survey_campaign: {
+        Args: { p_campaign_id: string; p_reason: string }
+        Returns: {
+          campaign_id: string
+          completed_at: string
+        }[]
       }
       normalize_address_fingerprint: {
         Args: {
@@ -2900,6 +3127,7 @@ export type Database = {
         | "class_attendance_photo_upload_attempt.read"
         | "class_attendance_photo_upload_attempt.update"
         | "class_attendance_photo_upload_attempt.delete"
+        | "post_program_survey.manage"
       app_role:
         | "unassigned"
         | "admin"
@@ -2930,13 +3158,13 @@ export type Database = {
       form_assignment_status: "pending" | "submitted"
       form_question_type:
         | "text"
+        | "number"
         | "single_choice"
         | "multi_choice"
         | "date"
         | "address"
         | "agreement"
         | "checkbox"
-        | "number"
         | "no-input-text"
       gift_card_allocation_status: "allocated" | "sent" | "opened"
       gift_card_asset_status:
@@ -3168,6 +3396,7 @@ export const Constants = {
         "class_attendance_photo_upload_attempt.read",
         "class_attendance_photo_upload_attempt.update",
         "class_attendance_photo_upload_attempt.delete",
+        "post_program_survey.manage",
       ],
       app_role: [
         "unassigned",
@@ -3202,13 +3431,13 @@ export const Constants = {
       form_assignment_status: ["pending", "submitted"],
       form_question_type: [
         "text",
+        "number",
         "single_choice",
         "multi_choice",
         "date",
         "address",
         "agreement",
         "checkbox",
-        "number",
         "no-input-text",
       ],
       gift_card_allocation_status: ["allocated", "sent", "opened"],

--- a/web/app/lib/database.types.ts
+++ b/web/app/lib/database.types.ts
@@ -2058,6 +2058,75 @@ export type Database = {
           },
         ]
       }
+      post_program_survey_email_event: {
+        Row: {
+          attempt_count: number
+          campaign_id: string
+          claim_expires_at: string | null
+          claimed_at: string | null
+          created_at: string
+          due_at: string
+          email_message_id: string | null
+          id: string
+          last_error: string | null
+          next_attempt_at: string | null
+          recipient_email: string
+          sent_at: string | null
+          slot_at: string
+          template_key: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          campaign_id: string
+          claim_expires_at?: string | null
+          claimed_at?: string | null
+          created_at?: string
+          due_at: string
+          email_message_id?: string | null
+          id?: string
+          last_error?: string | null
+          next_attempt_at?: string | null
+          recipient_email: string
+          sent_at?: string | null
+          slot_at: string
+          template_key: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          campaign_id?: string
+          claim_expires_at?: string | null
+          claimed_at?: string | null
+          created_at?: string
+          due_at?: string
+          email_message_id?: string | null
+          id?: string
+          last_error?: string | null
+          next_attempt_at?: string | null
+          recipient_email?: string
+          sent_at?: string | null
+          slot_at?: string
+          template_key?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "post_program_survey_email_event_campaign_id_fkey"
+            columns: ["campaign_id"]
+            isOneToOne: false
+            referencedRelation: "post_program_survey_campaign"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "post_program_survey_email_event_email_message_id_fkey"
+            columns: ["email_message_id"]
+            isOneToOne: false
+            referencedRelation: "email_message"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profile: {
         Row: {
           address_fingerprint: string | null
@@ -2916,6 +2985,17 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      claim_post_program_survey_email_events: {
+        Args: { p_limit?: number; p_now: string }
+        Returns: {
+          attempt_count: number
+          campaign_id: string
+          id: string
+          recipient_email: string
+          slot_at: string
+          template_key: string
+        }[]
+      }
       complete_post_program_survey_campaign: {
         Args: {
           p_answers: Json
@@ -2928,6 +3008,10 @@ export type Database = {
           completed_at: string
           submission_id: string
         }[]
+      }
+      complete_post_program_survey_email_event: {
+        Args: { p_email_message_id: string; p_event_id: string }
+        Returns: boolean
       }
       current_profile_id: { Args: never; Returns: string }
       current_user_role: {
@@ -2963,6 +3047,33 @@ export type Database = {
           p_workshop_enrollment_ids: string[]
         }
         Returns: string
+      }
+      ensure_post_program_survey_email_draft: {
+        Args: {
+          p_body: string
+          p_description: string
+          p_draft_key: string
+          p_subject: string
+          p_title: string
+          p_trigger_summary: string
+        }
+        Returns: undefined
+      }
+      ensure_post_program_survey_gift_card_email_draft: {
+        Args: never
+        Returns: undefined
+      }
+      ensure_post_program_survey_initial_email_draft: {
+        Args: never
+        Returns: undefined
+      }
+      ensure_post_program_survey_reminder_email_draft: {
+        Args: never
+        Returns: undefined
+      }
+      fail_post_program_survey_email_event: {
+        Args: { p_error: string; p_event_id: string }
+        Returns: boolean
       }
       has_completed_required_forms: {
         Args: { p_user_id: string }

--- a/web/app/lib/email/templates/index.ts
+++ b/web/app/lib/email/templates/index.ts
@@ -26,6 +26,12 @@ import {
   renderMealKitPickupReminderEmail,
   type MealKitPickupReminderTemplateData,
 } from '@/lib/email/templates/meal-kit-pickup-reminder'
+import {
+  renderPostProgramSurveyGiftCardEmail,
+  renderPostProgramSurveyInitialEmail,
+  renderPostProgramSurveyReminderEmail,
+  type PostProgramSurveyTemplateData,
+} from '@/lib/email/templates/post-program-survey'
 
 export type EmailTemplateMap = {
   family_enrollment_requested_v1: FamilyEnrollmentRequestedTemplateData
@@ -35,6 +41,9 @@ export type EmailTemplateMap = {
   gift_card_inventory_low_v1: GiftCardInventoryLowTemplateData
   gift_card_reminder_v1: GiftCardReminderTemplateData
   meal_kit_pickup_reminder_v1: MealKitPickupReminderTemplateData
+  post_program_survey_initial_v1: PostProgramSurveyTemplateData
+  post_program_survey_reminder_v1: PostProgramSurveyTemplateData
+  post_program_survey_gift_card_v1: PostProgramSurveyTemplateData
 }
 
 export type EmailTemplateKey = keyof EmailTemplateMap
@@ -64,6 +73,15 @@ export const emailTemplates: {
   },
   meal_kit_pickup_reminder_v1: {
     render: renderMealKitPickupReminderEmail,
+  },
+  post_program_survey_initial_v1: {
+    render: renderPostProgramSurveyInitialEmail,
+  },
+  post_program_survey_reminder_v1: {
+    render: renderPostProgramSurveyReminderEmail,
+  },
+  post_program_survey_gift_card_v1: {
+    render: renderPostProgramSurveyGiftCardEmail,
   },
 }
 

--- a/web/app/lib/email/templates/post-program-survey.ts
+++ b/web/app/lib/email/templates/post-program-survey.ts
@@ -1,0 +1,89 @@
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+export type PostProgramSurveyTemplateData = {
+  recipientName: string
+  surveyUrl: string
+}
+
+const renderPostProgramSurveyEmail = ({
+  recipientName,
+  surveyUrl,
+  subject,
+  paragraphs,
+}: PostProgramSurveyTemplateData & {
+  subject: string
+  paragraphs: string[]
+}) => {
+  const safeName = escapeHtml(recipientName.trim() || 'there')
+  const safeUrl = escapeHtml(surveyUrl)
+  const htmlParagraphs = paragraphs.map(paragraph => `<p style="margin:0 0 16px 0;">${escapeHtml(paragraph)}</p>`).join('')
+
+  return {
+    subject,
+    text: `Hi ${recipientName.trim() || 'there'},\n\n${paragraphs.join('\n\n')}\n\nComplete the survey: ${surveyUrl}\n\nThe summerlunch+ Team`,
+    html: `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background-color:#f6f8fb;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0;padding:24px;background-color:#f6f8fb;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background-color:#ffffff;border-radius:12px;overflow:hidden;">
+            <tr>
+              <td style="padding:24px 24px 8px 24px;text-align:center;">
+                <img src="https://cdn.summerlunchplus.com/summerlunch%2B.png" alt="SummerLunch Plus" width="180" style="display:block;margin:0 auto;border:0;outline:none;text-decoration:none;height:auto;" />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
+                <p style="margin:0 0 16px 0;">Hi ${safeName},</p>
+                ${htmlParagraphs}
+                <p style="margin:0 0 16px 0;"><a href="${safeUrl}">Complete the post-program survey</a></p>
+                <p style="margin:0;">The summerlunch+ Team</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`,
+  }
+}
+
+export const renderPostProgramSurveyInitialEmail = (data: PostProgramSurveyTemplateData) =>
+  renderPostProgramSurveyEmail({
+    ...data,
+    subject: 'Please complete your summerlunch+ post-program evaluation',
+    paragraphs: [
+      'Thank you for participating in the summerlunch+ program!',
+      'Just as you completed the pre-program questions when you registered, we now have our post-program evaluation for you to complete.',
+      'Please take a few minutes to answer the questions and share your experience with us. Your feedback helps us understand the impact of summerlunch+ and improve the program for future families.',
+    ],
+  })
+
+export const renderPostProgramSurveyReminderEmail = (data: PostProgramSurveyTemplateData) =>
+  renderPostProgramSurveyEmail({
+    ...data,
+    subject: 'Reminder: complete your summerlunch+ post-program evaluation',
+    paragraphs: [
+      'This is a quick reminder to complete your summerlunch+ post-program evaluation if you have not already done so.',
+      'It only takes a few minutes, and your feedback is very important to us.',
+    ],
+  })
+
+export const renderPostProgramSurveyGiftCardEmail = (data: PostProgramSurveyTemplateData) =>
+  renderPostProgramSurveyEmail({
+    ...data,
+    subject: 'Complete your survey to receive your final grocery gift card',
+    paragraphs: [
+      'It looks like you have still not completed your summerlunch+ post-program evaluation.',
+      'Please complete the survey as soon as possible.',
+      'To receive your final Week 8 grocery gift card, you must complete the post-program evaluation.',
+    ],
+  })

--- a/web/app/lib/gift-cards/runner.server.ts
+++ b/web/app/lib/gift-cards/runner.server.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/gift-cards/release.server'
 import { scanByIdKeyset } from '@/lib/supabase/keyset-pagination.server'
 import { adminClient } from '@/lib/supabase/adminClient'
+import { getPostProgramSurveyHold } from '@/lib/post-program-survey/gift-card-guard.server'
 
 import { hashGlrToken, newGlrToken } from './token.server'
 
@@ -702,6 +703,12 @@ const allocateGiftCards = async (): Promise<AllocationSummary> => {
         continue
       }
 
+      const postProgramHold = await getPostProgramSurveyHold(row.class_id, row.profile_id)
+      if (postProgramHold.held) {
+        rowsSkipped += 1
+        continue
+      }
+
       const requestedProvider = requestedProviderByProfileId.get(row.profile_id) ?? null
       if (requestedProvider === 'meal_kit') {
         rowsSkipped += 1
@@ -915,6 +922,12 @@ const sendDueReminders = async (appOrigin: string): Promise<ReminderSummary> => 
 
     try {
     if (row.blocked) {
+      remindersSkipped += 1
+      continue
+    }
+
+    const postProgramHold = await getPostProgramSurveyHold(row.class_id, row.profile_id)
+    if (postProgramHold.held) {
       remindersSkipped += 1
       continue
     }

--- a/web/app/lib/post-program-survey/campaign.server.ts
+++ b/web/app/lib/post-program-survey/campaign.server.ts
@@ -1,0 +1,86 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/database.types'
+import { resolveConnectedProfileIds } from '@/lib/family.server'
+import { resolveSemesterSurveyForm } from '@/lib/semester-survey.server'
+import { adminClient } from '@/lib/supabase/adminClient'
+
+type CampaignClient = SupabaseClient<Database>
+
+export type PostProgramSurveyCampaign = Pick<
+  Database['public']['Tables']['post_program_survey_campaign']['Row'],
+  'id' | 'semester_id' | 'form_id' | 'survey_profile_id' | 'available_at' | 'completed_at'
+>
+
+export async function ensurePostProgramSurveyCampaign({
+  semesterId,
+  enrollmentProfileId,
+  availableAt,
+}: {
+  semesterId: string
+  enrollmentProfileId: string
+  availableAt: string
+}) {
+  const familyProfileIds = Array.from(new Set(await resolveConnectedProfileIds(adminClient, [enrollmentProfileId]))).sort()
+  const familyAnchorProfileId = familyProfileIds[0]
+  if (!familyAnchorProfileId) {
+    throw new Error('Campaign family is empty')
+  }
+
+  const survey = await resolveSemesterSurveyForm(semesterId, 'post_program_survey')
+  if (!survey.formId) {
+    return null
+  }
+
+  const { data: enrollments, error: enrollmentError } = await adminClient
+    .from('workshop_enrollment')
+    .select('id')
+    .eq('semester_id', semesterId)
+    .eq('status', 'approved')
+    .in('profile_id', familyProfileIds)
+
+  if (enrollmentError) throw new Error(enrollmentError.message)
+  const enrollmentIds = (enrollments ?? []).map(enrollment => enrollment.id)
+  if (!enrollmentIds.length) return null
+
+  const { data: campaignId, error: campaignError } = await adminClient.rpc('ensure_post_program_survey_campaign', {
+    p_semester_id: semesterId,
+    p_form_id: survey.formId,
+    p_family_anchor_profile_id: familyAnchorProfileId,
+    p_survey_profile_id: enrollmentProfileId,
+    p_member_profile_ids: familyProfileIds,
+    p_workshop_enrollment_ids: enrollmentIds,
+    p_available_at: availableAt,
+  })
+
+  if (campaignError) throw new Error(campaignError.message)
+  return campaignId
+}
+
+export async function loadPostProgramSurveyCampaignForCurrentProfile(
+  supabase: CampaignClient,
+  semesterId: string
+): Promise<PostProgramSurveyCampaign | null> {
+  const { data: profileId, error: profileError } = await supabase.rpc('current_profile_id')
+  if (profileError) throw new Error(profileError.message)
+  if (!profileId) return null
+
+  const { data: membership, error: membershipError } = await supabase
+    .from('post_program_survey_campaign_member')
+    .select('campaign_id')
+    .eq('profile_id', profileId)
+
+  if (membershipError) throw new Error(membershipError.message)
+  const campaignIds = (membership ?? []).map(member => member.campaign_id)
+  if (!campaignIds.length) return null
+
+  const { data: campaign, error: campaignError } = await supabase
+    .from('post_program_survey_campaign')
+    .select('id, semester_id, form_id, survey_profile_id, available_at, completed_at')
+    .eq('semester_id', semesterId)
+    .in('id', campaignIds)
+    .maybeSingle()
+
+  if (campaignError) throw new Error(campaignError.message)
+  return campaign
+}

--- a/web/app/lib/post-program-survey/campaign.server.ts
+++ b/web/app/lib/post-program-survey/campaign.server.ts
@@ -84,3 +84,32 @@ export async function loadPostProgramSurveyCampaignForCurrentProfile(
   if (campaignError) throw new Error(campaignError.message)
   return campaign
 }
+
+export async function loadIncompletePostProgramSurveyCampaignsForCurrentProfile(
+  supabase: CampaignClient,
+  now = new Date().toISOString()
+): Promise<PostProgramSurveyCampaign[]> {
+  const { data: profileId, error: profileError } = await supabase.rpc('current_profile_id')
+  if (profileError) throw new Error(profileError.message)
+  if (!profileId) return []
+
+  const { data: membership, error: membershipError } = await supabase
+    .from('post_program_survey_campaign_member')
+    .select('campaign_id')
+    .eq('profile_id', profileId)
+
+  if (membershipError) throw new Error(membershipError.message)
+  const campaignIds = (membership ?? []).map(member => member.campaign_id)
+  if (!campaignIds.length) return []
+
+  const { data: campaigns, error: campaignError } = await supabase
+    .from('post_program_survey_campaign')
+    .select('id, semester_id, form_id, survey_profile_id, available_at, completed_at')
+    .in('id', campaignIds)
+    .is('completed_at', null)
+    .lte('available_at', now)
+    .order('available_at', { ascending: true })
+
+  if (campaignError) throw new Error(campaignError.message)
+  return campaigns ?? []
+}

--- a/web/app/lib/post-program-survey/gift-card-guard.server.ts
+++ b/web/app/lib/post-program-survey/gift-card-guard.server.ts
@@ -1,0 +1,52 @@
+import { adminClient } from '@/lib/supabase/adminClient'
+import { isLastWorkshopClass } from '@/lib/post-program-survey/gift-card-guard'
+
+export type PostProgramSurveyHold = {
+  held: boolean
+  reason: string | null
+}
+
+export async function getPostProgramSurveyHold(classId: string, profileId: string): Promise<PostProgramSurveyHold> {
+  const { data: classRow, error: classError } = await adminClient
+    .from('class')
+    .select('id, workshop_id, ends_at, workshop:workshop_id(semester_id)')
+    .eq('id', classId)
+    .maybeSingle()
+
+  if (classError || !classRow?.workshop_id) return { held: false, reason: null }
+  const workshop = Array.isArray(classRow.workshop) ? classRow.workshop[0] : classRow.workshop
+  if (!workshop?.semester_id) return { held: false, reason: null }
+
+  const [{ data: activeForm }, { data: workshopClasses }, { data: enrollment }] = await Promise.all([
+    adminClient
+      .from('semester_form_requirement')
+      .select('id')
+      .eq('semester_id', workshop.semester_id)
+      .eq('is_active', true)
+      .in('kind', ['post_survey', 'post_program_survey'] as never)
+      .maybeSingle(),
+    adminClient.from('class').select('id, ends_at').eq('workshop_id', classRow.workshop_id),
+    adminClient
+      .from('workshop_enrollment')
+      .select('id')
+      .eq('workshop_id', classRow.workshop_id)
+      .eq('semester_id', workshop.semester_id)
+      .eq('profile_id', profileId)
+      .eq('status', 'approved')
+      .maybeSingle(),
+  ])
+
+  if (!activeForm?.id || !enrollment?.id || !isLastWorkshopClass({ classId, classEndsAt: classRow.ends_at, workshopClasses: workshopClasses ?? [] })) {
+    return { held: false, reason: null }
+  }
+
+  const { data: campaignEnrollment } = await adminClient
+    .from('post_program_survey_campaign_enrollment')
+    .select('campaign:campaign_id(completed_at)')
+    .eq('workshop_enrollment_id', enrollment.id)
+    .maybeSingle()
+
+  const campaign = Array.isArray(campaignEnrollment?.campaign) ? campaignEnrollment?.campaign[0] : campaignEnrollment?.campaign
+  if (!campaign || campaign.completed_at) return { held: false, reason: null }
+  return { held: true, reason: 'Post-program survey required' }
+}

--- a/web/app/lib/post-program-survey/gift-card-guard.ts
+++ b/web/app/lib/post-program-survey/gift-card-guard.ts
@@ -1,0 +1,12 @@
+export const isLastWorkshopClass = ({
+  classId,
+  classEndsAt,
+  workshopClasses,
+}: {
+  classId: string
+  classEndsAt: string
+  workshopClasses: Array<{ id: string; ends_at: string }>
+}) => {
+  const latestEndsAt = workshopClasses.reduce<string | null>((latest, row) => (!latest || row.ends_at > latest ? row.ends_at : latest), null)
+  return latestEndsAt === classEndsAt && workshopClasses.some(row => row.id === classId)
+}

--- a/web/app/lib/post-program-survey/runner.server.ts
+++ b/web/app/lib/post-program-survey/runner.server.ts
@@ -1,21 +1,13 @@
 import { sendTemplateEmail } from '@/lib/email/send-email.server'
 import { ensurePostProgramSurveyCampaign } from '@/lib/post-program-survey/campaign.server'
+import { assertPostProgramSurveySchedule, POST_PROGRAM_SURVEY_SCHEDULE } from '@/lib/post-program-survey/schedule'
 import { adminClient } from '@/lib/supabase/adminClient'
 
 const CAMPAIGN_PAGE_SIZE = 200
 const EVENT_CLAIM_LIMIT = 100
 
-const scheduledSlots = [
-  { at: '2026-08-14T13:00:00.000Z', templateKey: 'post_program_survey_initial_v1' },
-  { at: '2026-08-19T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
-  { at: '2026-08-21T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
-  { at: '2026-08-26T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
-  { at: '2026-08-28T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
-  { at: '2026-09-02T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
-  { at: '2026-09-04T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
-] as const
-
-type TemplateKey = (typeof scheduledSlots)[number]['templateKey']
+type TemplateKey = (typeof POST_PROGRAM_SURVEY_SCHEDULE)[number]['templateKey']
+assertPostProgramSurveySchedule()
 
 type RunSummary = {
   runId: string
@@ -63,7 +55,7 @@ const ensureCampaigns = async () => {
       const campaignId = await ensurePostProgramSurveyCampaign({
         semesterId: row.semester_id,
         enrollmentProfileId: row.profile_id,
-        availableAt: scheduledSlots[0].at,
+        availableAt: POST_PROGRAM_SURVEY_SCHEDULE[0].at,
       })
       if (campaignId) campaignsEnsured += 1
     }
@@ -115,7 +107,7 @@ const createScheduledEvents = async (now: string, appOrigin: string) => {
 
   const eventRows = campaigns.flatMap(campaign =>
     Array.from(emailsByCampaign.get(campaign.id) ?? []).flatMap(recipientEmail =>
-      scheduledSlots.map(slot => ({
+      POST_PROGRAM_SURVEY_SCHEDULE.map(slot => ({
         campaign_id: campaign.id,
         template_key: slot.templateKey,
         slot_at: slot.at,

--- a/web/app/lib/post-program-survey/runner.server.ts
+++ b/web/app/lib/post-program-survey/runner.server.ts
@@ -1,0 +1,250 @@
+import { sendTemplateEmail } from '@/lib/email/send-email.server'
+import { ensurePostProgramSurveyCampaign } from '@/lib/post-program-survey/campaign.server'
+import { adminClient } from '@/lib/supabase/adminClient'
+
+const CAMPAIGN_PAGE_SIZE = 200
+const EVENT_CLAIM_LIMIT = 100
+
+const scheduledSlots = [
+  { at: '2026-08-14T13:00:00.000Z', templateKey: 'post_program_survey_initial_v1' },
+  { at: '2026-08-19T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
+  { at: '2026-08-21T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
+  { at: '2026-08-26T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+  { at: '2026-08-28T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+  { at: '2026-09-02T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+  { at: '2026-09-04T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+] as const
+
+type TemplateKey = (typeof scheduledSlots)[number]['templateKey']
+
+type RunSummary = {
+  runId: string
+  campaignsEnsured: number
+  eventsCreated: number
+  eventsClaimed: number
+  emailsSent: number
+  emailsSkipped: number
+  emailFailures: number
+  errors: string[]
+}
+
+type ClaimedEvent = {
+  id: string
+  campaign_id: string
+  template_key: string
+  recipient_email: string
+  slot_at: string
+  attempt_count: number
+}
+
+const publicOrigin = (appOrigin: string) => (process.env.PUBLIC_APP_ORIGIN?.trim().replace(/\/$/, '') || appOrigin)
+
+const ensureCampaigns = async () => {
+  let afterId = ''
+  let campaignsEnsured = 0
+
+  while (true) {
+    let query = adminClient
+      .from('workshop_enrollment')
+      .select('id, semester_id, profile_id')
+      .eq('status', 'approved')
+      .not('profile_id', 'is', null)
+      .order('id', { ascending: true })
+      .limit(CAMPAIGN_PAGE_SIZE)
+
+    if (afterId) query = query.gt('id', afterId)
+    const { data: rows, error } = await query
+    if (error) throw new Error(error.message)
+    if (!rows?.length) break
+
+    for (const row of rows) {
+      afterId = row.id
+      if (!row.profile_id) continue
+      const campaignId = await ensurePostProgramSurveyCampaign({
+        semesterId: row.semester_id,
+        enrollmentProfileId: row.profile_id,
+        availableAt: scheduledSlots[0].at,
+      })
+      if (campaignId) campaignsEnsured += 1
+    }
+
+    if (rows.length < CAMPAIGN_PAGE_SIZE) break
+  }
+
+  return campaignsEnsured
+}
+
+const createScheduledEvents = async (now: string, appOrigin: string) => {
+  const { data: campaigns, error: campaignError } = await adminClient
+    .from('post_program_survey_campaign')
+    .select('id, semester_id, completed_at')
+    .is('completed_at', null)
+    .lte('available_at', now)
+
+  if (campaignError) throw new Error(campaignError.message)
+  if (!campaigns?.length) return 0
+
+  const campaignIds = campaigns.map(campaign => campaign.id)
+  const { data: members, error: memberError } = await adminClient
+    .from('post_program_survey_campaign_member')
+    .select('campaign_id, profile_id')
+    .in('campaign_id', campaignIds)
+
+  if (memberError) throw new Error(memberError.message)
+  const profileIds = Array.from(new Set((members ?? []).map(member => member.profile_id)))
+  if (!profileIds.length) return 0
+
+  const { data: profiles, error: profileError } = await adminClient
+    .from('profile')
+    .select('id, role, email')
+    .in('id', profileIds)
+
+  if (profileError) throw new Error(profileError.message)
+  const profileById = new Map((profiles ?? []).map(profile => [profile.id, profile]))
+  const emailsByCampaign = new Map<string, Set<string>>()
+
+  for (const member of members ?? []) {
+    const profile = profileById.get(member.profile_id)
+    if (profile?.role !== 'guardian') continue
+    const email = profile.email?.trim().toLowerCase()
+    if (!email) continue
+    const emails = emailsByCampaign.get(member.campaign_id) ?? new Set<string>()
+    emails.add(email)
+    emailsByCampaign.set(member.campaign_id, emails)
+  }
+
+  const eventRows = campaigns.flatMap(campaign =>
+    Array.from(emailsByCampaign.get(campaign.id) ?? []).flatMap(recipientEmail =>
+      scheduledSlots.map(slot => ({
+        campaign_id: campaign.id,
+        template_key: slot.templateKey,
+        slot_at: slot.at,
+        recipient_email: recipientEmail,
+        due_at: slot.at,
+      }))
+    )
+  )
+
+  if (!eventRows.length) return 0
+  const { data, error } = await adminClient
+    .from('post_program_survey_email_event')
+    .upsert(eventRows, { onConflict: 'campaign_id,template_key,slot_at,recipient_email', ignoreDuplicates: true })
+    .select('id')
+
+  if (error) throw new Error(error.message)
+  void appOrigin
+  return data?.length ?? 0
+}
+
+const sendClaimedEvents = async (now: string, appOrigin: string) => {
+  const { data: claimed, error: claimError } = await adminClient.rpc('claim_post_program_survey_email_events', {
+    p_now: now,
+    p_limit: EVENT_CLAIM_LIMIT,
+  })
+  if (claimError) throw new Error(claimError.message)
+  const claimedEvents = (claimed ?? []) as ClaimedEvent[]
+  if (!claimedEvents.length) return { eventsClaimed: 0, emailsSent: 0, emailsSkipped: 0, emailFailures: 0, errors: [] as string[] }
+
+  const campaignIds = Array.from(new Set(claimedEvents.map(event => event.campaign_id)))
+  const { data: campaigns, error: campaignError } = await adminClient
+    .from('post_program_survey_campaign')
+    .select('id, semester_id, completed_at')
+    .in('id', campaignIds)
+
+  if (campaignError) throw new Error(campaignError.message)
+  const origin = publicOrigin(appOrigin)
+  let emailsSent = 0
+  let emailsSkipped = 0
+  let emailFailures = 0
+  const errors: string[] = []
+
+  for (const event of claimedEvents) {
+    const campaign = (campaigns ?? []).find(row => row.id === event.campaign_id)
+    const semesterId = campaign?.semester_id
+    if (!semesterId) {
+      await adminClient.rpc('fail_post_program_survey_email_event', {
+        p_event_id: event.id,
+        p_error: 'Campaign semester is missing',
+      })
+      emailFailures += 1
+      continue
+    }
+
+    if (campaign.completed_at) {
+      await adminClient.rpc('fail_post_program_survey_email_event', {
+        p_event_id: event.id,
+        p_error: 'Campaign completed before send',
+      })
+      emailsSkipped += 1
+      continue
+    }
+
+    const result = await sendTemplateEmail({
+      toEmail: event.recipient_email,
+      templateKey: event.template_key as TemplateKey,
+      templateData: {
+        recipientName: '',
+        surveyUrl: `${origin}/semester-surveys/${semesterId}/post-program`,
+      },
+      eventKey: `post-program-survey:${event.id}:attempt:${event.attempt_count}`,
+    })
+
+    if (result.status === 'failed') {
+      await adminClient.rpc('fail_post_program_survey_email_event', {
+        p_event_id: event.id,
+        p_error: result.error ?? 'Email send failed',
+      })
+      emailFailures += 1
+      errors.push(`event ${event.id}: ${result.error ?? 'Email send failed'}`)
+      continue
+    }
+
+    const { error: completeError } = await adminClient.rpc('complete_post_program_survey_email_event', {
+      p_event_id: event.id,
+      p_email_message_id: result.id,
+    })
+    if (completeError) {
+      emailFailures += 1
+      errors.push(`event ${event.id}: ${completeError.message}`)
+      continue
+    }
+
+    if (result.status === 'sent') emailsSent += 1
+    else emailsSkipped += 1
+  }
+
+  return { eventsClaimed: claimedEvents.length, emailsSent, emailsSkipped, emailFailures, errors }
+}
+
+export const runPostProgramSurveyJobs = async ({ appOrigin, runId }: { appOrigin: string; runId: string }): Promise<RunSummary> => {
+  const errors: string[] = []
+  let campaignsEnsured = 0
+  let eventsCreated = 0
+  let sent = { eventsClaimed: 0, emailsSent: 0, emailsSkipped: 0, emailFailures: 0, errors: [] as string[] }
+
+  try {
+    campaignsEnsured = await ensureCampaigns()
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'Campaign creation failed')
+  }
+
+  try {
+    eventsCreated = await createScheduledEvents(new Date().toISOString(), appOrigin)
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'Event creation failed')
+  }
+
+  try {
+    sent = await sendClaimedEvents(new Date().toISOString(), appOrigin)
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'Email send failed')
+  }
+
+  return {
+    runId,
+    campaignsEnsured,
+    eventsCreated,
+    ...sent,
+    errors: [...errors, ...sent.errors],
+  }
+}

--- a/web/app/lib/post-program-survey/runner.server.ts
+++ b/web/app/lib/post-program-survey/runner.server.ts
@@ -31,7 +31,7 @@ type ClaimedEvent = {
 
 const publicOrigin = (appOrigin: string) => (process.env.PUBLIC_APP_ORIGIN?.trim().replace(/\/$/, '') || appOrigin)
 
-const ensureCampaigns = async () => {
+const ensureCampaigns = async (availableAt: string) => {
   let afterId = ''
   let campaignsEnsured = 0
 
@@ -55,7 +55,7 @@ const ensureCampaigns = async () => {
       const campaignId = await ensurePostProgramSurveyCampaign({
         semesterId: row.semester_id,
         enrollmentProfileId: row.profile_id,
-        availableAt: POST_PROGRAM_SURVEY_SCHEDULE[0].at,
+        availableAt,
       })
       if (campaignId) campaignsEnsured += 1
     }
@@ -215,7 +215,7 @@ export const runPostProgramSurveyJobs = async ({ appOrigin, runId }: { appOrigin
   let sent = { eventsClaimed: 0, emailsSent: 0, emailsSkipped: 0, emailFailures: 0, errors: [] as string[] }
 
   try {
-    campaignsEnsured = await ensureCampaigns()
+    campaignsEnsured = await ensureCampaigns(new Date().toISOString())
   } catch (error) {
     errors.push(error instanceof Error ? error.message : 'Campaign creation failed')
   }

--- a/web/app/lib/post-program-survey/schedule.ts
+++ b/web/app/lib/post-program-survey/schedule.ts
@@ -1,0 +1,16 @@
+export const POST_PROGRAM_SURVEY_SCHEDULE = [
+  { at: '2026-08-14T13:00:00.000Z', templateKey: 'post_program_survey_initial_v1' },
+  { at: '2026-08-19T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
+  { at: '2026-08-21T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
+  { at: '2026-08-26T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+  { at: '2026-08-28T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+  { at: '2026-09-02T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+  { at: '2026-09-04T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+] as const
+
+export const assertPostProgramSurveySchedule = () => {
+  const slots = POST_PROGRAM_SURVEY_SCHEDULE.map(slot => slot.at)
+  if (new Set(slots).size !== slots.length || slots.some((slot, index) => index > 0 && slot <= slots[index - 1])) {
+    throw new Error('Post-program survey schedule must contain unique increasing slots')
+  }
+}

--- a/web/app/lib/post-program-survey/submission.server.ts
+++ b/web/app/lib/post-program-survey/submission.server.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { Database, Json } from '@/lib/database.types'
+
+type CampaignClient = SupabaseClient<Database>
+
+export type PostProgramSurveyCompletion = {
+  campaignId: string
+  submissionId: string
+  completedAt: string
+}
+
+export async function completePostProgramSurveyCampaign({
+  supabase,
+  campaignId,
+  answers,
+  requestMetadata,
+}: {
+  supabase: CampaignClient
+  campaignId: string
+  answers: Json
+  requestMetadata: Json
+}): Promise<PostProgramSurveyCompletion> {
+  const { data, error } = await supabase
+    .rpc('complete_post_program_survey_campaign', {
+      p_campaign_id: campaignId,
+      p_answers: answers,
+      p_request_metadata: requestMetadata,
+    })
+    .single()
+
+  if (error) throw new Error(error.message)
+  if (!data?.campaign_id || !data.submission_id || !data.completed_at) {
+    throw new Error('Campaign completion did not return a submission')
+  }
+
+  return {
+    campaignId: data.campaign_id,
+    submissionId: data.submission_id,
+    completedAt: data.completed_at,
+  }
+}

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -40,6 +40,7 @@ export default [
   route("internal/export-jobs/cleanup", "routes/internal/export-jobs.cleanup.ts"),
   route("internal/gift-card-jobs/run", "routes/internal/gift-card-jobs.run.ts"),
   route("internal/gift-card-inventory-alerts/run", "routes/internal/gift-card-inventory-alerts.run.ts"),
+  route("internal/post-program-survey-jobs/run", "routes/internal/post-program-survey-jobs.run.ts"),
   route("internal/zoom-jobs/run", "routes/internal/zoom-jobs.run.ts"),
   route("internal/zoom-jobs/reset", "routes/internal/zoom-jobs.reset.ts"),
   route("manage", "routes/manage/team.tsx", [

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -103,6 +103,7 @@ export default [
     route("email-message", "routes/manage/email-message.tsx"),
     route("email-drafts", "routes/manage/email-drafts.tsx"),
     route("email-drafts/:draftId", "routes/manage/email-drafts.$draftId.tsx"),
+    route("post-program-surveys", "routes/manage/post-program-surveys.tsx"),
     route("form-answer", "routes/manage/form-answer.tsx"),
     route("gift-cards", "routes/manage/gift-cards.tsx"),
     route("gift-cards/stats-data", "routes/manage/gift-cards.stats-data.ts"),

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -12,6 +12,7 @@ export default [
   route("my-forms/:formId", "routes/my-forms.$formId.tsx"),
   route("semester-surveys/:semesterId/pre-program", "routes/semester-surveys.pre.tsx"),
   route("semester-surveys/:semesterId/pre", "routes/semester-surveys.pre-redirect.tsx"),
+  route("semester-surveys/:semesterId/post-program", "routes/semester-surveys.post.tsx"),
   route("login", "routes/auth/login.tsx"),
   route(
     "sign-up",

--- a/web/app/routes/glr.$token.ts
+++ b/web/app/routes/glr.$token.ts
@@ -5,6 +5,7 @@ import { adminClient } from '@/lib/supabase/adminClient'
 
 import { resolveGiftCardRelease } from '@/lib/gift-cards/release.server'
 import { hashGlrToken } from '@/lib/gift-cards/token.server'
+import { getPostProgramSurveyHold } from '@/lib/post-program-survey/gift-card-guard.server'
 
 const homeMessageRedirect = ({ request, message }: { request: Request; message: string }) => {
   const url = new URL('/home', request.url)
@@ -59,7 +60,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     classEndsAt: (Array.isArray(classRelation) ? classRelation[0] : classRelation)?.ends_at ?? null,
   }).isReleased
 
-  if (!allocation || allocation.blocked || (allocation.status === 'allocated' && !released)) {
+  const postProgramHold = allocation ? await getPostProgramSurveyHold(allocation.class_id, allocation.profile_id) : null
+  if (!allocation || postProgramHold?.held || allocation.blocked || (allocation.status === 'allocated' && !released)) {
     return invalidLink({ request })
   }
 

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -12,6 +12,7 @@ import { resolveGiftCardRelease } from '@/lib/gift-cards/release.server'
 import { createLoaderProfile } from '@/lib/loader-profile.server'
 import { resolveFamilyGraph } from '@/lib/family.server'
 import { isRoleAtLeast } from '@/lib/roles'
+import { loadIncompletePostProgramSurveyCampaignsForCurrentProfile } from '@/lib/post-program-survey/campaign.server'
 import { createClient } from '@/lib/supabase/server'
 import {
   Table,
@@ -74,6 +75,7 @@ type LoaderData = {
   selectedProfileIdByClass: Record<string, string>
   selectedPhotoStatusByClass: Record<string, string>
   activePhotoUploadClassIdByWorkshop: Record<string, string>
+  postProgramSurveyLinks: Array<{ semesterId: string; campaignId: string }>
   nextClass:
       | {
         classId: string
@@ -212,7 +214,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     familyProfileIds: family.familyProfileIds.length,
   })
 
-  const [familyProfilesResponse, enrollmentsResponse] = await Promise.all([
+  const [familyProfilesResponse, enrollmentsResponse, postProgramSurveyCampaigns] = await Promise.all([
     adminClient
       .from('profile')
       .select('id, role, firstname, surname, email, user_id')
@@ -222,6 +224,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       .select('id, workshop_id, semester_id, status, requested_at, profile_id')
       .in('profile_id', family.familyProfileIds)
       .order('requested_at', { ascending: false }),
+    loadIncompletePostProgramSurveyCampaignsForCurrentProfile(supabase),
   ])
 
   const familyProfilesRaw = familyProfilesResponse.data
@@ -278,6 +281,10 @@ export async function loader({ request }: Route.LoaderArgs) {
       selectedProfileIdByClass: {},
       selectedPhotoStatusByClass: {},
       activePhotoUploadClassIdByWorkshop: {},
+      postProgramSurveyLinks: postProgramSurveyCampaigns.map(campaign => ({
+        semesterId: campaign.semester_id,
+        campaignId: campaign.id,
+      })),
       nextClass: null,
     } satisfies LoaderData
   }
@@ -572,6 +579,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     selectedProfileIdByClass,
     selectedPhotoStatusByClass: selectedPhotoStatusByClassFinal,
     activePhotoUploadClassIdByWorkshop,
+    postProgramSurveyLinks: postProgramSurveyCampaigns.map(campaign => ({
+      semesterId: campaign.semester_id,
+      campaignId: campaign.id,
+    })),
     nextClass,
   } satisfies LoaderData
 }
@@ -887,6 +898,7 @@ export default function Home() {
     selectedProfileIdByClass,
     selectedPhotoStatusByClass,
     activePhotoUploadClassIdByWorkshop,
+    postProgramSurveyLinks,
     nextClass,
   } = useLoaderData<LoaderData>()
   const actionData = useActionData<ActionData>()
@@ -1253,6 +1265,11 @@ export default function Home() {
         <Button asChild variant={tab === 'manage-family' ? 'default' : 'outline'}>
           <Link to="/home?tab=manage-family">Manage Family</Link>
         </Button>
+        {postProgramSurveyLinks.map(survey => (
+          <Button key={survey.campaignId} asChild className="bg-amber-400 text-slate-950 hover:bg-amber-300">
+            <Link to={`/semester-surveys/${survey.semesterId}/post-program`}>Complete post-program survey</Link>
+          </Button>
+        ))}
       </div>
 
       <header className="space-y-1">

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -12,6 +12,7 @@ import { resolveGiftCardRelease } from '@/lib/gift-cards/release.server'
 import { createLoaderProfile } from '@/lib/loader-profile.server'
 import { resolveFamilyGraph } from '@/lib/family.server'
 import { isRoleAtLeast } from '@/lib/roles'
+import { getPostProgramSurveyHold } from '@/lib/post-program-survey/gift-card-guard.server'
 import { loadIncompletePostProgramSurveyCampaignsForCurrentProfile } from '@/lib/post-program-survey/campaign.server'
 import { createClient } from '@/lib/supabase/server'
 import {
@@ -496,7 +497,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         .in('profile_id', family.familyProfileIds)
     : { data: [] }
 
-  const giftCardLinkByClass = ((allocationRowsRaw ?? []) as Array<{
+  const allocationRows = (allocationRowsRaw ?? []) as Array<{
     id: string
     class_id: string
     profile_id: string
@@ -508,7 +509,16 @@ export async function loader({ request }: Route.LoaderArgs) {
       release_ready_at?: string | null
       qualification_since_at?: string | null
     } | null
-  }>).reduce<
+  }>
+  const heldAllocationIds = new Set(
+    (
+      await Promise.all(
+        allocationRows.map(async row => ((await getPostProgramSurveyHold(row.class_id, row.profile_id)).held ? row.id : null))
+      )
+    ).filter((id): id is string => Boolean(id))
+  )
+
+  const giftCardLinkByClass = allocationRows.reduce<
     Record<
       string,
       {
@@ -517,6 +527,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       }
     >
   >((acc, row) => {
+    if (heldAllocationIds.has(row.id)) return acc
     if (row.blocked) return acc
     const released = resolveGiftCardRelease({
       metadata: row.metadata,

--- a/web/app/routes/internal/post-program-survey-jobs.run.ts
+++ b/web/app/routes/internal/post-program-survey-jobs.run.ts
@@ -1,0 +1,19 @@
+import type { ActionFunctionArgs } from 'react-router'
+
+import { validateInternalRunnerRequest } from '@/lib/internal-runner-auth.server'
+import { runPostProgramSurveyJobs } from '@/lib/post-program-survey/runner.server'
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
+  const authCheck = validateInternalRunnerRequest(request)
+  if (!authCheck.ok) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const appOrigin = new URL(request.url).origin
+  const result = await runPostProgramSurveyJobs({ appOrigin, runId: authCheck.runId })
+  return Response.json(result)
+}

--- a/web/app/routes/manage/class-attendance.tsx
+++ b/web/app/routes/manage/class-attendance.tsx
@@ -15,6 +15,7 @@ import {
 import { isRoleAtLeast } from '@/lib/roles'
 import { adminClient } from '@/lib/supabase/adminClient'
 import { createClient } from '@/lib/supabase/server'
+import { getPostProgramSurveyHold } from '@/lib/post-program-survey/gift-card-guard.server'
 import { runZoomRegistrantForStudent } from '@/lib/zoom-jobs/runner.server'
 import { Download, Loader2 } from 'lucide-react'
 import { Form, Link, useLoaderData, useLocation, useNavigation } from 'react-router'
@@ -1482,6 +1483,12 @@ export async function action({ request }: Route.ActionArgs) {
         already_allocated: true,
         message: 'Gift card already allocated for this class/profile (possibly allocated in another session).',
       }
+    }
+
+    const postProgramHold = await getPostProgramSurveyHold(classId, profileId)
+    if (postProgramHold.held) {
+      outcome = 'allocate_post_program_survey_held'
+      return allocationErrorResponse(409, 'Post-program survey is required before this final gift card can be allocated.')
     }
 
     const pickAvailableAsset = async (provider: 'PC' | 'Sobeys' | null) => {

--- a/web/app/routes/manage/post-program-surveys.tsx
+++ b/web/app/routes/manage/post-program-surveys.tsx
@@ -1,0 +1,143 @@
+import { Form, redirect, useActionData, useLoaderData, useNavigation } from 'react-router'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { requireAuth } from '@/lib/auth.server'
+import { isRoleAtLeast } from '@/lib/roles'
+import { adminClient } from '@/lib/supabase/adminClient'
+import { createClient } from '@/lib/supabase/server'
+
+import type { Route } from './+types/post-program-surveys'
+
+type ActionData = { error?: string; success?: string }
+
+const formatDateTime = (value: string | null) => (value ? new Date(value).toLocaleString() : '-')
+const groupByCampaign = <T extends { campaign_id: string }>(rows: T[]) =>
+  rows.reduce<Record<string, T[]>>((groups, row) => {
+    ;(groups[row.campaign_id] ??= []).push(row)
+    return groups
+  }, {})
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'manager')) {
+    throw redirect('/manage', { headers: auth.headers })
+  }
+
+  const { data: campaigns, error } = await adminClient
+    .from('post_program_survey_campaign')
+    .select('id, semester_id, survey_profile_id, available_at, completed_at, completed_submission_id, manually_completed_at, manual_completion_reason, created_at')
+    .order('created_at', { ascending: false })
+    .limit(200)
+  if (error) throw new Response(error.message, { status: 500, headers: auth.headers })
+
+  const campaignIds = (campaigns ?? []).map(campaign => campaign.id)
+  const [membersResult, enrollmentsResult, eventsResult, auditResult] = await Promise.all([
+    campaignIds.length
+      ? adminClient.from('post_program_survey_campaign_member').select('campaign_id, profile_id').in('campaign_id', campaignIds)
+      : Promise.resolve({ data: [] as Array<{ campaign_id: string; profile_id: string }> }),
+    campaignIds.length
+      ? adminClient.from('post_program_survey_campaign_enrollment').select('campaign_id, workshop_enrollment_id').in('campaign_id', campaignIds)
+      : Promise.resolve({ data: [] as Array<{ campaign_id: string; workshop_enrollment_id: string }> }),
+    campaignIds.length
+      ? adminClient.from('post_program_survey_email_event').select('campaign_id, template_key, slot_at, recipient_email, sent_at, last_error').in('campaign_id', campaignIds)
+      : Promise.resolve({ data: [] as Array<{ campaign_id: string; template_key: string; slot_at: string; recipient_email: string; sent_at: string | null; last_error: string | null }> }),
+    campaignIds.length
+      ? adminClient.from('post_program_survey_campaign_audit').select('campaign_id, event_type, source, created_at').in('campaign_id', campaignIds).order('created_at', { ascending: false })
+      : Promise.resolve({ data: [] as Array<{ campaign_id: string; event_type: string; source: string; created_at: string }> }),
+  ])
+
+  const members = (membersResult.data ?? []) as Array<{ campaign_id: string; profile_id: string }>
+  const enrollments = (enrollmentsResult.data ?? []) as Array<{ campaign_id: string; workshop_enrollment_id: string }>
+  const events = (eventsResult.data ?? []) as Array<{ campaign_id: string; template_key: string; slot_at: string; recipient_email: string; sent_at: string | null; last_error: string | null }>
+  const audits = (auditResult.data ?? []) as Array<{ campaign_id: string; event_type: string; source: string; created_at: string }>
+
+  return {
+    campaigns: campaigns ?? [],
+    membersByCampaign: groupByCampaign(members),
+    enrollmentsByCampaign: groupByCampaign(enrollments),
+    eventsByCampaign: groupByCampaign(events),
+    auditByCampaign: groupByCampaign(audits),
+  }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const auth = await requireAuth(request)
+  if (!isRoleAtLeast(auth.claims.role, 'manager')) {
+    return new Response('Unauthorized', { status: 403, headers: auth.headers })
+  }
+
+  const formData = await request.formData()
+  const campaignId = String(formData.get('campaign_id') ?? '').trim()
+  const reason = String(formData.get('reason') ?? '').trim()
+  if (!campaignId || !reason) return { error: 'Campaign and completion reason are required.' } satisfies ActionData
+
+  const { supabase } = createClient(request)
+  const { error } = await supabase.rpc('manually_complete_post_program_survey_campaign', {
+    p_campaign_id: campaignId,
+    p_reason: reason,
+  })
+  if (error) return { error: error.message } satisfies ActionData
+  return { success: 'Campaign marked complete with an audit record.' } satisfies ActionData
+}
+
+export default function PostProgramSurveysPage() {
+  const { campaigns, membersByCampaign, enrollmentsByCampaign, eventsByCampaign, auditByCampaign } = useLoaderData<typeof loader>()
+  const actionData = useActionData<ActionData>()
+  const navigation = useNavigation()
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Post-program survey campaigns</CardTitle>
+          <CardDescription>Campaign state, scheduled messages, and final-card survey holds. Survey answers are not shown here.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {actionData?.error ? <p className="mb-3 text-sm text-destructive">{actionData.error}</p> : null}
+          {actionData?.success ? <p className="mb-3 text-sm text-emerald-700">{actionData.success}</p> : null}
+          {campaigns.length === 0 ? <p className="text-sm text-muted-foreground">No campaigns found.</p> : (
+            <div className="space-y-4">
+              {campaigns.map(campaign => {
+                const events = eventsByCampaign[campaign.id] ?? []
+                const audits = auditByCampaign[campaign.id] ?? []
+                return (
+                  <section key={campaign.id} className="rounded-md border p-4 space-y-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium">Campaign {campaign.id}</p>
+                        <p className="text-xs text-muted-foreground">Semester {campaign.semester_id}</p>
+                      </div>
+                      <span className={campaign.completed_at ? 'text-sm text-emerald-700' : 'text-sm text-amber-700'}>
+                        {campaign.completed_at ? `Completed ${formatDateTime(campaign.completed_at)}` : 'Incomplete'}
+                      </span>
+                    </div>
+                    <div className="grid gap-2 text-sm md:grid-cols-3">
+                      <p>Available: {formatDateTime(campaign.available_at)}</p>
+                      <p>Members: {(membersByCampaign[campaign.id] ?? []).length}</p>
+                      <p>Accepted enrollments: {(enrollmentsByCampaign[campaign.id] ?? []).length}</p>
+                    </div>
+                    <p className="text-sm">Messages: {events.length}, sent: {events.filter(event => event.sent_at).length}, failures: {events.filter(event => event.last_error).length}</p>
+                    <p className="text-xs text-muted-foreground">Latest audit: {audits[0] ? `${audits[0].event_type} (${audits[0].source}) at ${formatDateTime(audits[0].created_at)}` : '-'}</p>
+                    {!campaign.completed_at ? (
+                      <Form method="post" className="flex flex-wrap items-end gap-2">
+                        <input type="hidden" name="campaign_id" value={campaign.id} />
+                        <div className="grid gap-1 min-w-72">
+                          <Label htmlFor={`reason-${campaign.id}`}>Manual completion reason</Label>
+                          <Input id={`reason-${campaign.id}`} name="reason" required />
+                        </div>
+                        <Button type="submit" variant="outline" disabled={navigation.state !== 'idle'}>Mark complete</Button>
+                      </Form>
+                    ) : campaign.manual_completion_reason ? <p className="text-sm text-muted-foreground">Manual reason: {campaign.manual_completion_reason}</p> : null}
+                  </section>
+                )
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/web/app/routes/semester-surveys.post.tsx
+++ b/web/app/routes/semester-surveys.post.tsx
@@ -1,0 +1,190 @@
+import { Form, Link, redirect, useActionData, useLoaderData, useNavigation } from 'react-router'
+
+import AuthStickerBackground from '@/components/auth/sticker-background'
+import FormQuestion, { type FormQuestionData } from '@/components/forms/form-question'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { enforceOnboardingGuard } from '@/lib/auth.server'
+import type { Json } from '@/lib/database.types'
+import { loadPostProgramSurveyCampaignForCurrentProfile } from '@/lib/post-program-survey/campaign.server'
+import { completePostProgramSurveyCampaign } from '@/lib/post-program-survey/submission.server'
+import { extractRequestMetadata } from '@/lib/request-metadata.server'
+import { adminClient } from '@/lib/supabase/adminClient'
+import { createClient } from '@/lib/supabase/server'
+
+import type { Route } from './+types/semester-surveys.post'
+
+type LoaderData = {
+  campaignId: string
+  completed: boolean
+  formName: string
+  questions: FormQuestionData[]
+}
+
+type ActionData = {
+  error?: string
+}
+
+const parseFormValue = (question: FormQuestionData, formData: FormData): Json | null => {
+  const fieldName = `question_${question.question_code}`
+
+  if (question.type === 'multi_choice') {
+    const choices = formData
+      .getAll(fieldName)
+      .filter((value): value is string => typeof value === 'string')
+      .map(value => value.trim())
+      .filter(Boolean)
+    return choices.length ? choices : null
+  }
+
+  if (question.type === 'checkbox') return formData.has(fieldName)
+  if (question.type === 'no-input-text') return null
+
+  const rawValue = (formData.get(fieldName) as string | null)?.trim() ?? ''
+  return rawValue || null
+}
+
+const loadQuestions = async (formId: string): Promise<FormQuestionData[]> => {
+  const { data: questions, error } = await adminClient
+    .from('form_question_map')
+    .select('question_code, prompt_override, options_override, metadata, form_question ( prompt, type, options )')
+    .eq('form_id', formId)
+    .order('position')
+
+  if (error) throw new Error(error.message)
+  return (questions ?? []).map(row => {
+    const base = Array.isArray(row.form_question) ? row.form_question[0] : row.form_question
+    return {
+      question_code: row.question_code ?? '',
+      prompt: row.prompt_override ?? base?.prompt ?? '',
+      type: (base?.type ?? 'text') as FormQuestionData['type'],
+      options: (row.options_override ?? base?.options ?? []) as Json,
+      metadata: (row.metadata ?? {}) as Json,
+    }
+  })
+}
+
+const loadCampaignForRequest = async (request: Request, semesterId: string) => {
+  const auth = await enforceOnboardingGuard(request)
+  const { supabase, headers } = createClient(request)
+  const campaign = await loadPostProgramSurveyCampaignForCurrentProfile(supabase, semesterId)
+  if (!campaign || new Date(campaign.available_at).getTime() > Date.now()) {
+    throw redirect('/home', { headers })
+  }
+  return { auth, supabase, headers, campaign }
+}
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const semesterId = params.semesterId
+  if (!semesterId) throw redirect('/home')
+
+  const { headers, campaign } = await loadCampaignForRequest(request, semesterId)
+  const { data: form, error } = await adminClient
+    .from('form')
+    .select('id, name')
+    .eq('id', campaign.form_id)
+    .maybeSingle()
+
+  if (error || !form?.id) throw redirect('/home', { headers })
+
+  return {
+    campaignId: campaign.id,
+    completed: campaign.completed_at !== null,
+    formName: form.name,
+    questions: campaign.completed_at ? [] : await loadQuestions(form.id),
+  } satisfies LoaderData
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const semesterId = params.semesterId
+  if (!semesterId) return { error: 'Semester is missing.' } satisfies ActionData
+
+  const { supabase, headers, campaign } = await loadCampaignForRequest(request, semesterId)
+  if (campaign.completed_at) throw redirect('/home', { headers })
+
+  const questions = await loadQuestions(campaign.form_id)
+  const formData = await request.formData()
+  const answers: Record<string, Json> = {}
+
+  for (const question of questions) {
+    const metadata = (question.metadata ?? {}) as Record<string, Json>
+    const value = parseFormValue(question, formData)
+    const required = metadata.optional !== true && question.type !== 'no-input-text'
+
+    if (
+      required &&
+      (value === null || value === '' || value === false || (Array.isArray(value) && value.length === 0))
+    ) {
+      return { error: `Please answer "${question.prompt}".` } satisfies ActionData
+    }
+
+    if (value !== null) answers[question.question_code] = value
+  }
+
+  try {
+    await completePostProgramSurveyCampaign({
+      supabase,
+      campaignId: campaign.id,
+      answers,
+      requestMetadata: JSON.parse(JSON.stringify(extractRequestMetadata(request))) as Json,
+    })
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Unable to save the survey.' } satisfies ActionData
+  }
+
+  throw redirect('/home', { headers })
+}
+
+export default function SemesterPostSurveyPage() {
+  const { completed, formName, questions } = useLoaderData() as LoaderData
+  const actionData = useActionData() as ActionData | undefined
+  const navigation = useNavigation()
+
+  return (
+    <AuthStickerBackground maxWidthClassName="max-w-3xl" dense scrollContent>
+      <div className="w-full py-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-2xl">{formName}</CardTitle>
+            <CardDescription>
+              {completed
+                ? 'Thank you. Your family has completed this post-program survey.'
+                : 'Please share your family’s experience with summerlunch+.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {completed ? (
+              <Button asChild>
+                <Link to="/home">Return home</Link>
+              </Button>
+            ) : (
+              <Form method="post" className="space-y-6">
+                {questions.map(question => {
+                  const metadata = (question.metadata ?? {}) as Record<string, Json>
+                  return (
+                    <FormQuestion
+                      key={question.question_code}
+                      question={question}
+                      required={metadata.optional !== true && question.type !== 'no-input-text'}
+                    />
+                  )
+                })}
+
+                {actionData?.error ? <p className="text-sm text-destructive">{actionData.error}</p> : null}
+
+                <div className="flex items-center justify-end gap-3">
+                  <Button variant="ghost" asChild>
+                    <Link to="/home">Cancel</Link>
+                  </Button>
+                  <Button type="submit" disabled={navigation.state !== 'idle'}>
+                    {navigation.state === 'idle' ? 'Submit survey' : 'Submitting survey...'}
+                  </Button>
+                </div>
+              </Form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AuthStickerBackground>
+  )
+}

--- a/web/tests/unit/post-program-survey.spec.ts
+++ b/web/tests/unit/post-program-survey.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+import { renderPostProgramSurveyGiftCardEmail, renderPostProgramSurveyInitialEmail, renderPostProgramSurveyReminderEmail } from '../../app/lib/email/templates/post-program-survey'
+import { isLastWorkshopClass } from '../../app/lib/post-program-survey/gift-card-guard'
+import { assertPostProgramSurveySchedule, POST_PROGRAM_SURVEY_SCHEDULE } from '../../app/lib/post-program-survey/schedule'
+
+test('post-program survey schedule has the seven approved Toronto slots', async () => {
+  assertPostProgramSurveySchedule()
+  expect(POST_PROGRAM_SURVEY_SCHEDULE).toEqual([
+    { at: '2026-08-14T13:00:00.000Z', templateKey: 'post_program_survey_initial_v1' },
+    { at: '2026-08-19T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
+    { at: '2026-08-21T01:00:00.000Z', templateKey: 'post_program_survey_reminder_v1' },
+    { at: '2026-08-26T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+    { at: '2026-08-28T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+    { at: '2026-09-02T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+    { at: '2026-09-04T01:00:00.000Z', templateKey: 'post_program_survey_gift_card_v1' },
+  ])
+})
+
+test('post-program templates retain their required purpose', async () => {
+  const data = { recipientName: 'Alex', surveyUrl: 'https://example.test/survey' }
+  expect(renderPostProgramSurveyInitialEmail(data).text).toContain('pre-program questions')
+  expect(renderPostProgramSurveyReminderEmail(data).text).toContain('quick reminder')
+  expect(renderPostProgramSurveyGiftCardEmail(data).text).toContain('final Week 8 grocery gift card')
+})
+
+test('only the latest workshop class is a final-card candidate', async () => {
+  const workshopClasses = [
+    { id: 'first', ends_at: '2026-08-20T22:00:00.000Z' },
+    { id: 'last', ends_at: '2026-08-27T22:00:00.000Z' },
+  ]
+  expect(isLastWorkshopClass({ classId: 'first', classEndsAt: workshopClasses[0].ends_at, workshopClasses })).toBeFalsy()
+  expect(isLastWorkshopClass({ classId: 'last', classEndsAt: workshopClasses[1].ends_at, workshopClasses })).toBeTruthy()
+})


### PR DESCRIPTION
## Summary
- add campaign, member, enrollment, audit, and scheduled-email database state
- add guardian survey route, CTA, scheduled email runner, and manager recovery page
- hold final workshop gift cards until campaign completion
- add fixed schedule and continuity checks

## Verification
- `supabase db reset`
- `npm run typecheck --prefix web`
- `npm run test -- tests/unit/post-program-survey.spec.ts` from `web/`

## Follow-up
- #536 remains open for completed-onboarding E2E fixtures and full integration coverage

Closes #538
Closes #539
Closes #540
Closes #541
Closes #542