### PR TITLE
Fix public post-program survey links

### DIFF
--- a/web/app/lib/email/templates/post-program-survey.ts
+++ b/web/app/lib/email/templates/post-program-survey.ts
@@ -22,11 +22,12 @@ const renderPostProgramSurveyEmail = ({
 }) => {
   const safeName = escapeHtml(recipientName.trim() || 'there')
   const safeUrl = escapeHtml(surveyUrl)
+  const accessFallback = 'If the link does not work, please log in to hub.summerlunchplus.com to access the survey instead.'
   const htmlParagraphs = paragraphs.map(paragraph => `<p style="margin:0 0 16px 0;">${escapeHtml(paragraph)}</p>`).join('')
 
   return {
     subject,
-    text: `Hi ${recipientName.trim() || 'there'},\n\n${paragraphs.join('\n\n')}\n\nComplete the survey: ${surveyUrl}\n\nThe summerlunch+ Team`,
+    text: `Hi ${recipientName.trim() || 'there'},\n\n${paragraphs.join('\n\n')}\n\nComplete the survey: ${surveyUrl}\n\n${accessFallback}\n\nThe summerlunch+ Team`,
     html: `<!doctype html>
 <html>
   <body style="margin:0;padding:0;background-color:#f6f8fb;">
@@ -43,8 +44,9 @@ const renderPostProgramSurveyEmail = ({
               <td style="padding:8px 24px 24px 24px;font-family:Arial,sans-serif;color:#1f2937;font-size:16px;line-height:24px;">
                 <p style="margin:0 0 16px 0;">Hi ${safeName},</p>
                 ${htmlParagraphs}
-                <p style="margin:0 0 16px 0;"><a href="${safeUrl}">Complete the post-program survey</a></p>
-                <p style="margin:0;">The summerlunch+ Team</p>
+                 <p style="margin:0 0 16px 0;"><a href="${safeUrl}">Complete the post-program survey</a></p>
+                 <p style="margin:0 0 16px 0;">${accessFallback}</p>
+                 <p style="margin:0;">The summerlunch+ Team</p>
               </td>
             </tr>
           </table>

--- a/web/app/lib/post-program-survey/runner.server.ts
+++ b/web/app/lib/post-program-survey/runner.server.ts
@@ -35,7 +35,12 @@ type ClaimedEvent = {
   attempt_count: number
 }
 
-const publicOrigin = (appOrigin: string) => (process.env.PUBLIC_APP_ORIGIN?.trim().replace(/\/$/, '') || appOrigin)
+const publicOrigin = (appOrigin: string) => {
+  const configuredOrigin = process.env.SITE_ORIGIN?.trim() || process.env.PUBLIC_APP_ORIGIN?.trim()
+  if (configuredOrigin) return configuredOrigin.replace(/\/$/, '')
+  if (appOrigin.includes('.railway.internal')) return 'https://hub.summerlunchplus.com'
+  return appOrigin.replace(/\/$/, '')
+}
 
 const ensureCampaigns = async (availableAt: string, afterId: string | null) => {
   let campaignsEnsured = 0

--- a/web/tests/unit/post-program-survey.spec.ts
+++ b/web/tests/unit/post-program-survey.spec.ts
@@ -23,6 +23,7 @@ test('post-program templates retain their required purpose', async () => {
   expect(renderPostProgramSurveyInitialEmail(data).text).toContain('pre-program questions')
   expect(renderPostProgramSurveyReminderEmail(data).text).toContain('quick reminder')
   expect(renderPostProgramSurveyGiftCardEmail(data).text).toContain('final Week 8 grocery gift card')
+  expect(renderPostProgramSurveyInitialEmail(data).text).toContain('If the link does not work, please log in to hub.summerlunchplus.com to access the survey instead.')
 })
 
 test('only the latest workshop class is a final-card candidate', async () => {


### PR DESCRIPTION
## Summary
- Prefer `SITE_ORIGIN` when generating post-program survey URLs.
- Never fall back to a `*.railway.internal` hostname in an email link.
- Add the requested login fallback instructions to text and HTML email versions.

## Verification
- `npm run typecheck`
- `npm run test -- tests/unit/post-program-survey.spec.ts`

This fixes future initial/reminder emails. Previously sent emails cannot be recalled.